### PR TITLE
feat: Show accordions with cards

### DIFF
--- a/app/.chainlit/config.toml
+++ b/app/.chainlit/config.toml
@@ -1,0 +1,118 @@
+[project]
+# Whether to enable telemetry (default: true). No personal data is collected.
+enable_telemetry = true
+
+
+# List of environment variables to be provided by each user to use the app.
+user_env = []
+
+# Duration (in seconds) during which the session is saved when the connection is lost
+session_timeout = 3600
+
+# Enable third parties caching (e.g LangChain cache)
+cache = false
+
+# Authorized origins
+allow_origins = ["*"]
+
+# Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
+# follow_symlink = false
+
+[features]
+# Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
+unsafe_allow_html = true
+
+# Process and display mathematical expressions. This can clash with "$" characters in messages.
+latex = false
+
+# Automatically tag threads with the current chat profile (if a chat profile is used)
+auto_tag_thread = true
+
+# Authorize users to spontaneously upload files with messages
+[features.spontaneous_file_upload]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
+[features.audio]
+    # Threshold for audio recording
+    min_decibels = -45
+    # Delay for the user to start speaking in MS
+    initial_silence_timeout = 3000
+    # Delay for the user to continue speaking in MS. If the user stops speaking for this duration, the recording will stop.
+    silence_timeout = 1500
+    # Above this duration (MS), the recording will forcefully stop.
+    max_duration = 15000
+    # Duration of the audio chunks in MS
+    chunk_duration = 1000
+    # Sample rate of the audio
+    sample_rate = 44100
+
+[UI]
+# Name of the assistant.
+name = "Assistant"
+
+# Description of the assistant. This is used for HTML tags.
+# description = ""
+
+# Large size content are by default collapsed for a cleaner ui
+default_collapse_content = true
+
+# Hide the chain of thought details from the user in the UI.
+hide_cot = false
+
+# Link to your github repo. This will add a github button in the UI's header.
+# github = ""
+
+# Specify a CSS file that can be used to customize the user interface.
+# The CSS file can be served from the public directory or via an external link.
+custom_css = "https://cdnjs.cloudflare.com/ajax/libs/uswds/3.8.1/css/uswds.min.css"
+
+# Specify a Javascript file that can be used to customize the user interface.
+# The Javascript file can be served from the public directory.
+custom_js = "https://cdnjs.cloudflare.com/ajax/libs/uswds/3.8.1/js/uswds.min.js"
+
+# Specify a custom font url.
+# custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+
+# Specify a custom meta image url.
+# custom_meta_image_url = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
+
+# Specify a custom build directory for the frontend.
+# This can be used to customize the frontend code.
+# Be careful: If this is a relative path, it should not start with a slash.
+# custom_build = "./public/build"
+
+[UI.theme]
+    default = "dark"
+    #layout = "wide"
+    #font_family = "Inter, sans-serif"
+# Override default MUI light theme. (Check theme.ts)
+[UI.theme.light]
+    #background = "#FAFAFA"
+    #paper = "#FFFFFF"
+
+    [UI.theme.light.primary]
+        #main = "#F80061"
+        #dark = "#980039"
+        #light = "#FFE7EB"
+    [UI.theme.light.text]
+        #primary = "#212121"
+        #secondary = "#616161"
+
+# Override default MUI dark theme. (Check theme.ts)
+[UI.theme.dark]
+    #background = "#FAFAFA"
+    #paper = "#FFFFFF"
+
+    [UI.theme.dark.primary]
+        #main = "#F80061"
+        #dark = "#980039"
+        #light = "#FFE7EB"
+    [UI.theme.dark.text]
+        #primary = "#EEEEEE"
+        #secondary = "#BDBDBD"
+
+[meta]
+generated_by = "1.1.304"

--- a/app/.chainlit/config.toml
+++ b/app/.chainlit/config.toml
@@ -30,7 +30,7 @@ auto_tag_thread = true
 
 # Authorize users to spontaneously upload files with messages
 [features.spontaneous_file_upload]
-    enabled = true
+    enabled = false
     accept = ["*/*"]
     max_files = 20
     max_size_mb = 500
@@ -51,7 +51,7 @@ auto_tag_thread = true
 
 [UI]
 # Name of the assistant.
-name = "Assistant"
+name = "Decision support tool"
 
 # Description of the assistant. This is used for HTML tags.
 # description = ""
@@ -63,7 +63,7 @@ default_collapse_content = true
 hide_cot = false
 
 # Link to your github repo. This will add a github button in the UI's header.
-# github = ""
+# github = "https://github.com/navapbc/labs-decision-support-tool"
 
 # Specify a CSS file that can be used to customize the user interface.
 # The CSS file can be served from the public directory or via an external link.
@@ -85,7 +85,7 @@ custom_js = "https://cdnjs.cloudflare.com/ajax/libs/uswds/3.8.1/js/uswds.min.js"
 # custom_build = "./public/build"
 
 [UI.theme]
-    default = "dark"
+    default = "light"
     #layout = "wide"
     #font_family = "Inter, sans-serif"
 # Override default MUI light theme. (Check theme.ts)

--- a/app/.chainlit/translations/en-US.json
+++ b/app/.chainlit/translations/en-US.json
@@ -1,0 +1,229 @@
+{
+    "components": {
+        "atoms": {
+            "buttons": {
+                "userButton": {
+                    "menu": {
+                        "settings": "Settings",
+                        "settingsKey": "S",
+                        "APIKeys": "API Keys",
+                        "logout": "Logout"
+                    }
+                }
+            }
+        },
+        "molecules": {
+            "newChatButton": {
+                "newChat": "New Chat"
+            },
+            "tasklist": {
+                "TaskList": {
+                    "title": "\ud83d\uddd2\ufe0f Task List",
+                    "loading": "Loading...",
+                    "error": "An error occurred"
+                }
+            },
+            "attachments": {
+                "cancelUpload": "Cancel upload",
+                "removeAttachment": "Remove attachment"
+            },
+            "newChatDialog": {
+                "createNewChat": "Create new chat?",
+                "clearChat": "This will clear the current messages and start a new chat.",
+                "cancel": "Cancel",
+                "confirm": "Confirm"
+            },
+            "settingsModal": {
+                "settings": "Settings",
+                "expandMessages": "Expand Messages",
+                "hideChainOfThought": "Hide Chain of Thought",
+                "darkMode": "Dark Mode"
+            },
+            "detailsButton": {
+                "using": "Using",
+                "used": "Used"
+            },
+            "auth": {
+                "authLogin": {
+                    "title": "Login to access the app.",
+                    "form": {
+                        "email": "Email address",
+                        "password": "Password",
+                        "noAccount": "Don't have an account?",
+                        "alreadyHaveAccount": "Already have an account?",
+                        "signup": "Sign Up",
+                        "signin": "Sign In",
+                        "or": "OR",
+                        "continue": "Continue",
+                        "forgotPassword": "Forgot password?",
+                        "passwordMustContain": "Your password must contain:",
+                        "emailRequired": "email is a required field",
+                        "passwordRequired": "password is a required field"
+                    },
+                    "error": {
+                        "default": "Unable to sign in.",
+                        "signin": "Try signing in with a different account.",
+                        "oauthsignin": "Try signing in with a different account.",
+                        "redirect_uri_mismatch": "The redirect URI is not matching the oauth app configuration.",
+                        "oauthcallbackerror": "Try signing in with a different account.",
+                        "oauthcreateaccount": "Try signing in with a different account.",
+                        "emailcreateaccount": "Try signing in with a different account.",
+                        "callback": "Try signing in with a different account.",
+                        "oauthaccountnotlinked": "To confirm your identity, sign in with the same account you used originally.",
+                        "emailsignin": "The e-mail could not be sent.",
+                        "emailverify": "Please verify your email, a new email has been sent.",
+                        "credentialssignin": "Sign in failed. Check the details you provided are correct.",
+                        "sessionrequired": "Please sign in to access this page."
+                    }
+                },
+                "authVerifyEmail": {
+                    "almostThere": "You're almost there! We've sent an email to ",
+                    "verifyEmailLink": "Please click on the link in that email to complete your signup.",
+                    "didNotReceive": "Can't find the email?",
+                    "resendEmail": "Resend email",
+                    "goBack": "Go Back",
+                    "emailSent": "Email sent successfully.",
+                    "verifyEmail": "Verify your email address"
+                },
+                "providerButton": {
+                    "continue": "Continue with {{provider}}",
+                    "signup": "Sign up with {{provider}}"
+                },
+                "authResetPassword": {
+                    "newPasswordRequired": "New password is a required field",
+                    "passwordsMustMatch": "Passwords must match",
+                    "confirmPasswordRequired": "Confirm password is a required field",
+                    "newPassword": "New password",
+                    "confirmPassword": "Confirm password",
+                    "resetPassword": "Reset Password"
+                },
+                "authForgotPassword": {
+                    "email": "Email address",
+                    "emailRequired": "email is a required field",
+                    "emailSent": "Please check the email address {{email}} for instructions to reset your password.",
+                    "enterEmail": "Enter your email address and we will send you instructions to reset your password.",
+                    "resendEmail": "Resend email",
+                    "continue": "Continue",
+                    "goBack": "Go Back"
+                }
+            }
+        },
+        "organisms": {
+            "chat": {
+                "history": {
+                    "index": {
+                        "showHistory": "Show history",
+                        "lastInputs": "Last Inputs",
+                        "noInputs": "Such empty...",
+                        "loading": "Loading..."
+                    }
+                },
+                "inputBox": {
+                    "input": {
+                        "placeholder": "Type your message here..."
+                    },
+                    "speechButton": {
+                        "start": "Start recording",
+                        "stop": "Stop recording"
+                    },
+                    "SubmitButton": {
+                        "sendMessage": "Send message",
+                        "stopTask": "Stop Task"
+                    },
+                    "UploadButton": {
+                        "attachFiles": "Attach files"
+                    },
+                    "waterMark": {
+                        "text": "Built with"
+                    }
+                },
+                "Messages": {
+                    "index": {
+                        "running": "Running",
+                        "executedSuccessfully": "executed successfully",
+                        "failed": "failed",
+                        "feedbackUpdated": "Feedback updated",
+                        "updating": "Updating"
+                    }
+                },
+                "dropScreen": {
+                    "dropYourFilesHere": "Drop your files here"
+                },
+                "index": {
+                    "failedToUpload": "Failed to upload",
+                    "cancelledUploadOf": "Cancelled upload of",
+                    "couldNotReachServer": "Could not reach the server",
+                    "continuingChat": "Continuing previous chat"
+                },
+                "settings": {
+                    "settingsPanel": "Settings panel",
+                    "reset": "Reset",
+                    "cancel": "Cancel",
+                    "confirm": "Confirm"
+                }
+            },
+            "threadHistory": {
+                "sidebar": {
+                    "filters": {
+                        "FeedbackSelect": {
+                            "feedbackAll": "Feedback: All",
+                            "feedbackPositive": "Feedback: Positive",
+                            "feedbackNegative": "Feedback: Negative"
+                        },
+                        "SearchBar": {
+                            "search": "Search"
+                        }
+                    },
+                    "DeleteThreadButton": {
+                        "confirmMessage": "This will delete the thread as well as it's messages and elements.",
+                        "cancel": "Cancel",
+                        "confirm": "Confirm",
+                        "deletingChat": "Deleting chat",
+                        "chatDeleted": "Chat deleted"
+                    },
+                    "index": {
+                        "pastChats": "Past Chats"
+                    },
+                    "ThreadList": {
+                        "empty": "Empty...",
+                        "today": "Today",
+                        "yesterday": "Yesterday",
+                        "previous7days": "Previous 7 days",
+                        "previous30days": "Previous 30 days"
+                    },
+                    "TriggerButton": {
+                        "closeSidebar": "Close sidebar",
+                        "openSidebar": "Open sidebar"
+                    }
+                },
+                "Thread": {
+                    "backToChat": "Go back to chat",
+                    "chatCreatedOn": "This chat was created on"
+                }
+            },
+            "header": {
+                "chat": "Chat",
+                "readme": "Readme"
+            }
+        }
+    },
+    "hooks": {
+        "useLLMProviders": {
+            "failedToFetchProviders": "Failed to fetch providers:"
+        }
+    },
+    "pages": {
+        "Design": {},
+        "Env": {
+            "savedSuccessfully": "Saved successfully",
+            "requiredApiKeys": "Required API Keys",
+            "requiredApiKeysInfo": "To use this app, the following API keys are required. The keys are stored on your device's local storage."
+        },
+        "Page": {
+            "notPartOfProject": "You are not part of this project."
+        },
+        "ResumeButton": {
+            "resumeChat": "Resume Chat"
+        }
+    }
+}

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -30,9 +30,6 @@ coverage.*
 # Poetry installer local error logs
 poetry-installer-error-*.log
 
-# Chainlit
-.chainlit
-
 # Cached models
 models/
 

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -5,6 +5,7 @@ from sentence_transformers import SentenceTransformer
 import chainlit as cl
 import src.adapters.db as db
 from src.app_config import AppConfig
+from src.format import format_guru_cards
 from src.generate import generate
 from src.retrieve import retrieve
 
@@ -15,17 +16,18 @@ embedding_model = SentenceTransformer(AppConfig().embedding_model)
 
 @cl.on_message
 async def main(message: cl.Message) -> None:
-    logger.info(f"Received: {message.content}")
+    logger.info(f"Received: {message.content!r}")
 
     with db.PostgresDBClient().get_session() as db_session:
-        logger.info(f"Retrieving context for {message.content!r}")
-        chunks_with_scores = retrieve(db_session, embedding_model, message.content)
-        chunks = [chunk for chunk, _ in chunks_with_scores]
-        for chunk in chunks:
-            logger.info(f"Retrieved: {chunk.document.name!r}")
+        chunks = retrieve(
+            db_session,
+            embedding_model,
+            message.content,
+        )
 
     response = generate(message.content, context=chunks)
+    formatted_guru_cards = format_guru_cards(chunks)
 
     await cl.Message(
-        content=response,
+        content=response + formatted_guru_cards,
     ).send()

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -1,0 +1,31 @@
+from typing import Sequence
+
+from src.db.models.document import Chunk
+
+# We need a unique identifier for each accordion,
+# even across multiple calls to this function
+_accordion_id = 0
+
+
+def format_guru_cards(chunks: Sequence[Chunk]) -> str:
+    cards_html = ""
+    for chunk in chunks:
+        global _accordion_id
+        _accordion_id += 1
+        cards_html += f"""
+<div class="usa-accordion" id=accordion-{_accordion_id}>
+    <h4 class="usa-accordion__heading">
+        <button
+            type="button"
+            class="usa-accordion__button"
+            aria-expanded="false"
+            aria-controls="a-{_accordion_id}"
+            >
+            <a href='https://link/to/guru_card'>{chunk.document.name}</a>
+        </button>
+    </h4>
+    <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>
+        <p>Summary: {chunk.document.content}</p>
+    </div>
+</div>"""
+    return "<h4>Related Guru cards</h4>" + cards_html

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -28,4 +28,4 @@ def format_guru_cards(chunks: Sequence[Chunk]) -> str:
         <p>Summary: {chunk.document.content}</p>
     </div>
 </div>"""
-    return "<h4>Related Guru cards</h4>" + cards_html
+    return "<h3>Related Guru cards</h3>" + cards_html

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -1,4 +1,5 @@
 import os
+from typing import Sequence
 
 from litellm import completion
 
@@ -22,7 +23,7 @@ def get_models() -> dict[str, str]:
     return {}
 
 
-def generate(query: str, context: list[Chunk] | None = None) -> str:
+def generate(query: str, context: Sequence[Chunk] | None = None) -> str:
     """
     Returns a string response from an LLM model, based on a query input.
     """

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Sequence, Tuple
 
 from sentence_transformers import SentenceTransformer
@@ -6,14 +7,40 @@ from sqlalchemy import Row, select
 import src.adapters.db as db
 from src.db.models.document import Chunk
 
+logger = logging.getLogger(__name__)
+
 
 def retrieve(
     db_session: db.Session, embedding_model: SentenceTransformer, query: str, k: int = 5
-) -> Sequence[Row[Tuple[Chunk, float]]]:
+) -> Sequence[Chunk]:
+    logger.info(f"Retrieving context for {query!r}")
+
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
 
-    return db_session.execute(
+    chunks = db_session.scalars(
+        select(Chunk).order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding)).limit(k)
+    ).all()
+
+    for chunk in chunks:
+        logger.info(f"Retrieved: {chunk.document.name!r}")
+
+    return chunks
+
+
+def retrieve_with_scores(
+    db_session: db.Session, embedding_model: SentenceTransformer, query: str, k: int = 5
+) -> Sequence[Row[Tuple[Chunk, float]]]:
+    logger.info(f"Retrieving context for {query!r}")
+
+    query_embedding = embedding_model.encode(query, show_progress_bar=False)
+
+    chunks_with_scores = db_session.execute(
         select(Chunk, Chunk.mpnet_embedding.max_inner_product(query_embedding))
         .order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding))
         .limit(k)
     ).all()
+
+    for chunk, score in chunks_with_scores:
+        logger.info(f"Retrieved: {chunk.document.name!r} with score {score}")
+
+    return chunks_with_scores

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -22,7 +22,7 @@ def retrieve(
     ).all()
 
     for chunk in chunks:
-        logger.info(f"Retrieved: {chunk.document.name!r}")
+        logger.debug(f"Retrieved: {chunk.document.name!r}")
 
     return chunks
 

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -1,0 +1,20 @@
+from src.format import format_guru_cards
+from tests.src.db.models.factories import ChunkFactory
+
+
+def test_format_guru_cards():
+    chunks = ChunkFactory.build_batch(3)
+    html = format_guru_cards(chunks)
+    assert "accordion-1" in html
+    assert "Related Guru cards" in html
+    assert chunks[0].document.name in html
+    assert chunks[0].document.content in html
+    assert chunks[1].document.name in html
+    assert chunks[1].document.content in html
+    assert chunks[2].document.name in html
+    assert chunks[2].document.content in html
+
+    # Check that a second call doesn't re-use the IDs
+    next_html = format_guru_cards(chunks)
+    assert "accordion-1" not in next_html
+    assert "accordion-4" in next_html

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -1,24 +1,39 @@
 from sqlalchemy import delete
 
 from src.db.models.document import Document
-from src.retrieve import retrieve
+from src.retrieve import retrieve, retrieve_with_scores
 from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 from tests.src.db.models.factories import ChunkFactory
+
+
+def _get_chunks():
+    return [
+        ChunkFactory.create(
+            content="Incomprehensibility characterizes unintelligible, overwhelmingly convoluted dissertations."
+        ),
+        ChunkFactory.create(
+            content="Curiosity inspires creative, innovative communities worldwide."
+        ),
+        ChunkFactory.create(content="The quick brown red fox jumps."),
+    ]
 
 
 def test_retrieve(db_session, enable_factory_create):
     db_session.execute(delete(Document))
     mock_embedding_model = MockSentenceTransformer()
-
-    ChunkFactory.create(
-        content="Incomprehensibility characterizes unintelligible, overwhelmingly convoluted dissertations."
-    )
-    medium_chunk = ChunkFactory.create(
-        content="Curiosity inspires creative, innovative communities worldwide."
-    )
-    short_chunk = ChunkFactory.create(content="The quick brown red fox jumps.")
+    _, medium_chunk, short_chunk = _get_chunks()
 
     results = retrieve(db_session, mock_embedding_model, "Very tiny words.", k=2)
+
+    assert results == [short_chunk, medium_chunk]
+
+
+def test_retrieve_with_scores(db_session, enable_factory_create):
+    db_session.execute(delete(Document))
+    mock_embedding_model = MockSentenceTransformer()
+    _, medium_chunk, short_chunk = _get_chunks()
+
+    results = retrieve_with_scores(db_session, mock_embedding_model, "Very tiny words.", k=2)
 
     assert len(results) == 2
     assert results[0][0] == short_chunk


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-282


## Changes
 - Commit the `.chainlit` folder (this is the majority of the additions in this PR)
   - Enable the unsafe_html in the config, and set custom HTML and JS for accordions from USWDS. Also enable light mode and disable file uploads
 - Add a `format_guru_cards` function and append the output to the response of the user message
 - Refactor `retrieve` into two functions, `retrieve` and `retrieve_with_scores`. The initial implementation was `retrieve_with_scores`, but we don't use it yet, so this simplifies the code. Also moved logging out of chainlit.py and directly into these functions. Add test coverage for these.


## Context for reviewers


## Testing
Tests added for formatter, manual testing screenshot below:
<img width="747" alt="image" src="https://github.com/navapbc/labs-decision-support-tool/assets/31424131/c971baf3-58b8-49a6-8504-50ba1dac9c71">

