### PR TITLE
feat: Add retrieval and docs_shown thresholds

### DIFF
--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -100,4 +100,3 @@ class DynamicAppConfig:
 
 
 app_config = DynamicAppConfig()
-

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from sentence_transformers import SentenceTransformer
 
-import src.adapters.db as db
+from src.adapters import db
 from src.util.env_config import PydanticBaseEnvConfig
 
 
@@ -100,5 +100,4 @@ class DynamicAppConfig:
 
 
 app_config = DynamicAppConfig()
-
 

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -27,8 +27,14 @@ class AppConfig(PydanticBaseEnvConfig):
     host: str = "127.0.0.1"
     port: int = 8080
 
+    # Used for ingestion (before chatbot application starts) and retrieval (during chatbot interactions)
     embedding_model: str = "multi-qa-mpnet-base-cos-v1"
+
+    # Default chat engine
     chat_engine: str = "guru-snap"
+
+    # The following are default configuration values regardless of chat_engine.
+    # Set engine-specific defaults in chat_engine.py.
 
     # Thresholds that determine which documents are sent to the LLM
     retrieval_k: int = 8

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -1,7 +1,4 @@
-import types
-from dataclasses import dataclass
 from functools import cached_property
-from typing import Any
 
 from sentence_transformers import SentenceTransformer
 
@@ -11,8 +8,9 @@ from src.util.env_config import PydanticBaseEnvConfig
 
 class AppConfig(PydanticBaseEnvConfig):
     # Do not instantiate this class directly. Use app_config instead.
-    # These are default configuration values for the app, and
+    # These are constant configuration values for the app, and
     # are shared across both local and deployed environments.
+    # Do not add changeable configuration settings to this class.
 
     # These values are overridden by environment variables.
 
@@ -33,17 +31,6 @@ class AppConfig(PydanticBaseEnvConfig):
     # Default chat engine
     chat_engine: str = "guru-snap"
 
-    # The following are default configuration values regardless of chat_engine.
-    # Set engine-specific defaults in chat_engine.py.
-
-    # Thresholds that determine which documents are sent to the LLM
-    retrieval_k: int = 8
-    retrieval_k_min_score: float = 0.45
-
-    # Thresholds that determine which retrieved documents are shown in the UI
-    docs_shown_max_num: int = 5
-    docs_shown_min_score: float = 0.65
-
     def db_session(self) -> db.Session:
         return db.PostgresDBClient().get_session()
 
@@ -52,57 +39,4 @@ class AppConfig(PydanticBaseEnvConfig):
         return SentenceTransformer(self.embedding_model)
 
 
-@dataclass
-class UserConfig:
-    """
-    Similar to AppConfig, but for user-changeable configurations.
-    If created using `UserConfig(app_config.model_dump())` or `app_config.create_user_config()`,
-    then app_config's configurations are set as default values.
-    """
-
-    retrieval_k: int
-    retrieval_k_min_score: float
-    docs_shown_max_num: int
-    docs_shown_min_score: float
-
-    def __init__(self, model_dump: dict[str, Any]) -> None:
-        for key, value in model_dump.items():
-            setattr(self, key, value)
-
-
-class DynamicAppConfig:
-    """
-    This class is needed as a wrapper around AppConfig to support dynamically changing
-    or reloading configuration values for unit testing, while still allowing cleaner calls
-    like `app_config.retrieval_k` (as opposed to `app_config().retrieval_k`).
-    """
-
-    def __init__(self) -> None:
-        self.reinit()
-
-    def reinit(self, new_config: AppConfig | None = None) -> None:
-        self.app_config = new_config if new_config else AppConfig()
-
-    def __getattr__(self, name: str) -> Any:
-        attrib = getattr(self.app_config, name)
-
-        if not hasattr(self.app_config, name):
-            raise AttributeError(f"No such field/method: {name}")
-
-        if isinstance(attrib, types.MethodType):
-
-            def func_wrapper(*args: Any, **kwargs: dict[str, Any]) -> Any:
-                return attrib(*args, **kwargs)
-
-            return func_wrapper
-
-        return attrib
-
-    def create_user_config(self, **kwargs: dict[str, Any]) -> UserConfig:
-        user_config = UserConfig(self.app_config.model_dump())
-        for key, value in kwargs.items():
-            setattr(user_config, key, value)
-        return user_config
-
-
-app_config = DynamicAppConfig()
+app_config = AppConfig()

--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -20,11 +20,20 @@ class AppConfig(PydanticBaseEnvConfig):
     # To customize these values in deployed environments, set
     # them in infra/app/app-config/env-config/environment-variables.tf
 
-    embedding_model: str = "multi-qa-mpnet-base-cos-v1"
     global_password: str | None = None
     host: str = "127.0.0.1"
     port: int = 8080
+
+    embedding_model: str = "multi-qa-mpnet-base-cos-v1"
     chat_engine: str = "guru-snap"
+
+    # Thresholds that determine which documents are sent to the LLM
+    retrieval_k: int = 8
+    retrieval_k_min_score: float = 0.45
+
+    # Thresholds that determine which retrieved documents are shown in the UI
+    docs_shown_max_num: int = 5
+    docs_shown_min_score: float = 0.65
 
     def db_session(self) -> db.Session:
         return db.PostgresDBClient().get_session()

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import chainlit as cl
 from chainlit.input_widget import InputWidget, Slider
 from src import chat_engine
-from src.app_config import UserConfig, app_config
+from src.app_config import app_config
 from src.format import format_guru_cards
 from src.login import require_login
 

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -6,8 +6,8 @@ from urllib.parse import parse_qs, urlparse
 import chainlit as cl
 from chainlit.input_widget import InputWidget, Slider
 from src import chat_engine
-from src.chat_engine import ChatEngineInterface
 from src.app_config import app_config
+from src.chat_engine import ChatEngineInterface
 from src.format import format_guru_cards
 from src.login import require_login
 

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -27,7 +27,7 @@ class ChatEngineInterface(ABC):
         super().__init__()
         self.user_config = app_config.create_user_config()
         # To set a default configuration for an engine: self.user_config.retrieval_k = 2
-        # To delete a configuration for an engine: self.user_config.__delattr__("retrieval_k")
+        # To remove a configuration for an engine: self.user_config.__delattr__("retrieval_k")
 
     @abstractmethod
     def on_message(self, question: str) -> OnMessageResult:

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -26,6 +26,7 @@ class ChatEngineInterface(ABC):
     def __init__(self) -> None:
         super().__init__()
         self.user_config = app_config.create_user_config()
+        # To set a default configuration for an engine: self.user_config.retrieval_k = 2
         # To delete a configuration for an engine: self.user_config.__delattr__("retrieval_k")
 
     @abstractmethod

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Sequence
 
+from src.app_config import UserConfig
 from src.db.models.document import ChunkWithScore
 from src.generate import generate
 from src.retrieve import retrieve_with_scores
@@ -22,7 +23,7 @@ class ChatEngineInterface(ABC):
     name: str
 
     @abstractmethod
-    def on_message(self, question: str) -> OnMessageResult:
+    def on_message(self, user_config: UserConfig, question: str) -> OnMessageResult:
         pass
 
 
@@ -50,11 +51,8 @@ def create_engine(engine_id: str) -> ChatEngineInterface | None:
 class GuruBaseEngine(ChatEngineInterface):
     datasets: list[str] = []
 
-    def on_message(self, question: str) -> OnMessageResult:
-        chunks_with_scores = retrieve_with_scores(
-            question,
-            datasets=self.datasets,
-        )
+    def on_message(self, user_config: UserConfig, question: str) -> OnMessageResult:
+        chunks_with_scores = retrieve_with_scores(question, user_config, datasets=self.datasets)
 
         response = generate(question, context=chunks_with_scores)
         return OnMessageResult(response, chunks_with_scores)
@@ -76,7 +74,7 @@ class PolicyMichiganEngine(ChatEngineInterface):
     engine_id: str = "policy-mi"
     name: str = "Michigan Bridges Policy Manual Chat Engine"
 
-    def on_message(self, question: str) -> OnMessageResult:
+    def on_message(self, user_config: UserConfig, question: str) -> OnMessageResult:
         logger.warning("TODO: Retrieve from MI Policy Manual")
         chunks: Sequence[ChunkWithScore] = []
         response = "TEMP: Replace with generated response once chunks are correct"

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -1,18 +1,25 @@
-import time
+import logging
+import random
 from typing import Sequence
 
 from src.app_config import app_config
 from src.db.models.document import ChunkWithScore
 
+logger = logging.getLogger(__name__)
+
 # We need a unique identifier for each accordion,
-# even across multiple calls to this function
-_accordion_id = int(time.time())
+# even across multiple calls to this function.
+# Choose a random number to avoid id collisions when hotloading the app during development.
+_accordion_id = random.randint(0, 1000000)
 
 
 def format_guru_cards(chunks_with_scores: Sequence[ChunkWithScore]) -> str:
     cards_html = ""
     for chunk_with_score in chunks_with_scores[: app_config.docs_shown_max_num]:
         if chunk_with_score.score < app_config.docs_shown_min_score:
+            logger.info(
+                "Skipping remaining chunks with score less than %f", app_config.docs_shown_min_score
+            )
             break
 
         global _accordion_id

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -2,7 +2,6 @@ import logging
 import random
 from typing import Sequence
 
-from src.app_config import UserConfig
 from src.db.models.document import ChunkWithScore
 
 logger = logging.getLogger(__name__)
@@ -13,14 +12,18 @@ logger = logging.getLogger(__name__)
 _accordion_id = random.randint(0, 1000000)
 
 
-def format_guru_cards(user_config: UserConfig, chunks_with_scores: Sequence[ChunkWithScore]) -> str:
+def format_guru_cards(
+    docs_shown_max_num: int,
+    docs_shown_min_score: float,
+    chunks_with_scores: Sequence[ChunkWithScore],
+) -> str:
     cards_html = ""
-    for chunk_with_score in chunks_with_scores[: user_config.docs_shown_max_num]:
+    for chunk_with_score in chunks_with_scores[:docs_shown_max_num]:
         document = chunk_with_score.chunk.document
-        if chunk_with_score.score < user_config.docs_shown_min_score:
+        if chunk_with_score.score < docs_shown_min_score:
             logger.info(
                 "Skipping chunk with score less than %f: %s",
-                user_config.docs_shown_min_score,
+                docs_shown_min_score,
                 document.name,
             )
             continue

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -2,7 +2,7 @@ import logging
 import random
 from typing import Sequence
 
-from src.app_config import app_config
+from src.app_config import UserConfig
 from src.db.models.document import ChunkWithScore
 
 logger = logging.getLogger(__name__)
@@ -13,12 +13,13 @@ logger = logging.getLogger(__name__)
 _accordion_id = random.randint(0, 1000000)
 
 
-def format_guru_cards(chunks_with_scores: Sequence[ChunkWithScore]) -> str:
+def format_guru_cards(user_config: UserConfig, chunks_with_scores: Sequence[ChunkWithScore]) -> str:
     cards_html = ""
-    for chunk_with_score in chunks_with_scores[: app_config.docs_shown_max_num]:
-        if chunk_with_score.score < app_config.docs_shown_min_score:
+    for chunk_with_score in chunks_with_scores[: user_config.docs_shown_max_num]:
+        if chunk_with_score.score < user_config.docs_shown_min_score:
             logger.info(
-                "Skipping remaining chunks with score less than %f", app_config.docs_shown_min_score
+                "Skipping remaining chunks with score less than %f",
+                user_config.docs_shown_min_score,
             )
             break
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -16,17 +16,18 @@ _accordion_id = random.randint(0, 1000000)
 def format_guru_cards(user_config: UserConfig, chunks_with_scores: Sequence[ChunkWithScore]) -> str:
     cards_html = ""
     for chunk_with_score in chunks_with_scores[: user_config.docs_shown_max_num]:
+        document = chunk_with_score.chunk.document
         if chunk_with_score.score < user_config.docs_shown_min_score:
             logger.info(
-                "Skipping remaining chunks with score less than %f",
+                "Skipping chunk with score less than %f: %s",
                 user_config.docs_shown_min_score,
+                document.name,
             )
-            break
+            continue
 
         global _accordion_id
         _accordion_id += 1
         similarity_score = f"<p>Similarity Score: {str(chunk_with_score.score)}</p>"
-        document = chunk_with_score.chunk.document
         cards_html += f"""
 <div class="usa-accordion" id=accordion-{_accordion_id}>
     <h4 class="usa-accordion__heading">

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -1,15 +1,20 @@
+import time
 from typing import Sequence
 
+from src.app_config import app_config
 from src.db.models.document import ChunkWithScore
 
 # We need a unique identifier for each accordion,
 # even across multiple calls to this function
-_accordion_id = 0
+_accordion_id = int(time.time())
 
 
 def format_guru_cards(chunks_with_scores: Sequence[ChunkWithScore]) -> str:
     cards_html = ""
-    for chunk_with_score in chunks_with_scores:
+    for chunk_with_score in chunks_with_scores[: app_config.docs_shown_max_num]:
+        if chunk_with_score.score < app_config.docs_shown_min_score:
+            break
+
         global _accordion_id
         _accordion_id += 1
         similarity_score = f"<p>Similarity Score: {str(chunk_with_score.score)}</p>"

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import patch
 
 import _pytest.monkeypatch
 import boto3
@@ -111,9 +112,10 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
 def app_config(monkeypatch, db_session):
     monkeypatch.setattr(AppConfig, "db_session", lambda _self: db_session)
     monkeypatch.setattr(AppConfig, "sentence_transformer", MockSentenceTransformer())
-    src_app_config.app_config.retrieval_k_min_score = 0.0
-    src_app_config.app_config.docs_shown_min_score = 0.0
-    return src_app_config.app_config
+
+    with patch("src.app_config.app_config.retrieval_k_min_score", 0.0):
+        with patch("src.app_config.app_config.docs_shown_min_score", 0.0):
+            yield src_app_config.app_config
 
 
 ####################

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 import src.adapters.db as db
 import tests.src.db.models.factories as factories
+from src import app_config as src_app_config
 from src.app_config import AppConfig
 from src.db import models
 from src.util.local import load_local_env_vars
@@ -110,6 +111,9 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
 def app_config(monkeypatch, db_session):
     monkeypatch.setattr(AppConfig, "db_session", lambda _self: db_session)
     monkeypatch.setattr(AppConfig, "sentence_transformer", MockSentenceTransformer())
+    src_app_config.app_config.retrieval_k_min_score = 0.0
+    src_app_config.app_config.docs_shown_min_score = 0.0
+    return src_app_config.app_config
 
 
 ####################

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,5 +1,4 @@
 import logging
-from unittest.mock import patch
 
 import _pytest.monkeypatch
 import boto3
@@ -113,9 +112,9 @@ def app_config(monkeypatch, db_session):
     monkeypatch.setattr(AppConfig, "db_session", lambda _self: db_session)
     monkeypatch.setattr(AppConfig, "sentence_transformer", MockSentenceTransformer())
 
-    with patch("src.app_config.app_config.retrieval_k_min_score", 0.0):
-        with patch("src.app_config.app_config.docs_shown_min_score", 0.0):
-            yield src_app_config.app_config
+    monkeypatch.setenv("RETRIEVAL_K_MIN_SCORE", "0.0")
+    src_app_config.app_config.reinit()
+    return src_app_config.app_config
 
 
 ####################

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 import src.adapters.db as db
 import tests.src.db.models.factories as factories
-from src import app_config as src_app_config
 from src.app_config import AppConfig
 from src.db import models
 from src.util.local import load_local_env_vars
@@ -111,10 +110,6 @@ def enable_factory_create(monkeypatch, db_session) -> db.Session:
 def app_config(monkeypatch, db_session):
     monkeypatch.setattr(AppConfig, "db_session", lambda _self: db_session)
     monkeypatch.setattr(AppConfig, "sentence_transformer", MockSentenceTransformer())
-
-    monkeypatch.setenv("RETRIEVAL_K_MIN_SCORE", "0.0")
-    src_app_config.app_config.reinit()
-    return src_app_config.app_config
 
 
 ####################

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -1,10 +1,5 @@
 from src import chat_engine
-from src.chat_engine import (
-    ChatEngineInterface,
-    GuruMultiprogramEngine,
-    GuruSnapEngine,
-    OnMessageResult,
-)
+from src.chat_engine import GuruMultiprogramEngine, GuruSnapEngine
 
 
 def test_available_engines():
@@ -28,41 +23,3 @@ def test_create_engine_Guru_SNAP():
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruSnapEngine.name
-
-
-class TestChatEngine(ChatEngineInterface):
-    engine_id: str = "test_chat_engine"
-    name: str = "Test Chat Engine for unit tests"
-    datasets = ["guru-snap", "guru-multiprogram", "policy-mi"]
-
-    # Engine-specific configurations
-    retrieval_k = 2
-
-    def on_message(self, question: str) -> OnMessageResult:
-        self._testing_hook(question)
-        return OnMessageResult("Some generated response from LLM", [])
-
-    def _testing_hook(self, question: str):
-        return
-
-
-def test_user_config_initialization():
-    engine = chat_engine.create_engine("test_chat_engine")
-    assert engine is not None
-    assert engine.datasets == TestChatEngine.datasets
-
-    assert engine.retrieval_k == 2
-
-
-def test_user_config_change(monkeypatch):
-    engine = chat_engine.create_engine("test_chat_engine")
-
-    # Simulate user changing the configuration value
-    engine.retrieval_k = 5  # similar code as in chainlit.py
-
-    # Check that the engine has the new configuration value
-    def assert_new_config_used(self, question):
-        assert self.retrieval_k == 5
-
-    monkeypatch.setattr(TestChatEngine, "_testing_hook", assert_new_config_used)
-    engine.on_message("A test question")

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -1,5 +1,11 @@
-import src.chat_engine as chat_engine
-from src.chat_engine import GuruMultiprogramEngine, GuruSnapEngine
+from src import chat_engine
+from src.app_config import app_config
+from src.chat_engine import (
+    ChatEngineInterface,
+    GuruMultiprogramEngine,
+    GuruSnapEngine,
+    OnMessageResult,
+)
 
 
 def test_available_engines():
@@ -23,3 +29,51 @@ def test_create_engine_Guru_SNAP():
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == GuruSnapEngine.name
+
+    # Check that the engine has the same configuration value as the app_config
+    assert engine.user_config.retrieval_k == app_config.retrieval_k
+
+
+class TestChatEngine(ChatEngineInterface):
+    engine_id: str = "test_chat_engine"
+    name: str = "Test Chat Engine for unit tests"
+    datasets = ["guru-snap", "guru-multiprogram", "policy-mi"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.user_config = app_config.create_user_config()
+        # Set a default retrieval_k
+        self.user_config.retrieval_k = 2
+        # Remove the retrieval_k_min_score configuration for an engine
+        self.user_config.__delattr__("retrieval_k_min_score")
+
+    def on_message(self, question: str) -> OnMessageResult:
+        self._testing_hook(question)
+        return OnMessageResult("Some generated response from LLM", [])
+
+    def _testing_hook(self, question: str):
+        print("====\n====", question)
+        return
+
+
+def test_user_config_initialization():
+    engine = chat_engine.create_engine("test_chat_engine")
+    assert engine is not None
+    assert engine.datasets == TestChatEngine.datasets
+
+    assert engine.user_config.retrieval_k == 2
+    assert not hasattr(engine.user_config, "retrieval_k_min_score")
+
+
+def test_user_config_change(monkeypatch):
+    engine = chat_engine.create_engine("test_chat_engine")
+
+    # Simulate user changing the configuration value
+    engine.user_config.retrieval_k = 5  # similar code as in chainlit.py
+
+    # Check that the engine has the new configuration value
+    def assert_new_config_used(self, _question):
+        assert self.user_config.retrieval_k == 5
+
+    monkeypatch.setattr(TestChatEngine, "_testing_hook", assert_new_config_used)
+    engine.on_message("A test question")

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -1,5 +1,4 @@
 from src import chat_engine
-from src.app_config import app_config
 from src.chat_engine import (
     ChatEngineInterface,
     GuruMultiprogramEngine,
@@ -30,29 +29,20 @@ def test_create_engine_Guru_SNAP():
     assert engine is not None
     assert engine.name == GuruSnapEngine.name
 
-    # Check that the engine has the same configuration value as the app_config
-    assert engine.user_config.retrieval_k == app_config.retrieval_k
-
 
 class TestChatEngine(ChatEngineInterface):
     engine_id: str = "test_chat_engine"
     name: str = "Test Chat Engine for unit tests"
     datasets = ["guru-snap", "guru-multiprogram", "policy-mi"]
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.user_config = app_config.create_user_config()
-        # Set a default retrieval_k
-        self.user_config.retrieval_k = 2
-        # Remove the retrieval_k_min_score configuration for an engine
-        self.user_config.__delattr__("retrieval_k_min_score")
+    # Engine-specific configurations
+    retrieval_k = 2
 
     def on_message(self, question: str) -> OnMessageResult:
         self._testing_hook(question)
         return OnMessageResult("Some generated response from LLM", [])
 
     def _testing_hook(self, question: str):
-        print("====\n====", question)
         return
 
 
@@ -61,19 +51,18 @@ def test_user_config_initialization():
     assert engine is not None
     assert engine.datasets == TestChatEngine.datasets
 
-    assert engine.user_config.retrieval_k == 2
-    assert not hasattr(engine.user_config, "retrieval_k_min_score")
+    assert engine.retrieval_k == 2
 
 
 def test_user_config_change(monkeypatch):
     engine = chat_engine.create_engine("test_chat_engine")
 
     # Simulate user changing the configuration value
-    engine.user_config.retrieval_k = 5  # similar code as in chainlit.py
+    engine.retrieval_k = 5  # similar code as in chainlit.py
 
     # Check that the engine has the new configuration value
-    def assert_new_config_used(self, _question):
-        assert self.user_config.retrieval_k == 5
+    def assert_new_config_used(self, question):
+        assert self.retrieval_k == 5
 
     monkeypatch.setattr(TestChatEngine, "_testing_hook", assert_new_config_used)
     engine.on_message("A test question")

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -2,15 +2,16 @@ import re
 
 from sqlalchemy import delete
 
+from src.app_config import app_config
 from src.db.models.document import Document
 from src.format import format_guru_cards
 from src.retrieve import retrieve_with_scores
 from tests.src.test_retrieve import _create_chunks
 
 
-def _get_chunks_with_scores():
+def _get_chunks_with_scores(user_config):
     _create_chunks()
-    return retrieve_with_scores("Very tiny words.", k=2)
+    return retrieve_with_scores("Very tiny words.", user_config)
 
 
 def _unique_accordion_ids(html):
@@ -24,9 +25,10 @@ def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enabl
 
     monkeypatch.setenv("DOCS_SHOWN_MIN_SCORE", "0.0")
     app_config.reinit()
+    user_config = app_config.create_user_config(retrieval_k=2)
 
-    chunks_with_scores = _get_chunks_with_scores()
-    html = format_guru_cards(chunks_with_scores)
+    chunks_with_scores = _get_chunks_with_scores(user_config)
+    html = format_guru_cards(user_config, chunks_with_scores)
     assert len(_unique_accordion_ids(html)) == len(chunks_with_scores)
     assert "Related Guru cards" in html
     assert chunks_with_scores[0].chunk.document.name in html
@@ -36,5 +38,5 @@ def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enabl
     assert "Similarity Score" in html
 
     # Check that a second call doesn't re-use the IDs
-    next_html = format_guru_cards(chunks_with_scores)
+    next_html = format_guru_cards(user_config, chunks_with_scores)
     assert len(_unique_accordion_ids(html + next_html)) == 2 * len(chunks_with_scores)

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -8,9 +8,9 @@ from src.retrieve import retrieve_with_scores
 from tests.src.test_retrieve import _create_chunks
 
 
-def _get_chunks_with_scores(user_config):
+def _get_chunks_with_scores():
     _create_chunks()
-    return retrieve_with_scores("Very tiny words.", user_config)
+    return retrieve_with_scores("Very tiny words.", retrieval_k=2, retrieval_k_min_score=0.0)
 
 
 def _unique_accordion_ids(html):
@@ -22,12 +22,10 @@ def _unique_accordion_ids(html):
 def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
 
-    monkeypatch.setenv("DOCS_SHOWN_MIN_SCORE", "0.0")
-    app_config.reinit()
-    user_config = app_config.create_user_config(retrieval_k=2)
-
-    chunks_with_scores = _get_chunks_with_scores(user_config)
-    html = format_guru_cards(user_config, chunks_with_scores)
+    chunks_with_scores = _get_chunks_with_scores()
+    html = format_guru_cards(
+        docs_shown_max_num=2, docs_shown_min_score=0.0, chunks_with_scores=chunks_with_scores
+    )
     assert len(_unique_accordion_ids(html)) == len(chunks_with_scores)
     assert "Related Guru cards" in html
     assert chunks_with_scores[0].chunk.document.name in html
@@ -37,11 +35,13 @@ def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enabl
     assert "Similarity Score" in html
 
     # Check that a second call doesn't re-use the IDs
-    next_html = format_guru_cards(user_config, chunks_with_scores)
+    next_html = format_guru_cards(
+        docs_shown_max_num=2, docs_shown_min_score=0.0, chunks_with_scores=chunks_with_scores
+    )
     assert len(_unique_accordion_ids(html + next_html)) == 2 * len(chunks_with_scores)
 
 
-def _create_chunks_with_scores():
+def _chunks_with_scores():
     return [
         ChunkWithScore(Chunk(document=Document(name="name1", content="content1")), 0.99),
         ChunkWithScore(Chunk(document=Document(name="name2", content="content2")), 0.90),
@@ -49,17 +49,15 @@ def _create_chunks_with_scores():
     ]
 
 
-def test_format_guru_cards_given_docs_shown_max_num(app_config):
-    assert app_config.docs_shown_min_score < 0.8
-    user_config = app_config.create_user_config()
-    user_config.docs_shown_max_num = 2
-    html = format_guru_cards(user_config, _create_chunks_with_scores())
+def test_format_guru_cards_given_docs_shown_max_num():
+    html = format_guru_cards(
+        docs_shown_max_num=2, docs_shown_min_score=0.8, chunks_with_scores=_chunks_with_scores()
+    )
     assert len(_unique_accordion_ids(html)) == 2
 
 
-def test_format_guru_cards_given_docs_shown_max_num_and_min_score(app_config):
-    user_config = app_config.create_user_config()
-    user_config.docs_shown_max_num = 2
-    user_config.docs_shown_min_score = 0.91
-    html = format_guru_cards(user_config, _create_chunks_with_scores())
+def test_format_guru_cards_given_docs_shown_max_num_and_min_score():
+    html = format_guru_cards(
+        docs_shown_max_num=2, docs_shown_min_score=0.91, chunks_with_scores=_chunks_with_scores()
+    )
     assert len(_unique_accordion_ids(html)) == 1

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -2,7 +2,7 @@ import re
 
 from sqlalchemy import delete
 
-from src.db.models.document import Document
+from src.db.models.document import Chunk, ChunkWithScore, Document
 from src.format import format_guru_cards
 from src.retrieve import retrieve_with_scores
 from tests.src.test_retrieve import _create_chunks
@@ -39,3 +39,27 @@ def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enabl
     # Check that a second call doesn't re-use the IDs
     next_html = format_guru_cards(user_config, chunks_with_scores)
     assert len(_unique_accordion_ids(html + next_html)) == 2 * len(chunks_with_scores)
+
+
+def _create_chunks_with_scores():
+    return [
+        ChunkWithScore(Chunk(document=Document(name="name1", content="content1")), 0.99),
+        ChunkWithScore(Chunk(document=Document(name="name2", content="content2")), 0.90),
+        ChunkWithScore(Chunk(document=Document(name="name3", content="content3")), 0.85),
+    ]
+
+
+def test_format_guru_cards_given_docs_shown_max_num(app_config):
+    assert app_config.docs_shown_min_score < 0.8
+    user_config = app_config.create_user_config()
+    user_config.docs_shown_max_num = 2
+    html = format_guru_cards(user_config, _create_chunks_with_scores())
+    assert len(_unique_accordion_ids(html)) == 2
+
+
+def test_format_guru_cards_given_docs_shown_max_num_and_min_score(app_config):
+    user_config = app_config.create_user_config()
+    user_config.docs_shown_max_num = 2
+    user_config.docs_shown_min_score = 0.91
+    html = format_guru_cards(user_config, _create_chunks_with_scores())
+    assert len(_unique_accordion_ids(html)) == 1

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -2,7 +2,6 @@ import re
 
 from sqlalchemy import delete
 
-from src.app_config import app_config
 from src.db.models.document import Document
 from src.format import format_guru_cards
 from src.retrieve import retrieve_with_scores

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -19,8 +19,11 @@ def _unique_accordion_ids(html):
     )
 
 
-def test_format_guru_cards_with_score(app_config, db_session, enable_factory_create):
+def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
+
+    monkeypatch.setenv("DOCS_SHOWN_MIN_SCORE", "0.0")
+    app_config.reinit()
 
     chunks_with_scores = _get_chunks_with_scores()
     html = format_guru_cards(chunks_with_scores)


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-356

Currently, the chatbot has 1 threshold (retrieval-k) that controls both:
- retrieval-k: the number of retrieved docs (e.g., Guru cards) that gets sent to the LLM for it to generate the free-text response, and
- the retrieved docs that gets shown to the user (which I’ll call max-num-docs-shown)

We want to be able to control these 2 thresholds independently because:
- we may want to have a high retrieval-k to give as much context as possible to the LLM
- but limit max-num-docs-shown to the user

We also want to control the docs shown based on the retrieval/similarity/relevance score, so also add a docs-shown-min-score, which will also limit the number of docs shown, i.e., a doc will only be shown if it meets the docs-shown-min-score AND does not exceed the max-num-docs-shown.

## Changes

* Adds the following thresholds as settings in the UI:
   - `retrieval_k`: Number of documents to retrieve for generating LLM response
   - `retrieval_k_min_score`: Minimum document score required for generating LLM response
   - `docs_shown_max_num`: Maximum number of retrieved documents to show in the UI
   - `docs_shown_min_score`: Minimum document score required to show document in the UI
* Have these configuration settings affect the behavior of the chatbot

## Context for reviewers

Ryan and team will adjust these settings to determined appropriate thresholds for each chat engine.

## Testing

Start the chatbot, repeatly change a setting in the Chainlit UI, submit a question, then expect the cited Guru cards to satisfy the adjusted settings. Examples include:
- high retrieval_k but lower docs_shown_max_num should show no more than docs_shown_max_num
- low retrieval_k but higher docs_shown_max_num should show no more than retrieval_k

Examine the scores and change the docs_shown_min_score setting value to somewhere in the middle of the score range; rerun the query; and expect fewer documents.

Select a very low or zero retrieval_k or retrieval_k_min_score; expect the generated answer to not use any documents, and no docs would be shown in the UI.