### PR TITLE
feat: Use URL query 'engine' parameter to set chatbot's configuration

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlparse
 
 import chainlit as cl
 from src import chat_engine
+from src.format import format_guru_cards
 from src.login import require_login
 
 logger = logging.getLogger(__name__)
@@ -49,8 +50,8 @@ async def on_message(message: cl.Message) -> None:
     engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
     try:
         result = engine.on_message(question=message.content)
-        answer = engine.format_answer_message(result)
-        await cl.Message(content=answer).send()
+        msg_content = result.response + format_guru_cards(result.chunks)
+        await cl.Message(content=msg_content).send()
     except Exception as err:  # pylint: disable=broad-exception-caught
         await cl.Message(
             author="backend",

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -14,7 +14,7 @@ require_login()
 @cl.on_chat_start
 async def start() -> None:
     engine_id = engine_url_query_value()
-    logger.info("engine_id: %s", engine_id)
+    logger.info("Engine ID: %s", engine_id)
     engine = chat_engine.create_engine(engine_id)
     if not engine:
         await cl.Message(
@@ -35,7 +35,7 @@ async def start() -> None:
 
 def engine_url_query_value() -> str:
     url = cl.user_session.get("http_referer")
-    logger.debug("URL: %s", url)
+    logger.debug("Referer URL: %s", url)
 
     # Using this suggestion: https://github.com/Chainlit/chainlit/issues/144#issuecomment-2227543547
     parsed_url = urlparse(url)

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -25,7 +25,7 @@ async def start() -> None:
         return
 
     cl.user_session.set("chat_engine", engine)
-    await engine.on_start()
+    engine.on_start()
     await cl.Message(
         author="backend",
         metadata={"engine": engine_id},

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -25,7 +25,6 @@ async def start() -> None:
         return
 
     cl.user_session.set("chat_engine", engine)
-    engine.on_start()
     await cl.Message(
         author="backend",
         metadata={"engine": engine_id},

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -47,7 +47,15 @@ async def on_message(message: cl.Message) -> None:
     logger.info("Received: %r", message.content)
 
     engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
-    results = engine.on_message(question=message.content, cl_message=message)
-    answer = engine.format_answer_message(results)
-
-    await cl.Message(content=answer).send()
+    try:
+        results = engine.on_message(question=message.content, cl_message=message)
+        answer = engine.format_answer_message(results)
+        await cl.Message(content=answer).send()
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        await cl.Message(
+            author="backend",
+            metadata={"error_class": err.__class__.__name__, "error": str(err)},
+            content=f"{err.__class__.__name__}: {err}",
+        ).send()
+        # Re-raise error to have it in the logs
+        raise err

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -49,8 +49,8 @@ async def on_message(message: cl.Message) -> None:
 
     engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
     try:
-        results = engine.on_message(question=message.content, cl_message=message)
-        answer = engine.format_answer_message(results)
+        result = engine.on_message(question=message.content, cl_message=message)
+        answer = engine.format_answer_message(result)
         await cl.Message(content=answer).send()
     except Exception as err:  # pylint: disable=broad-exception-caught
         await cl.Message(

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import parse_qs, urlparse
 
 import chainlit as cl
 import src.adapters.db as db
@@ -11,6 +12,22 @@ from src.shared import get_embedding_model
 logger = logging.getLogger(__name__)
 
 require_login()
+
+
+@cl.on_chat_start
+async def start() -> None:
+    chat_engine = engine_url_query_value()
+    print("chat_engine", chat_engine)
+
+
+def engine_url_query_value() -> str:
+    url = cl.user_session.get("http_referer")
+    logger.debug("URL: %s", url)
+
+    # Using this suggestion: https://github.com/Chainlit/chainlit/issues/144#issuecomment-2227543547
+    parsed_url = urlparse(url)
+    qs = parse_qs(parsed_url.query)
+    return qs.get("engine", ["default_engine"])[0]
 
 
 @cl.on_message

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from urllib.parse import parse_qs, urlparse
 
 import chainlit as cl
@@ -39,7 +40,7 @@ def engine_url_query_value() -> str:
     # Using this suggestion: https://github.com/Chainlit/chainlit/issues/144#issuecomment-2227543547
     parsed_url = urlparse(url)
     qs = parse_qs(parsed_url.query)
-    return qs.get("engine", ["default_engine"])[0]
+    return qs.get("engine", [os.environ.get("CHAT_ENGINE", "default_engine")])[0]
 
 
 @cl.on_message

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -49,7 +49,7 @@ async def on_message(message: cl.Message) -> None:
 
     engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
     try:
-        result = engine.on_message(question=message.content, cl_message=message)
+        result = engine.on_message(question=message.content)
         answer = engine.format_answer_message(result)
         await cl.Message(content=answer).send()
     except Exception as err:  # pylint: disable=broad-exception-caught

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 class OnMessageResult:
     response: str
     chunks: Sequence[Chunk]
-    data: Optional[dict] = None
 
 
 class ChatEngineInterface(ABC):

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Optional, Sequence
 
 import src.adapters.db as db
-from chainlit.input_widget import Switch
 from src.db.models.document import Chunk
 from src.format import format_guru_cards
 from src.generate import generate
@@ -65,21 +64,7 @@ class GuruBaseEngine(ChatEngineInterface):
     use_multiprogram_dataset_default = False
 
     async def on_start(self) -> dict:
-        chat_settings = cl.ChatSettings(
-            [
-                Switch(
-                    id="guru-snap", label="Guru cards: SNAP", initial=self.use_snap_dataset_default
-                ),
-                Switch(
-                    id="guru-multiprogram",
-                    label="Guru cards: Multi-program",
-                    initial=self.use_multiprogram_dataset_default,
-                ),
-            ]
-        )
-        settings = await chat_settings.send()
-        cl.user_session.set("settings", settings)
-        return settings
+        return {}
 
     def on_message(self, question: str) -> OnMessageResult:
         with db.PostgresDBClient().get_session() as db_session:

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence
 
 import chainlit as cl
 import src.adapters.db as db
-from chainlit.input_widget import Slider, Switch
+from chainlit.input_widget import Switch
 from src.db.models.document import Chunk
 from src.format import format_guru_cards
 from src.generate import generate

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -25,10 +25,6 @@ class ChatEngineInterface(ABC):
     name: str
 
     @abstractmethod
-    def on_start(self) -> None:
-        pass
-
-    @abstractmethod
     def on_message(self, question: str) -> OnMessageResult:
         pass
 
@@ -59,9 +55,6 @@ def create_engine(engine_id: str) -> ChatEngineInterface | None:
 
 # Subclasses of ChatEngineInterface can be extracted into a separate file if it gets too large
 class GuruBaseEngine(ChatEngineInterface):
-    def on_start(self) -> None:
-        pass
-
     def on_message(self, question: str) -> OnMessageResult:
         with db.PostgresDBClient().get_session() as db_session:
             chunks = retrieve(
@@ -97,9 +90,6 @@ class GuruSnapEngine(GuruBaseEngine):
 class PolicyMichiganEngine(ChatEngineInterface):
     engine_id: str = "policy-mi"
     name: str = "Michigan Bridges Policy Manual Chat Engine"
-
-    def on_start(self) -> None:
-        pass
 
     def on_message(self, question: str) -> OnMessageResult:
         logger.warning("TODO: Retrieve from MI Policy Manual")

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -25,7 +25,7 @@ class ChatEngineInterface(ABC):
     name: str
 
     @abstractmethod
-    async def on_start(self) -> dict:
+    def on_start(self) -> None:
         pass
 
     @abstractmethod
@@ -59,8 +59,8 @@ def create_engine(engine_id: str) -> ChatEngineInterface | None:
 
 # Subclasses of ChatEngineInterface can be extracted into a separate file if it gets too large
 class GuruBaseEngine(ChatEngineInterface):
-    async def on_start(self) -> dict:
-        return {}
+    def on_start(self) -> None:
+        pass
 
     def on_message(self, question: str) -> OnMessageResult:
         with db.PostgresDBClient().get_session() as db_session:
@@ -98,8 +98,8 @@ class PolicyMichiganEngine(ChatEngineInterface):
     engine_id: str = "policy-mi"
     name: str = "Michigan Bridges Policy Manual Chat Engine"
 
-    async def on_start(self) -> dict:
-        return {}
+    def on_start(self) -> None:
+        pass
 
     def on_message(self, question: str) -> OnMessageResult:
         logger.warning("TODO: Retrieve from MI Policy Manual")

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -122,7 +122,7 @@ class GuruSnapEngine(GuruBaseEngine):
 
     def on_message(self, question: str, cl_message: cl.Message) -> dict:
         # TODO: Only retrieve SNAP Guru cards https://navalabs.atlassian.net/browse/DST-328
-        logger.warn("TODO: Only retrieve SNAP Guru cards")
+        logger.warning("TODO: Only retrieve SNAP Guru cards")
         chunks: list[Chunk] = []
         response = "TEMP: Replace with generated response once chunks are correct"
         return {"chunks": chunks, "response": response}
@@ -136,7 +136,7 @@ class PolicyMichiganEngine(ChatEngineInterface):
         return {}
 
     def on_message(self, question: str, cl_message: cl.Message) -> dict:
-        logger.warn("TODO: Retrieve from MI Policy Manual")
+        logger.warning("TODO: Retrieve from MI Policy Manual")
         chunks = ["TODO: Retrieve from MI Policy Manual"]
         response = "TEMP: Replace with generated response once chunks are correct"
         return {"chunks": chunks, "response": response}

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -5,7 +5,6 @@ from typing import Sequence
 
 import src.adapters.db as db
 from src.db.models.document import Chunk
-from src.format import format_guru_cards
 from src.generate import generate
 from src.retrieve import retrieve
 from src.shared import get_embedding_model
@@ -26,10 +25,6 @@ class ChatEngineInterface(ABC):
 
     @abstractmethod
     def on_message(self, question: str) -> OnMessageResult:
-        pass
-
-    @abstractmethod
-    def format_answer_message(self, result: OnMessageResult) -> str:
         pass
 
 
@@ -66,9 +61,6 @@ class GuruBaseEngine(ChatEngineInterface):
         response = generate(question, context=chunks)
         return OnMessageResult(response, chunks)
 
-    def format_answer_message(self, result: OnMessageResult) -> str:
-        return result.response + format_guru_cards(result.chunks)
-
 
 class GuruMultiprogramEngine(GuruBaseEngine):
     engine_id: str = "guru-multiprogram"
@@ -96,7 +88,3 @@ class PolicyMichiganEngine(ChatEngineInterface):
         chunks: list[Chunk] = []
         response = "TEMP: Replace with generated response once chunks are correct"
         return OnMessageResult(response, chunks)
-
-    def format_answer_message(self, result: OnMessageResult) -> str:
-        # Placeholder for Policy Manual Citation format
-        return f"TODO: Placeholder for Policy Manual Citation format. {result}"

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -32,7 +32,7 @@ class ChatEngineInterface(ABC):
         pass
 
     @abstractmethod
-    def on_message(self, question: str, cl_message: cl.Message) -> OnMessageResult:
+    def on_message(self, question: str) -> OnMessageResult:
         pass
 
     @abstractmethod
@@ -82,7 +82,7 @@ class GuruBaseEngine(ChatEngineInterface):
         cl.user_session.set("settings", settings)
         return settings
 
-    def on_message(self, question: str, cl_message: cl.Message) -> OnMessageResult:
+    def on_message(self, question: str) -> OnMessageResult:
         with db.PostgresDBClient().get_session() as db_session:
             chunks = retrieve(
                 db_session,
@@ -108,7 +108,7 @@ class GuruSnapEngine(GuruBaseEngine):
     name: str = "Guru SNAP Chat Engine"
     use_snap_dataset_default = True
 
-    def on_message(self, question: str, cl_message: cl.Message) -> OnMessageResult:
+    def on_message(self, question: str) -> OnMessageResult:
         # TODO: Only retrieve SNAP Guru cards https://navalabs.atlassian.net/browse/DST-328
         logger.warning("TODO: Only retrieve SNAP Guru cards")
         chunks: list[Chunk] = []
@@ -123,7 +123,7 @@ class PolicyMichiganEngine(ChatEngineInterface):
     async def on_start(self) -> dict:
         return {}
 
-    def on_message(self, question: str, cl_message: cl.Message) -> OnMessageResult:
+    def on_message(self, question: str) -> OnMessageResult:
         logger.warning("TODO: Retrieve from MI Policy Manual")
         chunks: list[Chunk] = []
         response = "TEMP: Replace with generated response once chunks are correct"

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Sequence
 
 import src.adapters.db as db
 from src.db.models.document import Chunk

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Sequence, Type
+from typing import Optional, Sequence
 
 import chainlit as cl
 import src.adapters.db as db
@@ -11,6 +11,7 @@ from src.format import format_guru_cards
 from src.generate import generate
 from src.retrieve import retrieve
 from src.shared import get_embedding_model
+from src.util.class_utils import all_subclasses
 
 logger = logging.getLogger(__name__)
 
@@ -37,10 +38,6 @@ class ChatEngineInterface(ABC):
     @abstractmethod
     def format_answer_message(self, result: OnMessageResult) -> str:
         pass
-
-
-def all_subclasses(cls: Type) -> set:
-    return {cls}.union(s for c in cls.__subclasses__() for s in all_subclasses(c))
 
 
 def available_engines() -> list[str]:

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -61,7 +61,6 @@ class GuruBaseEngine(ChatEngineInterface):
     use_multiprogram_dataset_default = False
 
     async def on_start(self) -> dict:
-        logger.info("chat_engine name: %s", self.name)
         chat_settings = cl.ChatSettings(
             [
                 Slider(
@@ -95,8 +94,6 @@ class GuruBaseEngine(ChatEngineInterface):
         return settings
 
     def on_message(self, question: str, cl_message: cl.Message) -> dict:
-        logger.info("chat_engine name: %s", self.name)
-
         with db.PostgresDBClient().get_session() as db_session:
             chunks = retrieve(
                 db_session,
@@ -125,16 +122,21 @@ class GuruSnapEngine(GuruBaseEngine):
 
     def on_message(self, question: str, cl_message: cl.Message) -> dict:
         # TODO: Only retrieve SNAP Guru cards https://navalabs.atlassian.net/browse/DST-328
+        logger.warn("TODO: Only retrieve SNAP Guru cards")
         chunks: list[Chunk] = []
         response = "TEMP: Replace with generated response once chunks are correct"
         return {"chunks": chunks, "response": response}
 
 
-class PolicyMichiganEngine(GuruBaseEngine):
+class PolicyMichiganEngine(ChatEngineInterface):
     engine_id: str = "policy-mi"
     name: str = "Michigan Bridges Policy Manual Chat Engine"
 
+    async def on_start(self) -> dict:
+        return {}
+
     def on_message(self, question: str, cl_message: cl.Message) -> dict:
+        logger.warn("TODO: Retrieve from MI Policy Manual")
         chunks = ["TODO: Retrieve from MI Policy Manual"]
         response = "TEMP: Replace with generated response once chunks are correct"
         return {"chunks": chunks, "response": response}

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -1,0 +1,68 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Mapping, Type
+
+import src.adapters.db as db
+from src.format import format_guru_cards
+from src.generate import generate
+from src.retrieve import retrieve
+from src.shared import get_embedding_model
+
+logger = logging.getLogger(__name__)
+
+
+class ChatEngineInterface(ABC):
+    id: str
+    name: str = "Chat Engine Interface"
+
+    @abstractmethod
+    def on_start(self):
+        pass
+
+    @abstractmethod
+    def on_message(self, question: str, **kwargs):
+        pass
+
+    @abstractmethod
+    def format_answer_message(self, result: dict):
+        pass
+
+
+def available_engines():
+    return [engine_class.id for engine_class in ChatEngineInterface.__subclasses__()]
+
+
+def create_engine(id: str) -> ChatEngineInterface | None:
+    engines: Mapping[str, Type[ChatEngineInterface]] = {engine_class.id: engine_class for engine_class in ChatEngineInterface.__subclasses__()}  # type: ignore
+
+    if id not in engines:
+        return None
+
+    chat_engine_class = engines[id]
+    return chat_engine_class()
+
+
+# Subclasses of ChatEngineInterface can be extracted into a separate file if it gets too large
+class GuruMultiprogramEngine(ChatEngineInterface):
+    id: str = "guru-multiprogram"
+    name: str = "Guru Multi-program Chat Engine"
+
+    def on_start(self):
+        logger.info("chat_engine name: %s", self.name)
+
+    def on_message(self, question: str, **_kwargs):
+        logger.info("chat_engine name: %s", self.name)
+
+        with db.PostgresDBClient().get_session() as db_session:
+            chunks = retrieve(
+                db_session,
+                get_embedding_model(),
+                question,
+            )
+
+        response = generate(question, context=chunks)
+        return {"chunks": chunks, "response": response}
+
+    def format_answer_message(self, result: dict):
+        formatted_guru_cards = format_guru_cards(result["chunks"])
+        return result["response"] + formatted_guru_cards

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -68,22 +68,6 @@ class GuruBaseEngine(ChatEngineInterface):
     async def on_start(self) -> dict:
         chat_settings = cl.ChatSettings(
             [
-                Slider(
-                    id="temperature",
-                    label="Temperature for primary LLM",
-                    initial=0.1,
-                    min=0,
-                    max=2,
-                    step=0.1,
-                ),
-                Slider(
-                    id="retrieve_k",
-                    label="Guru cards to retrieve",
-                    initial=5,
-                    min=1,
-                    max=10,
-                    step=1,
-                ),
                 Switch(
                     id="guru-snap", label="Guru cards: SNAP", initial=self.use_snap_dataset_default
                 ),

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, Sequence
 
-import chainlit as cl
 import src.adapters.db as db
 from chainlit.input_widget import Switch
 from src.db.models.document import Chunk

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -60,9 +60,6 @@ def create_engine(engine_id: str) -> ChatEngineInterface | None:
 
 # Subclasses of ChatEngineInterface can be extracted into a separate file if it gets too large
 class GuruBaseEngine(ChatEngineInterface):
-    use_snap_dataset_default = False
-    use_multiprogram_dataset_default = False
-
     async def on_start(self) -> dict:
         return {}
 
@@ -84,13 +81,11 @@ class GuruBaseEngine(ChatEngineInterface):
 class GuruMultiprogramEngine(GuruBaseEngine):
     engine_id: str = "guru-multiprogram"
     name: str = "Guru Multi-program Chat Engine"
-    use_multiprogram_dataset_default = True
 
 
 class GuruSnapEngine(GuruBaseEngine):
     engine_id: str = "guru-snap"
     name: str = "Guru SNAP Chat Engine"
-    use_snap_dataset_default = True
 
     def on_message(self, question: str) -> OnMessageResult:
         # TODO: Only retrieve SNAP Guru cards https://navalabs.atlassian.net/browse/DST-328

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -1,6 +1,6 @@
 import logging
-from typing import Type
 from abc import ABC, abstractmethod
+from typing import Type
 
 import chainlit as cl
 import src.adapters.db as db

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -5,6 +5,7 @@ from typing import Type
 import chainlit as cl
 import src.adapters.db as db
 from chainlit.input_widget import Slider, Switch
+from src.db.models.document import Chunk
 from src.format import format_guru_cards
 from src.generate import generate
 from src.retrieve import retrieve
@@ -123,8 +124,8 @@ class GuruSnapEngine(GuruBaseEngine):
     use_snap_dataset_default = True
 
     def on_message(self, question: str, cl_message: cl.Message) -> dict:
-        # TODO: https://navalabs.atlassian.net/browse/DST-328
-        chunks = ["TODO: Only retrieve SNAP Guru cards"]
+        # TODO: Only retrieve SNAP Guru cards https://navalabs.atlassian.net/browse/DST-328
+        chunks: list[Chunk] = []
         response = "TEMP: Replace with generated response once chunks are correct"
         return {"chunks": chunks, "response": response}
 
@@ -132,6 +133,11 @@ class GuruSnapEngine(GuruBaseEngine):
 class PolicyMichiganEngine(GuruBaseEngine):
     engine_id: str = "policy-mi"
     name: str = "Michigan Bridges Policy Manual Chat Engine"
+
+    def on_message(self, question: str, cl_message: cl.Message) -> dict:
+        chunks = ["TODO: Retrieve from MI Policy Manual"]
+        response = "TEMP: Replace with generated response once chunks are correct"
+        return {"chunks": chunks, "response": response}
 
     def format_answer_message(self, results: dict) -> str:
         # Placeholder for Policy Manual Citation format

--- a/app/src/util/class_utils.py
+++ b/app/src/util/class_utils.py
@@ -1,7 +1,5 @@
-from typing import Type, TypeVar
-
-T = TypeVar("T")
+from typing import Type
 
 
-def all_subclasses(cls: Type[T]) -> set[Type[T]]:
+def all_subclasses(cls: Type) -> set[Type]:
     return {cls}.union(s for c in cls.__subclasses__() for s in all_subclasses(c))

--- a/app/src/util/class_utils.py
+++ b/app/src/util/class_utils.py
@@ -1,0 +1,7 @@
+from typing import Type, TypeVar
+
+T = TypeVar("T")
+
+
+def all_subclasses(cls: Type[T]) -> set[Type[T]]:
+    return {cls}.union(s for c in cls.__subclasses__() for s in all_subclasses(c))

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -1,0 +1,35 @@
+import src.chat_engine as chat_engine
+from src.chat_engine import GuruMultiprogramEngine, GuruSnapEngine
+
+
+def test_available_engines():
+    engines = chat_engine.available_engines()
+    assert isinstance(engines, list)
+    assert len(engines) > 0
+    assert "guru-multiprogram" in engines
+    assert "guru-snap" in engines
+    assert "policy-mi" in engines
+
+
+async def test_create_engine_Guru_Multiprogram():
+    engine_id = "guru-multiprogram"
+    engine = chat_engine.create_engine(engine_id)
+    assert engine is not None
+    assert engine.name == GuruMultiprogramEngine.name
+    settings = await engine.on_start()
+    assert settings["use_guru_snap_dataset"] is False
+    assert settings["use_guru_multiprogram_dataset"] is True
+
+    assert engine.format_answer_message({}) == ""
+
+
+async def test_create_engine_Guru_SNAP():
+    engine_id = "guru-snap"
+    engine = chat_engine.create_engine(engine_id)
+    assert engine is not None
+    assert engine.name == GuruSnapEngine.name
+    settings = await engine.on_start()
+    assert settings["use_guru_snap_dataset"] is True
+    assert settings["use_guru_multiprogram_dataset"] is False
+
+    assert engine.format_answer_message({}) == ""

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -1,5 +1,5 @@
 import src.chat_engine as chat_engine
-from src.chat_engine import GuruMultiprogramEngine, GuruSnapEngine
+from src.chat_engine import GuruMultiprogramEngine, GuruSnapEngine, OnMessageResult
 
 
 def test_available_engines():
@@ -11,6 +11,10 @@ def test_available_engines():
     assert "policy-mi" in engines
 
 
+def create_on_message_result(response="Some LLM response", chunks=None):
+    return OnMessageResult(response, chunks | [])
+
+
 async def test_create_engine_Guru_Multiprogram():
     engine_id = "guru-multiprogram"
     engine = chat_engine.create_engine(engine_id)
@@ -20,7 +24,7 @@ async def test_create_engine_Guru_Multiprogram():
     assert settings["use_guru_snap_dataset"] is False
     assert settings["use_guru_multiprogram_dataset"] is True
 
-    assert engine.format_answer_message({}) == ""
+    assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")
 
 
 async def test_create_engine_Guru_SNAP():
@@ -32,4 +36,4 @@ async def test_create_engine_Guru_SNAP():
     assert settings["use_guru_snap_dataset"] is True
     assert settings["use_guru_multiprogram_dataset"] is False
 
-    assert engine.format_answer_message({}) == ""
+    assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -1,5 +1,5 @@
 import src.chat_engine as chat_engine
-from src.chat_engine import GuruMultiprogramEngine, GuruSnapEngine, OnMessageResult
+from src.chat_engine import GuruMultiprogramEngine, GuruSnapEngine
 
 
 def test_available_engines():
@@ -11,17 +11,11 @@ def test_available_engines():
     assert "policy-mi" in engines
 
 
-def create_on_message_result(response="Some LLM response", chunks=None):
-    return OnMessageResult(response, chunks or [])
-
-
 def test_create_engine_Guru_Multiprogram():
     engine_id = "guru-multiprogram"
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruMultiprogramEngine.name
-
-    assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")
 
 
 def test_create_engine_Guru_SNAP():
@@ -29,5 +23,3 @@ def test_create_engine_Guru_SNAP():
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruSnapEngine.name
-
-    assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -12,28 +12,24 @@ def test_available_engines():
 
 
 def create_on_message_result(response="Some LLM response", chunks=None):
-    return OnMessageResult(response, chunks | [])
+    return OnMessageResult(response, chunks or [])
 
 
-async def test_create_engine_Guru_Multiprogram():
+def test_create_engine_Guru_Multiprogram():
     engine_id = "guru-multiprogram"
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruMultiprogramEngine.name
-    settings = await engine.on_start()
-    assert settings["use_guru_snap_dataset"] is False
-    assert settings["use_guru_multiprogram_dataset"] is True
+    engine.on_start()
 
     assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")
 
 
-async def test_create_engine_Guru_SNAP():
+def test_create_engine_Guru_SNAP():
     engine_id = "guru-snap"
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruSnapEngine.name
-    settings = await engine.on_start()
-    assert settings["use_guru_snap_dataset"] is True
-    assert settings["use_guru_multiprogram_dataset"] is False
+    engine.on_start()
 
     assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -20,7 +20,6 @@ def test_create_engine_Guru_Multiprogram():
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruMultiprogramEngine.name
-    engine.on_start()
 
     assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")
 
@@ -30,6 +29,5 @@ def test_create_engine_Guru_SNAP():
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruSnapEngine.name
-    engine.on_start()
 
     assert engine.format_answer_message(create_on_message_result()).startswith("Some LLM response")


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-327


## Changes


- Add `ChatEngineInterface` abstract class that acts as an interface for chat engines
- Refactor existing chatbot backend to `GuruMultiprogramEngine` class
- Add placeholder engines: `GuruSnapEngine` and `PolicyMichiganEngine`


## Testing
* Go to `chat/` or `/chat/?engine=unknownEngine`, expect "Available engines: ['guru-snap', 'policy-mi', 'guru-multiprogram']"
* Go to `/chat/?engine=guru-multiprogram`, expect "Chat engine started: Guru Multi-program Chat Engine"
   - Expect normal behavior after submitting a question
* Go to `/chat/?engine=guru-snap`, expect "Chat engine started: Guru SNAP Chat Engine"
   - Expect "TEMP: Replace with generated response once chunks are correct"
* Go to `/chat/?engine=policy-mi`, expect "Chat engine started: Michigan Bridges Policy Manual Chat Engine"
   - Expect "TEMP: Replace with generated response once chunks are correct"


