### PR TITLE
perf: Lower database auto-scaling settings

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -49,8 +49,8 @@ resource "aws_rds_cluster" "db" {
   deletion_protection = true
 
   serverlessv2_scaling_configuration {
-    max_capacity = 4.0
-    min_capacity = 2.0
+    max_capacity = 1.0
+    min_capacity = 0.5
   }
 
   db_subnet_group_name   = var.database_subnet_group_name


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-298


## Changes
 - Move auto scaling for DB from 2-4 to .5-1

## Context for reviewers
 - We don't expect many simultaneous users, and only a relatively small amount of data in the DB, so don't need heavy scaling. I initially set it this way to be confident the application would run, but manual testing suggests it works fine at these lower levels for our current level of usage.