### PR TITLE
refactor: Remove extraneous MockAppConfig and monkeypatch parameter in tests

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,5 +1,4 @@
 import logging
-from functools import cached_property
 
 import _pytest.monkeypatch
 import boto3
@@ -109,18 +108,8 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
 
 @pytest.fixture
 def app_config(monkeypatch, db_session):
-    class MockAppConfig:
-        def db_session(self):
-            return db_session
-
-        @cached_property
-        def sentence_transformer(self):
-            return MockSentenceTransformer()
-
-    mock_app_config = MockAppConfig()
-    monkeypatch.setattr(AppConfig, "db_session", mock_app_config.db_session)
-    monkeypatch.setattr(AppConfig, "sentence_transformer", mock_app_config.sentence_transformer)
-    return mock_app_config
+    monkeypatch.setattr(AppConfig, "db_session", lambda _self: db_session)
+    monkeypatch.setattr(AppConfig, "sentence_transformer", MockSentenceTransformer())
 
 
 ####################

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -11,7 +11,7 @@ def _get_chunks_with_scores():
     return retrieve_with_scores("Very tiny words.", k=2)
 
 
-def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enable_factory_create):
+def test_format_guru_cards_with_score(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
 
     chunks_with_scores = _get_chunks_with_scores()


### PR DESCRIPTION
## Changes

- [removed unnecessary MockAppConfig](https://github.com/navapbc/labs-decision-support-tool/commit/e039d51ccb9685eb9a21d9c1ce29a7dcc39c249a)
- [removed unused monkeypatch parameter](https://github.com/navapbc/labs-decision-support-tool/commit/43ac5f5497d18e4f0ee4112e2da4aa7778046963)

## Testing

No code behavior changes