### PR TITLE
feat: Augment response with retrieved cards

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -1,15 +1,31 @@
 import logging
 
+from sentence_transformers import SentenceTransformer
+
 import chainlit as cl
+import src.adapters.db as db
+from src.app_config import AppConfig
 from src.generate import generate
+from src.retrieve import retrieve
 
 logger = logging.getLogger(__name__)
+
+embedding_model = SentenceTransformer(AppConfig().embedding_model)
 
 
 @cl.on_message
 async def main(message: cl.Message) -> None:
     logger.info(f"Received: {message.content}")
-    response = generate(message.content)
+
+    with db.PostgresDBClient().get_session() as db_session:
+        logger.info(f"Retrieving context for {message.content!r}")
+        chunks_with_scores = retrieve(db_session, embedding_model, message.content)
+        chunks = [chunk for chunk, _ in chunks_with_scores]
+        for chunk in chunks:
+            logger.info(f"Retrieved: {chunk.document.name!r}")
+
+    response = generate(message.content, context=chunks)
+
     await cl.Message(
         content=response,
     ).send()

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -1,0 +1,19 @@
+from typing import Sequence, Tuple
+
+from sentence_transformers import SentenceTransformer
+from sqlalchemy import Row, select
+
+import src.adapters.db as db
+from src.db.models.document import Chunk
+
+
+def retrieve(
+    db_session: db.Session, embedding_model: SentenceTransformer, query: str, k: int = 5
+) -> Sequence[Row[Tuple[Chunk, float]]]:
+    query_embedding = embedding_model.encode(query, show_progress_bar=False)
+
+    return db_session.execute(
+        select(Chunk, Chunk.mpnet_embedding.max_inner_product(query_embedding))
+        .order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding))
+        .limit(k)
+    ).all()

--- a/app/tests/mock/mock_completion.py
+++ b/app/tests/mock/mock_completion.py
@@ -6,5 +6,7 @@ from litellm import completion
 def mock_completion(model, messages):
     # Convert the messages list of dictionaries to a string
     messages = json.dumps(messages, sort_keys=True)
+    # Strip generated JSON of escaped newlines to make it simple to compare with prompts
+    messages = messages.replace("\\n", "\n")
     mock_response = f"Called {model} with {messages}"
     return completion(model, messages, mock_response=mock_response)

--- a/app/tests/mock/mock_sentence_transformer.py
+++ b/app/tests/mock/mock_sentence_transformer.py
@@ -10,18 +10,18 @@ class MockSentenceTransformer:
     def encode(self, text, **kwargs):
         """
         Encode text into a 768-dimensional embedding that allows for similarity comparison via the dot product.
-        The embedding represents the average word length of the text
+        The direction of the vector maps to the average word length of the text.
         """
 
         tokens = self.tokenizer.tokenize(text)
         average_token_length = sum(len(token) for token in tokens) / len(tokens)
 
-        # Convert average word length to an angle, and pad the vector to length 768
-        angle = (1 / average_token_length) * 2 * math.pi
-        embedding = [math.cos(angle), math.sin(angle)] + ([0] * 766)
-
-        # Normalize the embedding before returning it
-        return [x / sum(embedding) for x in embedding]
+        # Map average length to between 0 and 90 degrees
+        # Then project that angle on the first two dimensions and pad the rest as 0
+        return [
+            math.cos(math.pi / 2 * average_token_length),
+            math.sin(math.pi / 2 * average_token_length),
+        ] + [0] * 766
 
 
 class MockTokenizer:

--- a/app/tests/mock/test_mock_sentence_transformer.py
+++ b/app/tests/mock/test_mock_sentence_transformer.py
@@ -7,8 +7,6 @@ def test_mock_sentence_transformer():
     assert embedding_model.max_seq_length == 512
     assert embedding_model.tokenizer.tokenize("Hello, world!") == ["Hello,", "world!"]
     assert len(embedding_model.encode("Hello, world!")) == 768
-    # It should be about 1, but with some tolerance for floating point imprecision
-    assert sum(embedding_model.encode("Hello, world!")) - 1 < 0.01
 
     # Test that we can compare similarity with dot product,
     # where sentences with the same average length word are considered more similar

--- a/app/tests/src/db/models/factories.py
+++ b/app/tests/src/db/models/factories.py
@@ -78,8 +78,8 @@ class ChunkFactory(BaseFactory):
     document = factory.SubFactory(DocumentFactory)
     content = factory.LazyAttribute(lambda o: o.document.content)
     tokens = factory.LazyAttribute(
-        lambda o: len(MockSentenceTransformer().tokenizer.tokenize(o.document.content))
+        lambda o: len(MockSentenceTransformer().tokenizer.tokenize(o.content))
     )
     mpnet_embedding = factory.LazyAttribute(
-        lambda o: MockSentenceTransformer().encode(o.document.content)
+        lambda o: MockSentenceTransformer().encode(o.content)
     )

--- a/app/tests/src/test_generate.py
+++ b/app/tests/src/test_generate.py
@@ -1,4 +1,5 @@
 import os
+
 from src.generate import PROMPT, generate, get_models
 from tests.mock import mock_completion
 from tests.src.db.models.factories import ChunkFactory

--- a/app/tests/src/test_generate.py
+++ b/app/tests/src/test_generate.py
@@ -1,10 +1,12 @@
+import os
 from src.generate import PROMPT, generate, get_models
 from tests.mock import mock_completion
 from tests.src.db.models.factories import ChunkFactory
 
 
 def test_get_models(monkeypatch):
-    monkeypatch.delenv("OPENAI_API_KEY")
+    if "OPENAI_API_KEY" in os.environ:
+        monkeypatch.delenv("OPENAI_API_KEY")
     assert get_models() == {}
 
     monkeypatch.setenv("OPENAI_API_KEY", "mock_key")

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -1,0 +1,27 @@
+from sqlalchemy import delete
+
+from src.db.models.document import Document
+from src.retrieve import retrieve
+from tests.mock.mock_sentence_transformer import MockSentenceTransformer
+from tests.src.db.models.factories import ChunkFactory
+
+
+def test_retrieve(db_session, enable_factory_create):
+    db_session.execute(delete(Document))
+    mock_embedding_model = MockSentenceTransformer()
+
+    ChunkFactory.create(
+        content="Incomprehensibility characterizes unintelligible, overwhelmingly convoluted dissertations."
+    )
+    medium_chunk = ChunkFactory.create(
+        content="Curiosity inspires creative, innovative communities worldwide."
+    )
+    short_chunk = ChunkFactory.create(content="The quick brown red fox jumps.")
+
+    results = retrieve(db_session, mock_embedding_model, "Very tiny words.", k=2)
+
+    assert len(results) == 2
+    assert results[0][0] == short_chunk
+    assert results[0][1] == -0.7071067690849304
+    assert results[1][0] == medium_chunk
+    assert results[1][1] == -0.25881901383399963


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-272


## Changes
 - Add retrieve() and test coverage
 - Add context keyword to generate() and test coverage
 - Integrate these into chainlit.py
 - Simplify the math behind the MockSentenceTransformer, and fix a bug in the ChunkFactory


## Context for reviewers



## Testing
Spin up the app at localhost:8000/chat, then run `make logs` (after you've ingested Guru cards) and ask a question. The logs should show the queried cards:
<img width="778" alt="image" src="https://github.com/navapbc/labs-decision-support-tool/assets/31424131/d86c9a5b-3f0e-46cb-b4a4-5f69dcf6364f">
<img width="1177" alt="image" src="https://github.com/navapbc/labs-decision-support-tool/assets/31424131/64defb3a-9aed-46e9-ae11-021cee6ab747">

