### PR TITLE
feat: Set default chat engine to 'guru-snap'

### DIFF
--- a/app/gunicorn.conf.py
+++ b/app/gunicorn.conf.py
@@ -7,11 +7,10 @@ Attributes:
 
 For more information, see https://docs.gunicorn.org/en/stable/configure.html
 """
-import os
 
-from src.app_config import AppConfig
+from src import shared
 
-app_config = AppConfig()
+app_config = shared.get_app_config()
 
 # Since the `-b 0.0.0.0:8000` argument is used when running in the Docker environment,
 # this bind variable is only used when not using Docker

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -18,3 +18,4 @@ class AppConfig(PydanticBaseEnvConfig):
     global_password: str | None = None
     host: str = "127.0.0.1"
     port: int = 8080
+    chat_engine: str = "guru-snap"

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from urllib.parse import parse_qs, urlparse
 
 import chainlit as cl

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -40,7 +40,7 @@ def engine_url_query_value() -> str:
     # Using this suggestion: https://github.com/Chainlit/chainlit/issues/144#issuecomment-2227543547
     parsed_url = urlparse(url)
     qs = parse_qs(parsed_url.query)
-    return qs.get("engine", [os.environ.get("CHAT_ENGINE", "default_engine")])[0]
+    return qs.get("engine", [os.environ.get("CHAT_ENGINE", "guru-snap")])[0]
 
 
 @cl.on_message

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -3,7 +3,7 @@ import os
 from urllib.parse import parse_qs, urlparse
 
 import chainlit as cl
-from src import chat_engine
+from src import chat_engine, shared
 from src.format import format_guru_cards
 from src.login import require_login
 
@@ -40,7 +40,7 @@ def engine_url_query_value() -> str:
     # Using this suggestion: https://github.com/Chainlit/chainlit/issues/144#issuecomment-2227543547
     parsed_url = urlparse(url)
     qs = parse_qs(parsed_url.query)
-    return qs.get("engine", [os.environ.get("CHAT_ENGINE", "guru-snap")])[0]
+    return qs.get("engine", [shared.get_app_config().chat_engine])[0]
 
 
 @cl.on_message


### PR DESCRIPTION
## Ticket

As requested by Ryan, set the default chat engine to 'guru-snap'.

## Changes
Change default chat engine to 'guru-snap'.

## Testing

Navigate to `/chat` (without the `engine` query parameter), expect "Chat engine started: Guru SNAP Chat Engine".

Navigate to `/chat/?engine=someNonExistingEngineId` to see available engines.