### PR TITLE
refactor: Move db_session and embedding_model args into AppConfig

### DIFF
--- a/app/gunicorn.conf.py
+++ b/app/gunicorn.conf.py
@@ -8,9 +8,9 @@ Attributes:
 For more information, see https://docs.gunicorn.org/en/stable/configure.html
 """
 
-from src import shared
+from src.app_config import get_app_config
 
-app_config = shared.get_app_config()
+app_config = get_app_config()
 
 # Since the `-b 0.0.0.0:8000` argument is used when running in the Docker environment,
 # this bind variable is only used when not using Docker

--- a/app/gunicorn.conf.py
+++ b/app/gunicorn.conf.py
@@ -8,9 +8,7 @@ Attributes:
 For more information, see https://docs.gunicorn.org/en/stable/configure.html
 """
 
-from src.app_config import get_app_config
-
-app_config = get_app_config()
+from src.app_config import app_config
 
 # Since the `-b 0.0.0.0:8000` argument is used when running in the Docker environment,
 # this bind variable is only used when not using Docker

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -1,3 +1,7 @@
+from functools import cached_property
+
+from sentence_transformers import SentenceTransformer
+
 import src.adapters.db as db
 from src.util.env_config import PydanticBaseEnvConfig
 
@@ -22,4 +26,10 @@ class AppConfig(PydanticBaseEnvConfig):
     chat_engine: str = "guru-snap"
 
     def db_session(self) -> db.Session:
+        print("\n=====\n========= REAL AppConfig.db_session")
         return db.PostgresDBClient().get_session()
+
+    @cached_property
+    def sentence_transformer(self) -> SentenceTransformer:
+        print("\n=====\n========= REAL AppConfig.sentence_transformer")
+        return SentenceTransformer(self.embedding_model)

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -1,3 +1,4 @@
+import src.adapters.db as db
 from src.util.env_config import PydanticBaseEnvConfig
 
 
@@ -19,3 +20,6 @@ class AppConfig(PydanticBaseEnvConfig):
     host: str = "127.0.0.1"
     port: int = 8080
     chat_engine: str = "guru-snap"
+
+    def db_session(self) -> db.Session:
+        return db.PostgresDBClient().get_session()

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -25,11 +25,15 @@ class AppConfig(PydanticBaseEnvConfig):
     port: int = 8080
     chat_engine: str = "guru-snap"
 
+    print("\n=====\n========= Creating REAL AppConfig")
+
     def db_session(self) -> db.Session:
         print("\n=====\n========= REAL AppConfig.db_session")
+        input("UNEXPECTED Press Enter app_config...")
         return db.PostgresDBClient().get_session()
 
     @cached_property
     def sentence_transformer(self) -> SentenceTransformer:
         print("\n=====\n========= REAL AppConfig.sentence_transformer")
+        input("UNEXPECTED Press Enter app_config...")
         return SentenceTransformer(self.embedding_model)

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -25,15 +25,9 @@ class AppConfig(PydanticBaseEnvConfig):
     port: int = 8080
     chat_engine: str = "guru-snap"
 
-    print("\n=====\n========= Creating REAL AppConfig")
-
     def db_session(self) -> db.Session:
-        print("\n=====\n========= REAL AppConfig.db_session")
-        input("UNEXPECTED Press Enter app_config...")
         return db.PostgresDBClient().get_session()
 
     @cached_property
     def sentence_transformer(self) -> SentenceTransformer:
-        print("\n=====\n========= REAL AppConfig.sentence_transformer")
-        input("UNEXPECTED Press Enter app_config...")
         return SentenceTransformer(self.embedding_model)

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -1,4 +1,4 @@
-from functools import cache, cached_property
+from functools import cached_property
 
 from sentence_transformers import SentenceTransformer
 
@@ -7,7 +7,7 @@ from src.util.env_config import PydanticBaseEnvConfig
 
 
 class AppConfig(PydanticBaseEnvConfig):
-    # Do not instantiate this class directly. Use get_app_config() instead.
+    # Do not instantiate this class directly. Use app_config instead.
     # These are default configuration values for the app, and
     # are shared across both local and deployed environments.
 
@@ -34,6 +34,4 @@ class AppConfig(PydanticBaseEnvConfig):
         return SentenceTransformer(self.embedding_model)
 
 
-@cache
-def get_app_config() -> AppConfig:
-    return AppConfig()
+app_config = AppConfig()

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -1,4 +1,4 @@
-from functools import cached_property
+from functools import cache, cached_property
 
 from sentence_transformers import SentenceTransformer
 
@@ -7,6 +7,7 @@ from src.util.env_config import PydanticBaseEnvConfig
 
 
 class AppConfig(PydanticBaseEnvConfig):
+    # Do not instantiate this class directly. Use get_app_config() instead.
     # These are default configuration values for the app, and
     # are shared across both local and deployed environments.
 
@@ -31,3 +32,8 @@ class AppConfig(PydanticBaseEnvConfig):
     @cached_property
     def sentence_transformer(self) -> SentenceTransformer:
         return SentenceTransformer(self.embedding_model)
+
+
+@cache
+def get_app_config() -> AppConfig:
+    return AppConfig()

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs, urlparse
 
 import chainlit as cl
 from src import chat_engine
-from src.app_config import get_app_config
+from src.app_config import app_config
 from src.format import format_guru_cards
 from src.login import require_login
 
@@ -40,7 +40,7 @@ def engine_url_query_value() -> str:
     # Using this suggestion: https://github.com/Chainlit/chainlit/issues/144#issuecomment-2227543547
     parsed_url = urlparse(url)
     qs = parse_qs(parsed_url.query)
-    return qs.get("engine", [get_app_config().chat_engine])[0]
+    return qs.get("engine", [app_config.chat_engine])[0]
 
 
 @cl.on_message

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -2,7 +2,8 @@ import logging
 from urllib.parse import parse_qs, urlparse
 
 import chainlit as cl
-from src import chat_engine, shared
+from src import chat_engine
+from src.app_config import get_app_config
 from src.format import format_guru_cards
 from src.login import require_login
 
@@ -39,7 +40,7 @@ def engine_url_query_value() -> str:
     # Using this suggestion: https://github.com/Chainlit/chainlit/issues/144#issuecomment-2227543547
     parsed_url = urlparse(url)
     qs = parse_qs(parsed_url.query)
-    return qs.get("engine", [shared.get_app_config().chat_engine])[0]
+    return qs.get("engine", [get_app_config().chat_engine])[0]
 
 
 @cl.on_message

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -6,7 +6,6 @@ from typing import Sequence
 from src.db.models.document import ChunkWithScore
 from src.generate import generate
 from src.retrieve import retrieve_with_scores
-from src.shared import get_embedding_model
 from src.util.class_utils import all_subclasses
 
 logger = logging.getLogger(__name__)
@@ -53,7 +52,6 @@ class GuruBaseEngine(ChatEngineInterface):
 
     def on_message(self, question: str) -> OnMessageResult:
         chunks_with_scores = retrieve_with_scores(
-            get_embedding_model(),
             question,
             datasets=self.datasets,
         )

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Sequence
 
-from src import shared
 from src.db.models.document import ChunkWithScore
 from src.generate import generate
 from src.retrieve import retrieve_with_scores

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Sequence
 
-import src.adapters.db as db
+from src import shared
 from src.db.models.document import ChunkWithScore
 from src.generate import generate
 from src.retrieve import retrieve_with_scores
@@ -53,13 +53,11 @@ class GuruBaseEngine(ChatEngineInterface):
     datasets: list[str] = []
 
     def on_message(self, question: str) -> OnMessageResult:
-        with db.PostgresDBClient().get_session() as db_session:
-            chunks_with_scores = retrieve_with_scores(
-                db_session,
-                get_embedding_model(),
-                question,
-                datasets=self.datasets,
-            )
+        chunks_with_scores = retrieve_with_scores(
+            get_embedding_model(),
+            question,
+            datasets=self.datasets,
+        )
 
         response = generate(question, context=chunks_with_scores)
         return OnMessageResult(response, chunks_with_scores)

--- a/app/src/ingest_guru_cards.py
+++ b/app/src/ingest_guru_cards.py
@@ -5,8 +5,8 @@ import sys
 from smart_open import open
 
 import src.adapters.db as db
+from src.app_config import get_app_config
 from src.db.models.document import Chunk, Document
-from src.shared import get_app_config
 from src.util.html import get_text_from_html
 
 logger = logging.getLogger(__name__)

--- a/app/src/ingest_guru_cards.py
+++ b/app/src/ingest_guru_cards.py
@@ -5,7 +5,7 @@ import sys
 from smart_open import open
 
 import src.adapters.db as db
-from src import shared
+from src.shared import get_app_config
 from src.db.models.document import Chunk, Document
 from src.util.html import get_text_from_html
 
@@ -38,7 +38,7 @@ def _ingest_cards(
         document = Document(name=name, content=content, **doc_attribs)
         db_session.add(document)
 
-        embedding_model = shared.get_app_config().sentence_transformer
+        embedding_model = get_app_config().sentence_transformer
         tokens = len(embedding_model.tokenizer.tokenize(content))
         mpnet_embedding = embedding_model.encode(content, show_progress_bar=False)
         chunk = Chunk(

--- a/app/src/ingest_guru_cards.py
+++ b/app/src/ingest_guru_cards.py
@@ -5,8 +5,8 @@ import sys
 from smart_open import open
 
 import src.adapters.db as db
+from src import shared
 from src.db.models.document import Chunk, Document
-from src.shared import get_app_config
 from src.util.html import get_text_from_html
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ def _ingest_cards(
         document = Document(name=name, content=content, **doc_attribs)
         db_session.add(document)
 
-        embedding_model = get_app_config().sentence_transformer
+        embedding_model = shared.get_app_config().sentence_transformer
         tokens = len(embedding_model.tokenizer.tokenize(content))
         mpnet_embedding = embedding_model.encode(content, show_progress_bar=False)
         chunk = Chunk(

--- a/app/src/ingest_guru_cards.py
+++ b/app/src/ingest_guru_cards.py
@@ -5,7 +5,7 @@ import sys
 from smart_open import open
 
 import src.adapters.db as db
-from src.app_config import get_app_config
+from src.app_config import app_config
 from src.db.models.document import Chunk, Document
 from src.util.html import get_text_from_html
 
@@ -38,7 +38,7 @@ def _ingest_cards(
         document = Document(name=name, content=content, **doc_attribs)
         db_session.add(document)
 
-        embedding_model = get_app_config().sentence_transformer
+        embedding_model = app_config.sentence_transformer
         tokens = len(embedding_model.tokenizer.tokenize(content))
         mpnet_embedding = embedding_model.encode(content, show_progress_bar=False)
         chunk = Chunk(
@@ -75,7 +75,7 @@ def main() -> None:
         "program": benefit_program,
         "region": benefit_region,
     }
-    with get_app_config().db_session() as db_session:
+    with app_config.db_session() as db_session:
         _ingest_cards(db_session, guru_cards_filepath, doc_attribs)
         db_session.commit()
 

--- a/app/src/ingest_guru_cards.py
+++ b/app/src/ingest_guru_cards.py
@@ -5,8 +5,8 @@ import sys
 from smart_open import open
 
 import src.adapters.db as db
-from src.shared import get_app_config
 from src.db.models.document import Chunk, Document
+from src.shared import get_app_config
 from src.util.html import get_text_from_html
 
 logger = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ def main() -> None:
         "program": benefit_program,
         "region": benefit_region,
     }
-    with db.PostgresDBClient().get_session() as db_session:
+    with get_app_config().db_session() as db_session:
         _ingest_cards(db_session, guru_cards_filepath, doc_attribs)
         db_session.commit()
 

--- a/app/src/login.py
+++ b/app/src/login.py
@@ -1,5 +1,5 @@
 import chainlit as cl
-from src.shared import get_app_config
+from src.app_config import get_app_config
 
 
 def login_callback(username: str, password: str) -> cl.User | None:

--- a/app/src/login.py
+++ b/app/src/login.py
@@ -1,9 +1,9 @@
 import chainlit as cl
-from src.shared import get_app_config
+from src import shared
 
 
 def login_callback(username: str, password: str) -> cl.User | None:
-    if password == get_app_config().global_password:
+    if password == shared.get_app_config().global_password:
         return cl.User(identifier=username)
     else:
         return None
@@ -14,5 +14,5 @@ def require_login() -> None:
     # requires CHAINLIT_AUTH_SECRET to be set (to sign the
     # authorization tokens.)
 
-    if get_app_config().global_password:
+    if shared.get_app_config().global_password:
         cl.password_auth_callback(login_callback)

--- a/app/src/login.py
+++ b/app/src/login.py
@@ -1,9 +1,9 @@
 import chainlit as cl
-from src import shared
+from src.shared import get_app_config
 
 
 def login_callback(username: str, password: str) -> cl.User | None:
-    if password == shared.get_app_config().global_password:
+    if password == get_app_config().global_password:
         return cl.User(identifier=username)
     else:
         return None
@@ -14,5 +14,5 @@ def require_login() -> None:
     # requires CHAINLIT_AUTH_SECRET to be set (to sign the
     # authorization tokens.)
 
-    if shared.get_app_config().global_password:
+    if get_app_config().global_password:
         cl.password_auth_callback(login_callback)

--- a/app/src/login.py
+++ b/app/src/login.py
@@ -1,18 +1,17 @@
 import chainlit as cl
-from src.app_config import get_app_config
+from src.app_config import app_config
 
 
 def login_callback(username: str, password: str) -> cl.User | None:
-    if password == get_app_config().global_password:
+    if password == app_config.global_password:
         return cl.User(identifier=username)
     else:
         return None
 
 
 def require_login() -> None:
-    # In addition to setting GLOBAL_PASSWORD, Chainlit also
-    # requires CHAINLIT_AUTH_SECRET to be set (to sign the
-    # authorization tokens.)
+    # Set GLOBAL_PASSWORD, and also set CHAINLIT_AUTH_SECRET for
+    # Chainlit to sign the authorization tokens.
 
-    if get_app_config().global_password:
+    if app_config.global_password:
         cl.password_auth_callback(login_callback)

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -3,8 +3,8 @@ from typing import Sequence
 
 from sqlalchemy import select
 
+from src.app_config import get_app_config
 from src.db.models.document import Chunk, ChunkWithScore, Document
-from src.shared import get_app_config
 
 logger = logging.getLogger(__name__)
 

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -3,8 +3,8 @@ from typing import Sequence
 
 from sqlalchemy import select
 
+from src import shared
 from src.db.models.document import Chunk, ChunkWithScore, Document
-from src.shared import get_app_config
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def retrieve_with_scores(
 ) -> Sequence[ChunkWithScore]:
     logger.info("Retrieving context for %r", query)
 
-    embedding_model = get_app_config().sentence_transformer
+    embedding_model = shared.get_app_config().sentence_transformer
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
 
     statement = select(Chunk, Chunk.mpnet_embedding.max_inner_product(query_embedding)).join(
@@ -32,7 +32,7 @@ def retrieve_with_scores(
     if filters:
         raise ValueError(f"Unknown filters: {filters.keys()}")
 
-    with get_app_config().db_session() as db_session:
+    with shared.get_app_config().db_session() as db_session:
         chunks_with_scores = db_session.execute(
             statement.order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding)).limit(k)
         ).all()

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -4,7 +4,6 @@ from typing import Sequence
 from sentence_transformers import SentenceTransformer
 from sqlalchemy import select
 
-import src.adapters.db as db
 from src import shared
 from src.db.models.document import Chunk, ChunkWithScore, Document
 

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 from sqlalchemy import select
 
-from src.app_config import get_app_config
+from src.app_config import app_config
 from src.db.models.document import Chunk, ChunkWithScore, Document
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ def retrieve_with_scores(
 ) -> Sequence[ChunkWithScore]:
     logger.info("Retrieving context for %r", query)
 
-    embedding_model = get_app_config().sentence_transformer
+    embedding_model = app_config.sentence_transformer
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
 
     statement = select(Chunk, Chunk.mpnet_embedding.max_inner_product(query_embedding)).join(
@@ -32,7 +32,7 @@ def retrieve_with_scores(
     if filters:
         raise ValueError(f"Unknown filters: {filters.keys()}")
 
-    with get_app_config().db_session() as db_session:
+    with app_config.db_session() as db_session:
         chunks_with_scores = db_session.execute(
             statement.order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding)).limit(k)
         ).all()

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -3,8 +3,8 @@ from typing import Sequence
 
 from sqlalchemy import select
 
-from src import shared
 from src.db.models.document import Chunk, ChunkWithScore, Document
+from src.shared import get_app_config
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def retrieve_with_scores(
 ) -> Sequence[ChunkWithScore]:
     logger.info("Retrieving context for %r", query)
 
-    embedding_model = shared.get_app_config().sentence_transformer
+    embedding_model = get_app_config().sentence_transformer
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
 
     statement = select(Chunk, Chunk.mpnet_embedding.max_inner_product(query_embedding)).join(
@@ -32,7 +32,7 @@ def retrieve_with_scores(
     if filters:
         raise ValueError(f"Unknown filters: {filters.keys()}")
 
-    with shared.get_app_config().db_session() as db_session:
+    with get_app_config().db_session() as db_session:
         chunks_with_scores = db_session.execute(
             statement.order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding)).limit(k)
         ).all()

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -1,23 +1,22 @@
 import logging
 from typing import Sequence
 
-from sentence_transformers import SentenceTransformer
 from sqlalchemy import select
 
-from src import shared
 from src.db.models.document import Chunk, ChunkWithScore, Document
+from src.shared import get_app_config
 
 logger = logging.getLogger(__name__)
 
 
 def retrieve_with_scores(
-    embedding_model: SentenceTransformer,
     query: str,
     k: int = 5,
     **filters: Sequence[str] | None,
 ) -> Sequence[ChunkWithScore]:
     logger.info("Retrieving context for %r", query)
 
+    embedding_model = get_app_config().sentence_transformer
     query_embedding = embedding_model.encode(query, show_progress_bar=False)
 
     statement = select(Chunk, Chunk.mpnet_embedding.max_inner_product(query_embedding)).join(
@@ -33,7 +32,7 @@ def retrieve_with_scores(
     if filters:
         raise ValueError(f"Unknown filters: {filters.keys()}")
 
-    with shared.get_app_config().db_session() as db_session:
+    with get_app_config().db_session() as db_session:
         chunks_with_scores = db_session.execute(
             statement.order_by(Chunk.mpnet_embedding.max_inner_product(query_embedding)).limit(k)
         ).all()

--- a/app/src/shared.py
+++ b/app/src/shared.py
@@ -1,8 +1,0 @@
-from functools import cache
-
-from src.app_config import AppConfig
-
-
-@cache
-def get_app_config() -> AppConfig:
-    return AppConfig()

--- a/app/src/shared.py
+++ b/app/src/shared.py
@@ -1,15 +1,8 @@
 from functools import cache
 
-from sentence_transformers import SentenceTransformer
-
 from src.app_config import AppConfig
 
 
 @cache
 def get_app_config() -> AppConfig:
     return AppConfig()
-
-
-@cache
-def get_embedding_model() -> SentenceTransformer:
-    return SentenceTransformer(get_app_config().embedding_model)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 import src.adapters.db as db
 import tests.src.db.models.factories as factories
-from src import shared
+
 from src.db import models
 from src.util.local import load_local_env_vars
 from tests.lib import db_testing
@@ -120,9 +120,12 @@ def app_config(monkeypatch, db_session):
             return MockSentenceTransformer()
 
     mock_app_config = MockAppConfig()
-    print("\n=====\n=========mock_app_config", monkeypatch)
+    print("\n=====\n=========mock_app_config", monkeypatch, mock_app_config.db_session())
     # input("Press Enter app_config...")
-    monkeypatch.setattr(shared, "get_app_config", lambda: mock_app_config)
+    # monkeypatch.setattr(shared, "get_app_config", lambda: mock_app_config)
+    # monkeypatch.setattr("src.shared.get_app_config", lambda: mock_app_config)
+    monkeypatch.setattr("src.app_config.AppConfig.db_session", mock_app_config.db_session)
+    monkeypatch.setattr("src.app_config.AppConfig.sentence_transformer", mock_app_config.sentence_transformer)
     return mock_app_config
 
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+from functools import cached_property
 
 import _pytest.monkeypatch
 import boto3
@@ -110,16 +111,17 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
 def app_config(monkeypatch, db_session):
     class MockAppConfig:
         def db_session(self):
-            print("==============MockAppConfig.db_session")
+            print("\n=====\n=========MockAppConfig.db_session")
             return db_session
 
-        def create_embedding_model(self):
-            print("==============MockAppConfig.create_embedding_model")
+        @cached_property
+        def sentence_transformer(self):
+            print("\n=====\n=========MockAppConfig.sentence_transformer")
             return MockSentenceTransformer()
 
-    app_config = MockAppConfig()
-    monkeypatch.setattr(shared, "get_app_config", lambda: app_config)
-    return app_config
+    mock_app_config = MockAppConfig()
+    monkeypatch.setattr(shared, "get_app_config", lambda: mock_app_config)
+    return mock_app_config
 
 
 ####################

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -6,12 +6,12 @@ import moto
 import pytest
 
 import src.adapters.db as db
-from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 import tests.src.db.models.factories as factories
 from src import shared
 from src.db import models
 from src.util.local import load_local_env_vars
 from tests.lib import db_testing
+from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 
 logger = logging.getLogger(__name__)
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 import src.adapters.db as db
 import tests.src.db.models.factories as factories
-
+from src.app_config import AppConfig
 from src.db import models
 from src.util.local import load_local_env_vars
 from tests.lib import db_testing
@@ -111,21 +111,15 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
 def app_config(monkeypatch, db_session):
     class MockAppConfig:
         def db_session(self):
-            print("\n=====\n=========MockAppConfig.db_session")
             return db_session
 
         @cached_property
         def sentence_transformer(self):
-            print("\n=====\n=========MockAppConfig.sentence_transformer")
             return MockSentenceTransformer()
 
     mock_app_config = MockAppConfig()
-    print("\n=====\n=========mock_app_config", monkeypatch, mock_app_config.db_session())
-    # input("Press Enter app_config...")
-    # monkeypatch.setattr(shared, "get_app_config", lambda: mock_app_config)
-    # monkeypatch.setattr("src.shared.get_app_config", lambda: mock_app_config)
-    monkeypatch.setattr("src.app_config.AppConfig.db_session", mock_app_config.db_session)
-    monkeypatch.setattr("src.app_config.AppConfig.sentence_transformer", mock_app_config.sentence_transformer)
+    monkeypatch.setattr(AppConfig, "db_session", mock_app_config.db_session)
+    monkeypatch.setattr(AppConfig, "sentence_transformer", mock_app_config.sentence_transformer)
     return mock_app_config
 
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -120,6 +120,8 @@ def app_config(monkeypatch, db_session):
             return MockSentenceTransformer()
 
     mock_app_config = MockAppConfig()
+    print("\n=====\n=========mock_app_config", monkeypatch)
+    # input("Press Enter app_config...")
     monkeypatch.setattr(shared, "get_app_config", lambda: mock_app_config)
     return mock_app_config
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -6,7 +6,9 @@ import moto
 import pytest
 
 import src.adapters.db as db
+from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 import tests.src.db.models.factories as factories
+from src import shared
 from src.db import models
 from src.util.local import load_local_env_vars
 from tests.lib import db_testing
@@ -102,6 +104,22 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
     """
     monkeypatch.setattr(factories, "_db_session", db_session)
     return db_session
+
+
+@pytest.fixture
+def app_config(monkeypatch, db_session):
+    class MockAppConfig:
+        def db_session(self):
+            print("==============MockAppConfig.db_session")
+            return db_session
+
+        def create_embedding_model(self):
+            print("==============MockAppConfig.create_embedding_model")
+            return MockSentenceTransformer()
+
+    app_config = MockAppConfig()
+    monkeypatch.setattr(shared, "get_app_config", lambda: app_config)
+    return app_config
 
 
 ####################

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -11,16 +11,7 @@ def _get_chunks_with_scores():
     return retrieve_with_scores("Very tiny words.", k=2)
 
 
-# def mock_app_config(db_session):
-#     class MockAppConfig:
-#         def db_session(self):
-#             print("==============MockAppConfig.db_session")
-#             return db_session
-#     return lambda: MockAppConfig()
-
-
 def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enable_factory_create):
-    print("\n=====\n=========test_format_guru_cards_with_score", monkeypatch, app_config.db_session())
     db_session.execute(delete(Document))
 
     chunks_with_scores = _get_chunks_with_scores()

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -1,5 +1,6 @@
 from sqlalchemy import delete
 
+from src import shared
 from src.db.models.document import Document
 from src.format import format_guru_cards
 from src.retrieve import retrieve_with_scores
@@ -7,16 +8,24 @@ from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 from tests.src.test_retrieve import _create_chunks
 
 
-def _get_chunks_with_scores(db_session):
-    db_session.execute(delete(Document))
-    mock_embedding_model = MockSentenceTransformer()
+def _get_chunks_with_scores():
+    mock_embedding_model = MockSentenceTransformer() # TODO: remove
     _create_chunks()
-    return retrieve_with_scores(db_session, mock_embedding_model, "Very tiny words.", k=2)
+    return retrieve_with_scores(mock_embedding_model, "Very tiny words.", k=2)
 
 
-def test_format_guru_cards_with_score(db_session, enable_factory_create):
+# def mock_app_config(db_session):
+#     class MockAppConfig:
+#         def db_session(self):
+#             print("==============MockAppConfig.db_session")
+#             return db_session
+#     return lambda: MockAppConfig()
+
+
+def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
-    chunks_with_scores = _get_chunks_with_scores(db_session)
+    # monkeypatch.setattr(shared, "get_app_config", mock_app_config(db_session)) # TODO: get app_config from conftest.py and/or set db_session in shared.app_config
+    chunks_with_scores = _get_chunks_with_scores()
     html = format_guru_cards(chunks_with_scores)
     assert "accordion-1" in html
     assert "Related Guru cards" in html

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -1,6 +1,5 @@
 from sqlalchemy import delete
 
-from src import shared
 from src.db.models.document import Document
 from src.format import format_guru_cards
 from src.retrieve import retrieve_with_scores
@@ -9,7 +8,7 @@ from tests.src.test_retrieve import _create_chunks
 
 
 def _get_chunks_with_scores():
-    mock_embedding_model = MockSentenceTransformer() # TODO: remove
+    mock_embedding_model = MockSentenceTransformer()  # TODO: remove
     _create_chunks()
     return retrieve_with_scores(mock_embedding_model, "Very tiny words.", k=2)
 

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -20,6 +20,7 @@ def _get_chunks_with_scores():
 
 
 def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enable_factory_create):
+    print("\n=====\n=========test_format_guru_cards_with_score", monkeypatch)
     db_session.execute(delete(Document))
     # monkeypatch.setattr(shared, "get_app_config", mock_app_config(db_session)) # TODO: get app_config from conftest.py and/or set db_session in shared.app_config
     chunks_with_scores = _get_chunks_with_scores()

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -20,9 +20,9 @@ def _get_chunks_with_scores():
 
 
 def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enable_factory_create):
-    print("\n=====\n=========test_format_guru_cards_with_score", monkeypatch)
+    print("\n=====\n=========test_format_guru_cards_with_score", monkeypatch, app_config.db_session())
     db_session.execute(delete(Document))
-    # monkeypatch.setattr(shared, "get_app_config", mock_app_config(db_session)) # TODO: get app_config from conftest.py and/or set db_session in shared.app_config
+
     chunks_with_scores = _get_chunks_with_scores()
     html = format_guru_cards(chunks_with_scores)
     assert "accordion-1" in html

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -3,14 +3,12 @@ from sqlalchemy import delete
 from src.db.models.document import Document
 from src.format import format_guru_cards
 from src.retrieve import retrieve_with_scores
-from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 from tests.src.test_retrieve import _create_chunks
 
 
 def _get_chunks_with_scores():
-    mock_embedding_model = MockSentenceTransformer()  # TODO: remove
     _create_chunks()
-    return retrieve_with_scores(mock_embedding_model, "Very tiny words.", k=2)
+    return retrieve_with_scores("Very tiny words.", k=2)
 
 
 # def mock_app_config(db_session):

--- a/app/tests/src/test_login.py
+++ b/app/tests/src/test_login.py
@@ -1,34 +1,24 @@
-import os
-
 import chainlit.config
-from src.app_config import get_app_config
+from src.app_config import app_config
 from src.login import login_callback, require_login
 
 
 def test_require_login_no_password(monkeypatch):
-    if "GLOBAL_PASSWORD" in os.environ:
-        monkeypatch.delenv("GLOBAL_PASSWORD")
-
-    # Rebuild AppConfig with new environment variables
-    get_app_config.cache_clear()
-
+    app_config.global_password = None
     require_login()
 
     assert not chainlit.config.code.password_auth_callback
 
 
 def test_require_login_with_password(monkeypatch):
-    monkeypatch.setenv("GLOBAL_PASSWORD", "password")
-    get_app_config.cache_clear()
-
+    app_config.global_password = "password"
     require_login()
 
     assert chainlit.config.code.password_auth_callback
 
 
 def test_login_callback(monkeypatch):
-    monkeypatch.setenv("GLOBAL_PASSWORD", "correct pass")
-    get_app_config.cache_clear()
+    app_config.global_password = "correct pass"
 
     assert login_callback("some user", "wrong pass") is None
     assert login_callback("some user", "correct pass").identifier == "some user"

--- a/app/tests/src/test_login.py
+++ b/app/tests/src/test_login.py
@@ -1,7 +1,7 @@
 import os
 
 import chainlit.config
-import src.shared
+from src.app_config import get_app_config
 from src.login import login_callback, require_login
 
 
@@ -10,7 +10,7 @@ def test_require_login_no_password(monkeypatch):
         monkeypatch.delenv("GLOBAL_PASSWORD")
 
     # Rebuild AppConfig with new environment variables
-    src.shared.get_app_config.cache_clear()
+    get_app_config.cache_clear()
 
     require_login()
 
@@ -19,7 +19,7 @@ def test_require_login_no_password(monkeypatch):
 
 def test_require_login_with_password(monkeypatch):
     monkeypatch.setenv("GLOBAL_PASSWORD", "password")
-    src.shared.get_app_config.cache_clear()
+    get_app_config.cache_clear()
 
     require_login()
 
@@ -28,7 +28,7 @@ def test_require_login_with_password(monkeypatch):
 
 def test_login_callback(monkeypatch):
     monkeypatch.setenv("GLOBAL_PASSWORD", "correct pass")
-    src.shared.get_app_config.cache_clear()
+    get_app_config.cache_clear()
 
     assert login_callback("some user", "wrong pass") is None
     assert login_callback("some user", "correct pass").identifier == "some user"

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -33,9 +33,7 @@ def test_retrieve__with_empty_filter(app_config, db_session, enable_factory_crea
     db_session.execute(delete(Document))
     _, medium_chunk, short_chunk = _create_chunks()
 
-    results = retrieve_with_scores(
-        mock_embedding_model, "Very tiny words.", k=2, datasets=[]
-    )
+    results = retrieve_with_scores(mock_embedding_model, "Very tiny words.", k=2, datasets=[])
 
     assert _format_retrieval_results(results) == [short_chunk, medium_chunk]
 

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -3,10 +3,7 @@ from sqlalchemy import delete
 
 from src.db.models.document import Document
 from src.retrieve import retrieve_with_scores
-from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 from tests.src.db.models.factories import ChunkFactory, DocumentFactory
-
-mock_embedding_model = MockSentenceTransformer()
 
 
 def _create_chunks(document=None):
@@ -33,16 +30,14 @@ def test_retrieve__with_empty_filter(app_config, db_session, enable_factory_crea
     db_session.execute(delete(Document))
     _, medium_chunk, short_chunk = _create_chunks()
 
-    results = retrieve_with_scores(mock_embedding_model, "Very tiny words.", k=2, datasets=[])
+    results = retrieve_with_scores("Very tiny words.", k=2, datasets=[])
 
     assert _format_retrieval_results(results) == [short_chunk, medium_chunk]
 
 
 def test_retrieve__with_unknown_filter(app_config, db_session, enable_factory_create):
     with pytest.raises(ValueError):
-        retrieve_with_scores(
-            mock_embedding_model, "Very tiny words.", k=2, unknown_column=["some value"]
-        )
+        retrieve_with_scores("Very tiny words.", k=2, unknown_column=["some value"])
 
 
 def test_retrieve__with_dataset_filter(app_config, db_session, enable_factory_create):
@@ -53,7 +48,6 @@ def test_retrieve__with_dataset_filter(app_config, db_session, enable_factory_cr
     )
 
     results = retrieve_with_scores(
-        mock_embedding_model,
         "Very tiny words.",
         k=2,
         datasets=["SNAP"],
@@ -69,7 +63,6 @@ def test_retrieve__with_other_filters(app_config, db_session, enable_factory_cre
     )
 
     results = retrieve_with_scores(
-        mock_embedding_model,
         "Very tiny words.",
         k=2,
         programs=["SNAP"],
@@ -82,7 +75,7 @@ def test_retrieve_with_scores(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
     _, medium_chunk, short_chunk = _create_chunks()
 
-    results = retrieve_with_scores(mock_embedding_model, "Very tiny words.", k=2)
+    results = retrieve_with_scores("Very tiny words.", k=2)
 
     assert len(results) == 2
     assert results[0].chunk == short_chunk

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -29,25 +29,25 @@ def _format_retrieval_results(retrieval_results):
     return [chunk_with_score.chunk for chunk_with_score in retrieval_results]
 
 
-def test_retrieve__with_empty_filter(db_session, enable_factory_create):
+def test_retrieve__with_empty_filter(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
     _, medium_chunk, short_chunk = _create_chunks()
 
     results = retrieve_with_scores(
-        db_session, mock_embedding_model, "Very tiny words.", k=2, datasets=[]
+        mock_embedding_model, "Very tiny words.", k=2, datasets=[]
     )
 
     assert _format_retrieval_results(results) == [short_chunk, medium_chunk]
 
 
-def test_retrieve__with_unknown_filter(db_session, enable_factory_create):
+def test_retrieve__with_unknown_filter(app_config, db_session, enable_factory_create):
     with pytest.raises(ValueError):
         retrieve_with_scores(
-            db_session, mock_embedding_model, "Very tiny words.", k=2, unknown_column=["some value"]
+            mock_embedding_model, "Very tiny words.", k=2, unknown_column=["some value"]
         )
 
 
-def test_retrieve__with_dataset_filter(db_session, enable_factory_create):
+def test_retrieve__with_dataset_filter(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
     _create_chunks(document=DocumentFactory.create())
     _, snap_medium_chunk, snap_short_chunk = _create_chunks(
@@ -55,7 +55,6 @@ def test_retrieve__with_dataset_filter(db_session, enable_factory_create):
     )
 
     results = retrieve_with_scores(
-        db_session,
         mock_embedding_model,
         "Very tiny words.",
         k=2,
@@ -64,7 +63,7 @@ def test_retrieve__with_dataset_filter(db_session, enable_factory_create):
     assert _format_retrieval_results(results) == [snap_short_chunk, snap_medium_chunk]
 
 
-def test_retrieve__with_other_filters(db_session, enable_factory_create):
+def test_retrieve__with_other_filters(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
     _create_chunks(document=DocumentFactory.create(program="Medicaid", region="PA"))
     _, snap_medium_chunk, snap_short_chunk = _create_chunks(
@@ -72,7 +71,6 @@ def test_retrieve__with_other_filters(db_session, enable_factory_create):
     )
 
     results = retrieve_with_scores(
-        db_session,
         mock_embedding_model,
         "Very tiny words.",
         k=2,
@@ -82,11 +80,11 @@ def test_retrieve__with_other_filters(db_session, enable_factory_create):
     assert _format_retrieval_results(results) == [snap_short_chunk, snap_medium_chunk]
 
 
-def test_retrieve_with_scores(db_session, enable_factory_create):
+def test_retrieve_with_scores(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
     _, medium_chunk, short_chunk = _create_chunks()
 
-    results = retrieve_with_scores(db_session, mock_embedding_model, "Very tiny words.", k=2)
+    results = retrieve_with_scores(mock_embedding_model, "Very tiny words.", k=2)
 
     assert len(results) == 2
     assert results[0].chunk == short_chunk


### PR DESCRIPTION
## Ticket

From [Slack](https://nava.slack.com/archives/C06DP498D1D/p1721764756834649):

> - [retrieve_with_scores()](https://github.com/navapbc/labs-decision-support-tool/blob/cb9d663d1f575cc06119f561893eff3ee099288e/app/src/retrieve.py#L15) and [_ingest_cards()](https://github.com/navapbc/labs-decision-support-tool/blob/cb9d663d1f575cc06119f561893eff3ee099288e/app/src/ingest_guru_cards.py#L26) take the 2 arguments `db_session` and `embedding_model`.
> - I see these 2 arguments as "[context](https://www.baeldung.com/cs/context-design-pattern)" or "fixtures", and not really arguments that would change with different calls to these functions.
> - Additionally, any retrieval function should use the same `embedding_model` as the ingest function.
> What do y'all think about wrapping these 2 arguments into a context class or moving them into the `AppConfig` class?

## Changes

Move `db_session` and `embedding_model` args into `AppConfig` to be used as a context object.

## Testing

No changes in software behavior.
