### PR TITLE
feat: Normalize similarity scores of retrieved Guru cards

### DIFF
--- a/app/local.env
+++ b/app/local.env
@@ -70,4 +70,8 @@ AWS_DEFAULT_REGION=us-east-1
 # DST app configuration
 ###########################
 
-EMBEDDING_MODEL=/app/models/multi-qa-mpnet-base-dot-v1
+# Default chat engine
+# CHAT_ENGINE=guru-snap
+
+# Path to embedding model used for vector database
+EMBEDDING_MODEL=/app/models/multi-qa-mpnet-base-cos-v1

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -1,8 +1,7 @@
 from functools import cached_property
 
-from sentence_transformers import SentenceTransformer
-
 import src.adapters.db as db
+from sentence_transformers import SentenceTransformer
 from src.util.env_config import PydanticBaseEnvConfig
 
 

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -1,7 +1,8 @@
 from functools import cached_property
 
-import src.adapters.db as db
 from sentence_transformers import SentenceTransformer
+
+import src.adapters.db as db
 from src.util.env_config import PydanticBaseEnvConfig
 
 

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -20,7 +20,7 @@ class AppConfig(PydanticBaseEnvConfig):
     # To customize these values in deployed environments, set
     # them in infra/app/app-config/env-config/environment-variables.tf
 
-    embedding_model: str = "multi-qa-mpnet-base-dot-v1"
+    embedding_model: str = "multi-qa-mpnet-base-cos-v1"
     global_password: str | None = None
     host: str = "127.0.0.1"
     port: int = 8080

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -2,6 +2,7 @@ import logging
 from typing import Sequence
 
 from sqlalchemy import select
+from sentence_transformers import util
 
 from src.app_config import app_config
 from src.db.models.document import Chunk, ChunkWithScore, Document
@@ -38,6 +39,7 @@ def retrieve_with_scores(
         ).all()
 
         for chunk, score in chunks_with_scores:
-            logger.info(f"Retrieved: {chunk.document.name!r} with score {score}")
+            dot_score = util.dot_score(chunk.mpnet_embedding, query_embedding).item()
+            logger.info(f"Retrieved: {chunk.document.name!r} with score {-score}, dot score: {dot_score}")
 
-        return [ChunkWithScore(chunk, score) for chunk, score in chunks_with_scores]
+        return [ChunkWithScore(chunk, -score) for chunk, score in chunks_with_scores]

--- a/app/src/retrieve.py
+++ b/app/src/retrieve.py
@@ -2,7 +2,6 @@ import logging
 from typing import Sequence
 
 from sqlalchemy import select
-from sentence_transformers import util
 
 from src.app_config import app_config
 from src.db.models.document import Chunk, ChunkWithScore, Document
@@ -39,7 +38,9 @@ def retrieve_with_scores(
         ).all()
 
         for chunk, score in chunks_with_scores:
-            dot_score = util.dot_score(chunk.mpnet_embedding, query_embedding).item()
-            logger.info(f"Retrieved: {chunk.document.name!r} with score {-score}, dot score: {dot_score}")
+            # Confirmed that the `max_inner_product` method returns the same score as using sentence_transformers.util.dot_score
+            # used in code at https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1
+            logger.info(f"Retrieved: {chunk.document.name!r} with score {-score}")
 
+        # Scores from the DB query are negated, presumably to reverse the default sort order
         return [ChunkWithScore(chunk, -score) for chunk, score in chunks_with_scores]

--- a/app/src/util/embedding_models.py
+++ b/app/src/util/embedding_models.py
@@ -1,0 +1,33 @@
+from sentence_transformers import SentenceTransformer, util
+
+
+def test_sentence_transformer(embedding_model: str) -> None:
+    """
+    Exercises specified embedding model and calculates scores from the embedding vectors.
+    The embedding models will be downloaded automatically to ~/.cache/huggingface/hub, if it does not already exist.
+    Used the scores to confirm/compare against those of pgvector's max_inner_product.
+    """
+    transformer = SentenceTransformer(embedding_model)
+    # transformer.save(f"sentence_transformers/{embedding_model}")
+    text = "Curiosity inspires creative, innovative communities worldwide."
+    embedding = transformer.encode(text)
+    print("=== ", embedding_model, len(embedding))
+
+    for query in [
+        text,
+        "How does curiosity inspire communities?",
+        "What's the best pet?",
+        "What's the meaning of life?",
+    ]:
+        query_embedding = transformer.encode(query)
+        # Code adapted from https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1
+        score = util.dot_score(embedding, query_embedding)
+        print("Score:", score.item(), "for:", query)
+
+
+# To run: python -m src.util.embedding_models
+if __name__ == "__main__":
+    embedding_models = ["multi-qa-mpnet-base-cos-v1", "multi-qa-mpnet-base-dot-v1"]
+    for model in embedding_models:
+        print(model)
+        test_sentence_transformer(model)

--- a/app/tests/mock/test_mock_sentence_transformer.py
+++ b/app/tests/mock/test_mock_sentence_transformer.py
@@ -29,14 +29,15 @@ def test_mock_sentence_transformer():
     assert dot_product(medium_text, medium_text) > dot_product(medium_text, short_text)
 
 
-# This test doesn't normally run with the other tests because it requires downloading large embedding models.
-# To run this test, remove the `manual_` prefix so that the function begins with `test_`.
-# Run the test locally: pytest tests/mock/test_mock_sentence_transformer.py --capture=no -k test_sentence_transformer
+# This test is skipped because it requires downloading large embedding models but is good for manual testing.
+# To run this test, comment out the `@pytest.mark.skip ...` line, then run the test locally with:
+# pytest tests/mock/test_mock_sentence_transformer.py --capture=no -k test_sentence_transformer
 # The embedding models will be downloaded automatically to ~/.cache/huggingface/hub, if it does not already exist.
+@pytest.mark.skip(reason="requires downloading large embedding models")
 @pytest.mark.parametrize(
     "embedding_model", ["multi-qa-mpnet-base-cos-v1", "multi-qa-mpnet-base-dot-v1"]
 )
-def manual_test_sentence_transformer(embedding_model):
+def test_sentence_transformer(embedding_model):
     transformer = SentenceTransformer(embedding_model)
     text = "Curiosity inspires creative, innovative communities worldwide."
     embedding = transformer.encode(text)

--- a/app/tests/mock/test_mock_sentence_transformer.py
+++ b/app/tests/mock/test_mock_sentence_transformer.py
@@ -43,11 +43,12 @@ def manual_test_sentence_transformer(embedding_model):
     print("\n===", embedding_model, len(embedding))
 
     for query in [
+        text,
         "How does curiosity inspire communities?",
         "What's the best pet?",
         "What's the meaning of life?",
     ]:
         query_embedding = transformer.encode(query)
         # Code adapted from https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1
-        score = util.dot_score(query_embedding, embedding)[0]
-        print("Score:", score, "for:", query)
+        score = util.dot_score(embedding, query_embedding)
+        print("Score:", score.item(), "for:", query)

--- a/app/tests/mock/test_mock_sentence_transformer.py
+++ b/app/tests/mock/test_mock_sentence_transformer.py
@@ -1,3 +1,6 @@
+import pytest
+from sentence_transformers import SentenceTransformer, util
+
 from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 
 
@@ -24,3 +27,27 @@ def test_mock_sentence_transformer():
     assert dot_product(long_text, long_text) > dot_product(long_text, medium_text)
     assert dot_product(long_text, medium_text) > dot_product(long_text, short_text)
     assert dot_product(medium_text, medium_text) > dot_product(medium_text, short_text)
+
+
+# This test doesn't normally run with the other tests because it requires downloading large embedding models.
+# To run this test, remove the `manual_` prefix so that the function begins with `test_`.
+# Run the test locally: pytest tests/mock/test_mock_sentence_transformer.py --capture=no -k test_sentence_transformer
+# The embedding models will be downloaded automatically to ~/.cache/huggingface/hub, if it does not already exist.
+@pytest.mark.parametrize(
+    "embedding_model", ["multi-qa-mpnet-base-cos-v1", "multi-qa-mpnet-base-dot-v1"]
+)
+def manual_test_sentence_transformer(embedding_model):
+    transformer = SentenceTransformer(embedding_model)
+    text = "Curiosity inspires creative, innovative communities worldwide."
+    embedding = transformer.encode(text)
+    print("\n===", embedding_model, len(embedding))
+
+    for query in [
+        "How does curiosity inspire communities?",
+        "What's the best pet?",
+        "What's the meaning of life?",
+    ]:
+        query_embedding = transformer.encode(query)
+        # Code adapted from https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1
+        score = util.dot_score(query_embedding, embedding)[0]
+        print("Score:", score, "for:", query)

--- a/app/tests/mock/test_mock_sentence_transformer.py
+++ b/app/tests/mock/test_mock_sentence_transformer.py
@@ -1,6 +1,3 @@
-import pytest
-from sentence_transformers import SentenceTransformer, util
-
 from tests.mock.mock_sentence_transformer import MockSentenceTransformer
 
 
@@ -27,29 +24,3 @@ def test_mock_sentence_transformer():
     assert dot_product(long_text, long_text) > dot_product(long_text, medium_text)
     assert dot_product(long_text, medium_text) > dot_product(long_text, short_text)
     assert dot_product(medium_text, medium_text) > dot_product(medium_text, short_text)
-
-
-# This test is skipped because it requires downloading large embedding models but is good for manual testing.
-# To run this test, comment out the `@pytest.mark.skip ...` line, then run the test locally with:
-# pytest tests/mock/test_mock_sentence_transformer.py --capture=no -k test_sentence_transformer
-# The embedding models will be downloaded automatically to ~/.cache/huggingface/hub, if it does not already exist.
-@pytest.mark.skip(reason="requires downloading large embedding models")
-@pytest.mark.parametrize(
-    "embedding_model", ["multi-qa-mpnet-base-cos-v1", "multi-qa-mpnet-base-dot-v1"]
-)
-def test_sentence_transformer(embedding_model):
-    transformer = SentenceTransformer(embedding_model)
-    text = "Curiosity inspires creative, innovative communities worldwide."
-    embedding = transformer.encode(text)
-    print("\n===", embedding_model, len(embedding))
-
-    for query in [
-        text,
-        "How does curiosity inspire communities?",
-        "What's the best pet?",
-        "What's the meaning of life?",
-    ]:
-        query_embedding = transformer.encode(query)
-        # Code adapted from https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1
-        score = util.dot_score(embedding, query_embedding)
-        print("Score:", score.item(), "for:", query)

--- a/app/tests/src/test_retrieve.py
+++ b/app/tests/src/test_retrieve.py
@@ -79,6 +79,6 @@ def test_retrieve_with_scores(app_config, db_session, enable_factory_create):
 
     assert len(results) == 2
     assert results[0].chunk == short_chunk
-    assert results[0].score == -0.7071067690849304
+    assert results[0].score == 0.7071067690849304
     assert results[1].chunk == medium_chunk
-    assert results[1].score == -0.25881901383399963
+    assert results[1].score == 0.25881901383399963

--- a/docs/app/getting-started.md
+++ b/docs/app/getting-started.md
@@ -26,7 +26,7 @@ A very simple [docker-compose.yml](/docker-compose.yml) has been included to sup
 **Note:** Run everything from within the `/app` folder:
 
 1. Set up an (empty) local secrets file: `touch .env` and copy the provided example Docker override: `cp ../docker-compose.override.yml.example ../docker-compose.override.yml`
-2. Download the `multi-qa-mpnet-base-dot-v1` model into the `models` directory: `git clone https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-dot-v1 models/multi-qa-mpnet-base-dot-v1`
+2. Download the embedding model into the `models` directory: `git clone https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1 models/multi-qa-mpnet-base-cos-v1`
 3. Run `make init start` to build the image and start the container.
 4. Navigate to `localhost:8000/chat` to access the Chainlit UI.
 5. Run `make run-logs` to see the logs of the running application container


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-352

Currently scores are not normalized, so their range is unknown. It is common to normalize the scores so that they range from -1 to 1.


## Changes

Normalize similarity scores of retrieved Guru cards by using the `multi-qa-mpnet-base-cos-v1` embedding model, which normalizes the vector saved to the DB.

Also added manual test and confirmed that the `max_inner_product` method returns the same score magnitude as using `sentence_transformers.util.dot_score` used in code at https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1.

Scores from the DB query are negated, presumably to reverse the default sort order, so the code reverses the negation when recording the score in `ChunkWithScore`; also updated associated test.

## Testing

```
# Reset the database and run migrations
make db-recreate

# Ingest SNAP cards
make ingest-guru-cards DATASET_ID=guru-snap BENEFIT_PROGRAM=SNAP BENEFIT_REGION=Michigan FILEPATH=/app/guru_cards_setA.json

# Ingest Multiprogram cards
make ingest-guru-cards DATASET_ID=guru-multiprogram BENEFIT_PROGRAM=multiprogram BENEFIT_REGION=Michigan FILEPATH=/app/guru_cards_setB.json
```

Run the application and make a query. The scores should be between -1 and 1, where 1 is maximally relevant.

## Reminder

After this is deployed in the `dev` environment, reminder to clear the DB and re-ingest datasets -- see [instructions](https://nava.slack.com/archives/C06DP498D1D/p1721397891286199?thread_ts=1721396512.937399&cid=C06DP498D1D).