### PR TITLE
refactor: Use generalized ChunkWithScore

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -51,10 +51,9 @@ async def on_message(message: cl.Message) -> None:
         result = engine.on_message(question=message.content)
         msg_content = result.response + format_guru_cards(result.chunks_with_scores)
         chunk_titles_and_scores: dict[str, float] = {}
-        for chunk in result.chunks_with_scores:
-            score = chunk[1]
-            title = chunk[0].document.name
-            chunk_titles_and_scores |= {title: score}
+        for chunk_with_score in result.chunks_with_scores:
+            title = chunk_with_score.chunk.document.name
+            chunk_titles_and_scores |= {title: chunk_with_score.score}
 
         await cl.Message(
             content=msg_content,

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -3,10 +3,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Sequence
 
-from sqlalchemy import Row
-
 import src.adapters.db as db
-from src.db.models.document import Chunk
+from src.db.models.document import ChunkWithScore
 from src.generate import generate
 from src.retrieve import retrieve_with_scores
 from src.shared import get_embedding_model
@@ -18,7 +16,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class OnMessageResult:
     response: str
-    chunks_with_scores: Sequence[Row[tuple[Chunk, float]]]
+    chunks_with_scores: Sequence[ChunkWithScore]
 
 
 class ChatEngineInterface(ABC):
@@ -85,6 +83,6 @@ class PolicyMichiganEngine(ChatEngineInterface):
 
     def on_message(self, question: str) -> OnMessageResult:
         logger.warning("TODO: Retrieve from MI Policy Manual")
-        chunks: Sequence[Row[tuple[Chunk, float]]] = []
+        chunks: Sequence[ChunkWithScore] = []
         response = "TEMP: Replace with generated response once chunks are correct"
         return OnMessageResult(response, chunks)

--- a/app/src/db/models/document.py
+++ b/app/src/db/models/document.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from uuid import UUID
 
 import numpy as np
@@ -39,3 +40,9 @@ class Chunk(Base, IdMixin, TimestampMixin):
 
     document_id: Mapped[UUID] = mapped_column(ForeignKey("document.id", ondelete="CASCADE"))
     document: Mapped[Document] = relationship(Document)
+
+
+@dataclass
+class ChunkWithScore:
+    chunk: Chunk
+    score: float

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -1,22 +1,19 @@
 from typing import Sequence
 
-from sqlalchemy import Row
-
-from src.db.models.document import Chunk
+from src.db.models.document import ChunkWithScore
 
 # We need a unique identifier for each accordion,
 # even across multiple calls to this function
 _accordion_id = 0
 
 
-def format_guru_cards(chunks_with_score: Sequence[Row[tuple[Chunk, float]]]) -> str:
+def format_guru_cards(chunks_with_scores: Sequence[ChunkWithScore]) -> str:
     cards_html = ""
-    for chunk in chunks_with_score:
+    for chunk_with_score in chunks_with_scores:
         global _accordion_id
-        chunk_response = chunk[0]
-        score = chunk[1]
         _accordion_id += 1
-        similarity_score = f"<p>Similarity Score: {str(score)}</p>"
+        similarity_score = f"<p>Similarity Score: {str(chunk_with_score.score)}</p>"
+        document = chunk_with_score.chunk.document
         cards_html += f"""
 <div class="usa-accordion" id=accordion-{_accordion_id}>
     <h4 class="usa-accordion__heading">
@@ -26,11 +23,11 @@ def format_guru_cards(chunks_with_score: Sequence[Row[tuple[Chunk, float]]]) -> 
             aria-expanded="false"
             aria-controls="a-{_accordion_id}"
             >
-            <a href='https://link/to/guru_card'>{chunk_response.document.name}</a>
+            <a href='https://link/to/guru_card'>{document.name}</a>
         </button>
     </h4>
     <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>
-        <p>Summary: {chunk_response.document.content}</p>
+        <p>Summary: {document.content}</p>
         {similarity_score}
     </div>
 </div>"""

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -2,9 +2,8 @@ import os
 from typing import Sequence
 
 from litellm import completion
-from sqlalchemy import Row
 
-from src.db.models.document import Chunk
+from src.db.models.document import ChunkWithScore
 
 PROMPT = """Provide answers in plain language written at the average American reading level.
 Use bullet points. Keep your answers brief, max of 5 sentences.
@@ -34,7 +33,7 @@ def get_models() -> dict[str, str]:
 
 def generate(
     query: str,
-    context: Sequence[Row[tuple[Chunk, float]]] | None = None,
+    context: Sequence[ChunkWithScore] | None = None,
 ) -> str:
     """
     Returns a string response from an LLM model, based on a query input.
@@ -42,7 +41,10 @@ def generate(
 
     if context:
         context_text = "\n\n".join(
-            [chunk[0].document.name + "\n" + chunk[0].content for chunk in context]
+            [
+                chunk_with_score.chunk.document.name + "\n" + chunk_with_score.chunk.content
+                for chunk_with_score in context
+            ]
         )
         messages = [
             {

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Sequence, Tuple
+from typing import Sequence
 
 from sentence_transformers import SentenceTransformer
-from sqlalchemy import Row, select
+from sqlalchemy import select
 
 import src.adapters.db as db
-from src.db.models.document import Chunk, Document
+from src.db.models.document import Chunk, ChunkWithScore, Document
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def retrieve_with_scores(
     query: str,
     k: int = 5,
     **filters: Sequence[str] | None,
-) -> Sequence[Row[Tuple[Chunk, float]]]:
+) -> Sequence[ChunkWithScore]:
     logger.info("Retrieving context for %r", query)
 
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
@@ -41,4 +41,4 @@ def retrieve_with_scores(
     for chunk, score in chunks_with_scores:
         logger.info(f"Retrieved: {chunk.document.name!r} with score {score}")
 
-    return chunks_with_scores
+    return [ChunkWithScore(chunk, score) for chunk, score in chunks_with_scores]

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -16,17 +16,17 @@ def _get_chunks_with_scores(db_session):
 
 def test_format_guru_cards_with_score(db_session, enable_factory_create):
     db_session.execute(delete(Document))
-    chunks = _get_chunks_with_scores(db_session)
-    html = format_guru_cards(chunks)
+    chunks_with_scores = _get_chunks_with_scores(db_session)
+    html = format_guru_cards(chunks_with_scores)
     assert "accordion-1" in html
     assert "Related Guru cards" in html
-    assert chunks[0][0].document.name in html
-    assert chunks[0][0].document.content in html
-    assert chunks[1][0].document.name in html
-    assert chunks[1][0].document.content in html
+    assert chunks_with_scores[0].chunk.document.name in html
+    assert chunks_with_scores[0].chunk.document.content in html
+    assert chunks_with_scores[1].chunk.document.name in html
+    assert chunks_with_scores[1].chunk.document.content in html
     assert "Similarity Score" in html
 
     # Check that a second call doesn't re-use the IDs
-    next_html = format_guru_cards(chunks)
+    next_html = format_guru_cards(chunks_with_scores)
     assert "accordion-1" not in next_html
     assert "accordion-4" in next_html

--- a/app/tests/src/test_generate.py
+++ b/app/tests/src/test_generate.py
@@ -2,6 +2,7 @@ import os
 
 import ollama
 
+from src.db.models.document import ChunkWithScore
 from src.generate import PROMPT, generate, get_models
 from tests.mock import mock_completion
 from tests.src.db.models.factories import ChunkFactory
@@ -111,8 +112,11 @@ def test_generate(monkeypatch):
 
 def test_generate_with_context_with_score(monkeypatch):
     monkeypatch.setattr("src.generate.completion", mock_completion.mock_completion)
-    context = [(ChunkFactory.build(), 0.2000), (ChunkFactory.build(), -0.3000)]
-    context_text = f"{context[0][0].document.name}\n{context[0][0].content}\n\n{context[1][0].document.name}\n{context[1][0].content}"
+    context = [
+        ChunkWithScore(ChunkFactory.build(), 0.2000),
+        ChunkWithScore(ChunkFactory.build(), -0.3000),
+    ]
+    context_text = f"{context[0].chunk.document.name}\n{context[0].chunk.content}\n\n{context[1].chunk.document.name}\n{context[1].chunk.content}"
     expected_response = (
         'Called gpt-4o with [{"content": "'
         + PROMPT

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -26,7 +26,7 @@ def _create_chunks(document=None):
 
 
 def _format_retrieval_results(retrieval_results):
-    return [chunk for chunk, _ in retrieval_results]
+    return [chunk_with_score.chunk for chunk_with_score in retrieval_results]
 
 
 def test_retrieve__with_empty_filter(db_session, enable_factory_create):
@@ -89,7 +89,7 @@ def test_retrieve_with_scores(db_session, enable_factory_create):
     results = retrieve_with_scores(db_session, mock_embedding_model, "Very tiny words.", k=2)
 
     assert len(results) == 2
-    assert results[0][0] == short_chunk
-    assert results[0][1] == -0.7071067690849304
-    assert results[1][0] == medium_chunk
-    assert results[1][1] == -0.25881901383399963
+    assert results[0].chunk == short_chunk
+    assert results[0].score == -0.7071067690849304
+    assert results[1].chunk == medium_chunk
+    assert results[1].score == -0.25881901383399963


### PR DESCRIPTION
## Ticket

Follow-on PR to address https://github.com/navapbc/labs-decision-support-tool/pull/30#discussion_r1685514610

## Changes

Refactor code to use generalized `ChunkWithScore` class to minimize exposure of `sqlalchemy` into other code unnecessarily and reduce coupling of that code to a DB.

## Testing

No code behavior change.