### PR TITLE
feat: Retrieve from database based on filters

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -50,12 +50,15 @@ def create_engine(engine_id: str) -> ChatEngineInterface | None:
 
 # Subclasses of ChatEngineInterface can be extracted into a separate file if it gets too large
 class GuruBaseEngine(ChatEngineInterface):
+    datasets: list[str] = []
+
     def on_message(self, question: str) -> OnMessageResult:
         with db.PostgresDBClient().get_session() as db_session:
             chunks = retrieve(
                 db_session,
                 get_embedding_model(),
                 question,
+                datasets=self.datasets,
             )
 
         response = generate(question, context=chunks)
@@ -65,18 +68,13 @@ class GuruBaseEngine(ChatEngineInterface):
 class GuruMultiprogramEngine(GuruBaseEngine):
     engine_id: str = "guru-multiprogram"
     name: str = "Guru Multi-program Chat Engine"
+    datasets = ["guru-multiprogram"]
 
 
 class GuruSnapEngine(GuruBaseEngine):
     engine_id: str = "guru-snap"
     name: str = "Guru SNAP Chat Engine"
-
-    def on_message(self, question: str) -> OnMessageResult:
-        # TODO: Only retrieve SNAP Guru cards https://navalabs.atlassian.net/browse/DST-328
-        logger.warning("TODO: Only retrieve SNAP Guru cards")
-        chunks: list[Chunk] = []
-        response = "TEMP: Replace with generated response once chunks are correct"
-        return OnMessageResult(response, chunks)
+    datasets = ["guru-snap"]
 
 
 class PolicyMichiganEngine(ChatEngineInterface):

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -20,6 +20,7 @@ def retrieve(
     query: str,
     k: int = 5,
     benefit_programs: Sequence | None = None,
+    benefit_regions: Sequence | None = None,
 ) -> Sequence[Chunk]:
     logger.info(f"Retrieving context for {query!r}")
 
@@ -43,6 +44,8 @@ def retrieve(
     statement = select(Chunk).join(Chunk.document)
     if benefit_programs:
         statement = statement.filter(Document.program.in_(benefit_programs))
+    if benefit_regions:
+        statement = statement.filter(Document.region.in_(benefit_regions))
     rchs = db_session.execute(statement.limit(k)).all()
 
     if _DEBUGGING:

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -1,28 +1,60 @@
 import logging
+from pprint import pprint
 from typing import Sequence, Tuple
 
 from sentence_transformers import SentenceTransformer
 from sqlalchemy import Row, select
 
 import src.adapters.db as db
-from src.db.models.document import Chunk
+from src.db.models.document import Chunk, Document
 
 logger = logging.getLogger(__name__)
+_DEBUGGING = True
+if _DEBUGGING:
+    logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 
 
 def retrieve(
-    db_session: db.Session, embedding_model: SentenceTransformer, query: str, k: int = 5
+    db_session: db.Session,
+    embedding_model: SentenceTransformer,
+    query: str,
+    k: int = 5,
+    benefit_programs: Sequence | None = None,
 ) -> Sequence[Chunk]:
     logger.info(f"Retrieving context for {query!r}")
 
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
 
+    if _DEBUGGING:
+        docstmt = select(Document.name, Document.program, Document.region)
+        print("stmt", docstmt.compile(compile_kwargs={"literal_binds": True}))
+        docs = db_session.execute(docstmt).all()
+        print("docs:", docs)
+
+        chstmt = select(Chunk.tokens, Document.program, Chunk.content).join(Chunk.document)
+        chs = db_session.execute(chstmt).all()
+        print("chunks:")
+        pprint(chs)
+        if benefit_programs:
+            chs = db_session.execute(chstmt.filter(Document.program.in_(benefit_programs))).all()
+            print("filtered chunks:")
+            pprint(chs)
+
+    statement = select(Chunk).join(Chunk.document)
+    if benefit_programs:
+        statement = statement.filter(Document.program.in_(benefit_programs))
+    rchs = db_session.execute(statement.limit(k)).all()
+
+    if _DEBUGGING:
+        print("returned chunks:")
+        pprint(rchs)
+
     chunks = db_session.scalars(
-        select(Chunk).order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding)).limit(k)
+        statement.order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding)).limit(k)
     ).all()
 
     for chunk in chunks:
-        logger.debug(f"Retrieved: {chunk.document.name!r}")
+        print(f"Retrieved: {chunk.document.name!r} {chunk.content!r}")
 
     return chunks
 

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -17,7 +17,7 @@ def retrieve(
     k: int = 5,
     **filters: Sequence | None,
 ) -> Sequence[Chunk]:
-    logger.info(f"Retrieving context for {query!r}")
+    logger.info("Retrieving context for %r", query)
 
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
 
@@ -37,7 +37,7 @@ def retrieve(
     ).all()
 
     for chunk in chunks:
-        print(f"Retrieved: {chunk.document.name!r} {chunk.content!r}")
+        logger.debug("Retrieved: %r", chunk.document.name)
 
     return chunks
 

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -15,7 +15,7 @@ def retrieve(
     embedding_model: SentenceTransformer,
     query: str,
     k: int = 5,
-    **filters: Sequence | None,
+    **filters: Sequence[str] | None,
 ) -> Sequence[Chunk]:
     chunks_with_scores = retrieve_with_scores(db_session, embedding_model, query, k, **filters)
     return [chunk for chunk, _ in chunks_with_scores]
@@ -26,7 +26,7 @@ def retrieve_with_scores(
     embedding_model: SentenceTransformer,
     query: str,
     k: int = 5,
-    **filters: Sequence | None,
+    **filters: Sequence[str] | None,
 ) -> Sequence[Row[Tuple[Chunk, float]]]:
     logger.info("Retrieving context for %r", query)
 
@@ -36,11 +36,11 @@ def retrieve_with_scores(
         Chunk.document
     )
     if benefit_dataset := filters.pop("datasets", None):
-        statement = statement.filter(Document.dataset.in_(benefit_dataset))
+        statement = statement.where(Document.dataset.in_(benefit_dataset))
     if benefit_programs := filters.pop("programs", None):
-        statement = statement.filter(Document.program.in_(benefit_programs))
+        statement = statement.where(Document.program.in_(benefit_programs))
     if benefit_regions := filters.pop("regions", None):
-        statement = statement.filter(Document.region.in_(benefit_regions))
+        statement = statement.where(Document.region.in_(benefit_regions))
 
     if filters:
         raise ValueError(f"Unknown filters: {filters.keys()}")

--- a/app/tests/src/db/models/factories.py
+++ b/app/tests/src/db/models/factories.py
@@ -70,8 +70,8 @@ class DocumentFactory(BaseFactory):
     name = factory.Faker("word")
     content = factory.Faker("text")
     dataset = factory.Faker("word")
-    program = factory.Faker("random_choices", elements=["SNAP", "Medicaid", "TANF"])
-    region = factory.Faker("random_choices", elements=["MI", "MD", "PA"])
+    program = factory.Faker("random_element", elements=["SNAP", "Medicaid", "TANF"])
+    region = factory.Faker("random_element", elements=["MI", "MD", "PA"])
 
 
 class ChunkFactory(BaseFactory):

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -3,35 +3,54 @@ from sqlalchemy import delete
 from src.db.models.document import Document
 from src.retrieve import retrieve, retrieve_with_scores
 from tests.mock.mock_sentence_transformer import MockSentenceTransformer
-from tests.src.db.models.factories import ChunkFactory
+from tests.src.db.models.factories import ChunkFactory, DocumentFactory
 
 
-def _get_chunks():
+def _create_chunks(document=None):
+    if not document:
+        document = DocumentFactory.create()
     return [
         ChunkFactory.create(
-            content="Incomprehensibility characterizes unintelligible, overwhelmingly convoluted dissertations."
+            document=document,
+            content="Incomprehensibility characterizes unintelligible, overwhelmingly convoluted dissertations.",
         ),
         ChunkFactory.create(
-            content="Curiosity inspires creative, innovative communities worldwide."
+            document=document,
+            content="Curiosity inspires creative, innovative communities worldwide.",
         ),
-        ChunkFactory.create(content="The quick brown red fox jumps."),
+        ChunkFactory.create(document=document, content="The quick brown red fox jumps."),
     ]
 
 
 def test_retrieve(db_session, enable_factory_create):
     db_session.execute(delete(Document))
     mock_embedding_model = MockSentenceTransformer()
-    _, medium_chunk, short_chunk = _get_chunks()
+    _, medium_chunk, short_chunk = _create_chunks()
 
     results = retrieve(db_session, mock_embedding_model, "Very tiny words.", k=2)
 
     assert results == [short_chunk, medium_chunk]
 
 
+def test_retrieve__with_1_filter(db_session, enable_factory_create):
+    db_session.execute(delete(Document))
+    mock_embedding_model = MockSentenceTransformer()
+    _create_chunks(document=DocumentFactory.create(program="Medicaid"))
+    _, snap_medium_chunk, snap_short_chunk = _create_chunks(
+        document=DocumentFactory.create(program="SNAP")
+    )
+
+    results = retrieve(
+        db_session, mock_embedding_model, "Very tiny words.", k=2, benefit_programs=["SNAP"]
+    )
+
+    assert results == [snap_short_chunk, snap_medium_chunk]
+
+
 def test_retrieve_with_scores(db_session, enable_factory_create):
     db_session.execute(delete(Document))
     mock_embedding_model = MockSentenceTransformer()
-    _, medium_chunk, short_chunk = _get_chunks()
+    _, medium_chunk, short_chunk = _create_chunks()
 
     results = retrieve_with_scores(db_session, mock_embedding_model, "Very tiny words.", k=2)
 

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -34,6 +34,15 @@ def test_retrieve(db_session, enable_factory_create):
     assert results == [short_chunk, medium_chunk]
 
 
+def test_retrieve__with_empty_filter(db_session, enable_factory_create):
+    db_session.execute(delete(Document))
+    _, medium_chunk, short_chunk = _create_chunks()
+
+    results = retrieve(db_session, mock_embedding_model, "Very tiny words.", k=2, datasets=[])
+
+    assert results == [short_chunk, medium_chunk]
+
+
 def test_retrieve__with_unknown_filter(db_session, enable_factory_create):
     with pytest.raises(ValueError):
         retrieve(

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -54,7 +54,7 @@ def test_retrieve__with_dataset_filter(db_session, enable_factory_create):
     db_session.execute(delete(Document))
     _create_chunks(document=DocumentFactory.create())
     _, snap_medium_chunk, snap_short_chunk = _create_chunks(
-        document=DocumentFactory.create(dataset="my_very_unique_dataset")
+        document=DocumentFactory.create(dataset="SNAP")
     )
 
     results = retrieve(
@@ -62,7 +62,7 @@ def test_retrieve__with_dataset_filter(db_session, enable_factory_create):
         mock_embedding_model,
         "Very tiny words.",
         k=2,
-        datasets=["my_very_unique_dataset"],
+        datasets=["SNAP"],
     )
     assert results == [snap_short_chunk, snap_medium_chunk]
 

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -40,9 +40,7 @@ def test_retrieve__with_1_filter(db_session, enable_factory_create):
         document=DocumentFactory.create(program="SNAP")
     )
 
-    results = retrieve(
-        db_session, mock_embedding_model, "Very tiny words.", k=2, benefit_programs=["SNAP"]
-    )
+    results = retrieve(db_session, mock_embedding_model, "Very tiny words.", k=2, programs=["SNAP"])
 
     assert results == [snap_short_chunk, snap_medium_chunk]
 
@@ -59,8 +57,8 @@ def test_retrieve__with_2_filters(db_session, enable_factory_create):
         mock_embedding_model,
         "Very tiny words.",
         k=2,
-        benefit_programs=["SNAP"],
-        benefit_regions=["MI"],
+        programs=["SNAP"],
+        regions=["MI"],
     )
 
     assert results == [snap_short_chunk, snap_medium_chunk]


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-328
follow-on to PR #27

## Changes

Flush out the `GuruSnapEngine` implementation by enabling query the DB using filters (SQL `WHERE`) against the new `dataset`, `program`, and `region` columns.

## Testing

Grab datasets from [our S3 bucket](https://us-east-1.console.aws.amazon.com/s3/buckets/decision-support-tool-app-dev?bucketType=general&region=us-east-1&tab=objects#), and move them to the `app` folder. ([dataset descriptions](https://nava.slack.com/archives/C06ETE82UHM/p1717787155567219?thread_ts=1717783522.574479&cid=C06ETE82UHM))

```
# Reset the database and run migrations
make db-recreate

# Ingest guru-snap dataset, which will be used by the guru-snap engine
make ingest-guru-cards DATASET_ID=guru-snap BENEFIT_PROGRAM=SNAP BENEFIT_REGION=Michigan FILEPATH=/app/guru_cards_setA.json

# Ingest guru-multiprogram dataset, which will be used by the guru-multiprogram engine
make ingest-guru-cards DATASET_ID=guru-multiprogram BENEFIT_PROGRAM=multiprogram BENEFIT_REGION=Michigan FILEPATH=/app/guru_cards_setB.json
```

1. Go to `/chat/` or `/chat/?engine=guru-snap`; expect "Chat engine started: Guru SNAP Chat Engine"
1. Ask a SNAP-related question like "SNAP eligibility" and expect Guru cards related to SNAP
2. Ask a non-SNAP-related question like "energy assistance" and expect **irrelevant** Guru cards (b/c it's only querying against the SNAP Guru cards)

Unchanged:
1. Go to `/chat/?engine=guru-multiprogram`; expect "Chat engine started: Guru Multi-program Chat Engine"
2. Ask a non-SNAP-related question like "energy assistance" and expect **relevant** Guru cards
