### PR TITLE
fix: set uvicorn worker to 1

### DIFF
--- a/app/gunicorn.conf.py
+++ b/app/gunicorn.conf.py
@@ -16,10 +16,5 @@ app_config = AppConfig()
 # Since the `-b 0.0.0.0:8000` argument is used when running in the Docker environment,
 # this bind variable is only used when not using Docker
 bind = app_config.host + ':' + str(app_config.port)
-# Calculates the number of usable cores and doubles it. Recommended number of workers per core is two.
-# https://docs.gunicorn.org/en/latest/design.html#how-many-workers
-# We use 'os.sched_getaffinity(pid)' not 'os.cpu_count()' because it returns only allowable CPUs.
-# os.sched_getaffinity(pid): Return the set of CPUs the process with PID pid is restricted to.
-# os.cpu_count(): Return the number of CPUs in the system.
-workers = len(os.sched_getaffinity(0)) * 2
+workers = 1
 threads = 4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,18 @@ services:
       args:
         - RUN_UID=${RUN_UID:-4000}
         - RUN_USER=${RUN_USER:-app}
-    command: ["poetry", "run", "gunicorn","-k uvicorn.workers.UvicornWorker","-b 0.0.0.0:8000", "src.app:app"]
+    command:
+      [
+        "poetry",
+        "run",
+        "uvicorn",
+        "src.app:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8000",
+        "--reload",
+      ]
     container_name: main-app
     env_file: ./app/local.env
     ports:


### PR DESCRIPTION
## Changes

> change amount of worker #'s to 1

## Context for reviewers

> Chainlit uses Socket.io for backend server connections; multiple workeres are currently unsupported by gunicorn
https://flask-socketio.readthedocs.io/en/latest/deployment.html#gunicorn-web-server

## Testing

> Run `make start`
> Navigate to `localhost:8000/chat` and enter a query into the chatbot, response should be returned
