### PR TITLE
feat: add accordion chunk citations

### DIFF
--- a/app/src/format.py
+++ b/app/src/format.py
@@ -42,7 +42,7 @@ def _get_bem_documents_to_show(
     # Build a dictionary of documents with their associated chunks,
     # Ordered by the highest score of each chunk associated with the document
     documents: OrderedDict[Document, list[ChunkWithScore]] = OrderedDict()
-    for chunk_with_score in chunks_with_scores:
+    for chunk_with_score in chunks_with_scores[:docs_shown_max_num]:
         document = chunk_with_score.chunk.document
         if chunk_with_score.score < docs_shown_min_score:
             logger.info(
@@ -57,7 +57,7 @@ def _get_bem_documents_to_show(
         else:
             documents[document] = [chunk_with_score]
 
-    return documents[:docs_shown_max_num]
+    return documents
 
 
 def format_bem_documents(
@@ -124,4 +124,5 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
                 {internal_citation}
                 </div>
             </div>"""
-    return "<h3>Source(s)</h3>" + html if not html else ""
+
+    return "<h3>Source(s)</h3>" + html if html else ""

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -99,7 +99,7 @@ def format_to_accordion_html(document: Document, score: float) -> str:
             </button>
         </h4>
         <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>
-            <p>Summary: {document.content.strip() if document.content else document.content}</p>
+            <p>Summary: {document.content.strip() if document.content else ""}</p>
             {similarity_score}
         </div>
     </div>"""

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -66,7 +66,7 @@ def format_bem_documents(
     documents = _get_bem_documents_to_show(
         docs_shown_max_num, docs_shown_min_score, chunks_with_scores
     )
-    cards_html = ""
+    pdf_chunks = ""
     for chunk_with_score in documents:
         document = chunk_with_score.document
         if chunk_with_score.max_score < docs_shown_min_score:
@@ -76,9 +76,9 @@ def format_bem_documents(
                 document.name,
             )
             continue
-        cards_html += format_to_accordion_html(document=document, score=chunk_with_score.max_score)
+        pdf_chunks += format_to_accordion_html(document=document, score=chunk_with_score.max_score)
 
-    return "<h3>Source(s)</h3>" + cards_html
+    return "<h3>Source(s)</h3>" + pdf_chunks
 
 
 def format_to_accordion_html(document: Document, score: float) -> str:

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -3,7 +3,7 @@ import random
 import re
 from typing import OrderedDict, Sequence
 
-from src.db.models.document import ChunkWithScore, Document, DocumentWithMaxScore
+from src.db.models.document import ChunkWithScore, Document
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ def _get_bem_documents_to_show(
 def format_bem_documents(
     docs_shown_max_num: int,
     docs_shown_min_score: float,
-    chunks_with_scores: Sequence[ChunkWithScore],
+    chunks_with_scores: list[ChunkWithScore],
 ) -> str:
     documents = _get_bem_documents_to_show(
         docs_shown_max_num, docs_shown_min_score, chunks_with_scores
@@ -100,17 +100,14 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
     global _accordion_id
     _accordion_id += 1
     html = "<h3>Source(s)</h3>"
+    internal_citation = ""
     for document in documents:
-        internal_citation = ""
         for index, chunk in enumerate(documents[document], start=1):
             formatted_chunk = re.sub(r"\n+", "\n", chunk.chunk.content).strip()
             formatted_chunk = f"<p>Summary: {formatted_chunk} </p>" if formatted_chunk else ""
             citation = f"<h4>Citation #{index} (score: {chunk.score})</h4>"
             similarity_score = f"<p>Similarity Score: {str(chunk.score)}</p>"
-            internal_citation += f"""<div id="a-{_accordion_id}" class="usa-accordion__content usa-prose margin-left-2 border-left-1 border-base-lighter" hidden>
-                    {citation}{formatted_chunk}{similarity_score}
-                </div>"""
-
+            internal_citation += f"""{citation}<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_chunk}{similarity_score}</div>"""
         html += f"""
             <div class="usa-accordion" id=accordion-{_accordion_id}>
                 <h4 class="usa-accordion__heading">
@@ -123,6 +120,8 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
                         <a href='https://link'>{document.name}</a>
                     </button>
                 </h4>
+                <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>
                 {internal_citation}
+                </div>
             </div>"""
     return html if html != "" else ""

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -98,10 +98,10 @@ def _format_to_accordion_html(document: Document, score: float) -> str:
 
 def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkWithScore]]) -> str:
     global _accordion_id
-    _accordion_id += 1
-    html = "<h3>Source(s)</h3>"
+    html = ""
     internal_citation = ""
     for document in documents:
+        _accordion_id += 1
         for index, chunk in enumerate(documents[document], start=1):
             formatted_chunk = re.sub(r"\n+", "\n", chunk.chunk.content).strip()
             formatted_chunk = f"<p>Summary: {formatted_chunk} </p>" if formatted_chunk else ""
@@ -124,4 +124,4 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
                 {internal_citation}
                 </div>
             </div>"""
-    return html if html != "" else ""
+    return "<h3>Source(s)</h3>" + html if html != "" else ""

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -98,8 +98,10 @@ def test_format_bem_documents():
     html = format_bem_documents(
         docs_shown_max_num=2, docs_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
+    print(html)
     assert docs[0].name not in html
     assert docs[1].name not in html
-    assert docs[2].name in html
     assert docs[3].name in html
+    assert "Citation #2" in html
+    assert "Citation #3" not in html
     assert "<p>Similarity Score: 0.95</p>" in html

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -3,7 +3,7 @@ import re
 from sqlalchemy import delete
 
 from src.db.models.document import ChunkWithScore, Document
-from src.format import format_bem_documents, format_guru_cards
+from src.format import format_bem_documents, format_guru_cards, format_to_accordion_html
 from src.retrieve import retrieve_with_scores
 from tests.src.db.models.factories import ChunkFactory, DocumentFactory
 from tests.src.test_retrieve import _create_chunks
@@ -64,6 +64,17 @@ def test_format_guru_cards_given_docs_shown_max_num_and_min_score():
     assert len(_unique_accordion_ids(html)) == 1
 
 
+def test_format_to_accordion_html(app_config, db_session, enable_factory_create):
+    db_session.execute(delete(Document))
+    chunks_with_scores = _get_chunks_with_scores()
+    document = chunks_with_scores[0].chunk.document
+    score = 0.92
+    html = format_to_accordion_html(document=document, score=score)
+    assert document.name in html
+    assert document.content in html
+    assert "<p>Similarity Score: 0.92</p>" in html
+
+
 def test_format_bem_documents():
     docs = DocumentFactory.build_batch(4)
 
@@ -87,4 +98,8 @@ def test_format_bem_documents():
     html = format_bem_documents(
         docs_shown_max_num=2, docs_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
-    assert html == f"<h3>Source(s)</h3><ul><li>{docs[3].name}</li><li>{docs[2].name}</li></ul>"
+    assert docs[0].name not in html
+    assert docs[1].name not in html
+    assert docs[2].name in html
+    assert docs[3].name in html
+    assert "<p>Similarity Score: 0.95</p>" in html

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -3,7 +3,7 @@ import re
 from sqlalchemy import delete
 
 from src.db.models.document import ChunkWithScore, Document
-from src.format import format_bem_documents, format_guru_cards, format_to_accordion_html
+from src.format import format_bem_documents, format_guru_cards, _format_to_accordion_html
 from src.retrieve import retrieve_with_scores
 from tests.src.db.models.factories import ChunkFactory, DocumentFactory
 from tests.src.test_retrieve import _create_chunks
@@ -64,12 +64,12 @@ def test_format_guru_cards_given_docs_shown_max_num_and_min_score():
     assert len(_unique_accordion_ids(html)) == 1
 
 
-def test_format_to_accordion_html(app_config, db_session, enable_factory_create):
+def test__format_to_accordion_html(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
     chunks_with_scores = _get_chunks_with_scores()
     document = chunks_with_scores[0].chunk.document
     score = 0.92
-    html = format_to_accordion_html(document=document, score=score)
+    html = _format_to_accordion_html(document=document, score=score)
     assert document.name in html
     assert document.content in html
     assert "<p>Similarity Score: 0.92</p>" in html

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -3,7 +3,7 @@ import re
 from sqlalchemy import delete
 
 from src.db.models.document import ChunkWithScore, Document
-from src.format import format_bem_documents, format_guru_cards, _format_to_accordion_html
+from src.format import _format_to_accordion_html, format_bem_documents, format_guru_cards
 from src.retrieve import retrieve_with_scores
 from tests.src.db.models.factories import ChunkFactory, DocumentFactory
 from tests.src.test_retrieve import _create_chunks

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -98,7 +98,7 @@ def test_format_bem_documents():
     html = format_bem_documents(
         docs_shown_max_num=2, docs_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
-    print(html)
+
     assert docs[0].name not in html
     assert docs[1].name not in html
     assert docs[3].name in html

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -99,9 +99,9 @@ def test_format_bem_documents():
         docs_shown_max_num=2, docs_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
 
-    assert docs[0].name not in html
-    assert docs[1].name not in html
-    assert docs[3].name in html
+    assert docs[0].content not in html
+    assert docs[1].content not in html
+    assert docs[3].content in html
     assert "Citation #2" in html
     assert "Citation #3" not in html
     assert "<p>Similarity Score: 0.95</p>" in html


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-374 


## Changes
> extract accordion format html to function
> change _get_bem_docs_to_show

## Testing
- run `make start` in app directory
- navigate to http://localhost:8000/chat/?engine=bridges-eligibility-manual
- set `Minimum document score required for generating LLM response` and `Minimum document score required to show document in the UI` to -1
- run query
<img width="826" alt="Screenshot 2024-08-12 at 11 46 24 AM" src="https://github.com/user-attachments/assets/a86bbb98-647e-42a8-9068-41d5d457f3c9">

