### PR TITLE
fix: Rename docs_shown_* variable to chunks_shown_*

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -102,7 +102,7 @@ _WIDGET_FACTORIES = {
     ),
     "retrieval_k": lambda default_value: Slider(
         id="retrieval_k",
-        label="Number of documents to retrieve for generating LLM response",
+        label="Number of citations to retrieve for generating LLM response",
         initial=default_value,
         min=0,
         max=10,
@@ -110,23 +110,23 @@ _WIDGET_FACTORIES = {
     ),
     "retrieval_k_min_score": lambda initial_value: Slider(
         id="retrieval_k_min_score",
-        label="Minimum document score required for generating LLM response",
+        label="Minimum citation score required for generating LLM response",
         initial=initial_value,
         min=-1,
         max=1,
         step=0.25,
     ),
-    "docs_shown_max_num": lambda initial_value: Slider(
-        id="docs_shown_max_num",
-        label="Maximum number of retrieved documents to show in the UI",
+    "chunks_shown_max_num": lambda initial_value: Slider(
+        id="chunks_shown_max_num",
+        label="Maximum number of retrieved citations to show in the UI",
         initial=initial_value,
         min=0,
         max=10,
         step=1,
     ),
-    "docs_shown_min_score": lambda initial_value: Slider(
-        id="docs_shown_min_score",
-        label="Minimum document score required to show document in the UI",
+    "chunks_shown_min_score": lambda initial_value: Slider(
+        id="chunks_shown_min_score",
+        label="Minimum citation score required to show citation in the UI",
         initial=initial_value,
         min=-1,
         max=1,
@@ -144,8 +144,8 @@ async def on_message(message: cl.Message) -> None:
         result = await cl.make_async(lambda: engine.on_message(question=message.content))()
 
         msg_content = result.response + engine.formatter(
-            docs_shown_max_num=engine.docs_shown_max_num,
-            docs_shown_min_score=engine.docs_shown_min_score,
+            chunks_shown_max_num=engine.chunks_shown_max_num,
+            chunks_shown_min_score=engine.chunks_shown_min_score,
             chunks_with_scores=result.chunks_with_scores,
         )
 

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -26,8 +26,8 @@ class ChatEngineInterface(ABC):
     formatter: Callable
 
     # Thresholds that determine which retrieved documents are shown in the UI
-    docs_shown_max_num: int = 5
-    docs_shown_min_score: float = 0.65
+    chunks_shown_max_num: int = 5
+    chunks_shown_min_score: float = 0.65
 
     # List of engine-specific configuration settings that can be set by the user.
     # The string elements must match the attribute names for the configuration setting.
@@ -74,8 +74,8 @@ class BaseEngine(ChatEngineInterface):
         "llm",
         "retrieval_k",
         "retrieval_k_min_score",
-        "docs_shown_max_num",
-        "docs_shown_min_score",
+        "chunks_shown_max_num",
+        "chunks_shown_min_score",
     ]
 
     def on_message(self, question: str) -> OnMessageResult:

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -33,7 +33,6 @@ def format_guru_cards(
 
 
 def _get_bem_documents_to_show(
-
     chunks_shown_max_num: int,
     chunks_shown_min_score: float,
     chunks_with_scores: list[ChunkWithScore],
@@ -43,12 +42,12 @@ def _get_bem_documents_to_show(
     # Build a dictionary of documents with their associated chunks,
     # Ordered by the highest score of each chunk associated with the document
     documents: OrderedDict[Document, list[ChunkWithScore]] = OrderedDict()
-    for chunk_with_score in chunks_with_scores[:docs_shown_max_num]:
+    for chunk_with_score in chunks_with_scores[:chunks_shown_max_num]:
         document = chunk_with_score.chunk.document
-        if chunk_with_score.score < docs_shown_min_score:
+        if chunk_with_score.score < chunks_shown_min_score:
             logger.info(
                 "Skipping chunk with score less than %f: %s",
-                docs_shown_min_score,
+                chunks_shown_min_score,
                 chunk_with_score.chunk.document.name,
             )
             continue

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -13,17 +13,17 @@ _accordion_id = random.randint(0, 1000000)
 
 
 def format_guru_cards(
-    docs_shown_max_num: int,
-    docs_shown_min_score: float,
+    chunks_shown_max_num: int,
+    chunks_shown_min_score: float,
     chunks_with_scores: Sequence[ChunkWithScore],
 ) -> str:
     cards_html = ""
-    for chunk_with_score in chunks_with_scores[:docs_shown_max_num]:
+    for chunk_with_score in chunks_with_scores[:chunks_shown_max_num]:
         document = chunk_with_score.chunk.document
-        if chunk_with_score.score < docs_shown_min_score:
+        if chunk_with_score.score < chunks_shown_min_score:
             logger.info(
                 "Skipping chunk with score less than %f: %s",
-                docs_shown_min_score,
+                chunks_shown_min_score,
                 document.name,
             )
             continue
@@ -52,15 +52,15 @@ def format_guru_cards(
 
 
 def _get_bem_documents_to_show(
-    docs_shown_max_num: int,
-    docs_shown_min_score: float,
+    chunks_shown_max_num: int,
+    chunks_shown_min_score: float,
     chunks_with_scores: Sequence[ChunkWithScore],
 ) -> Sequence[Document]:
     # Build a deduplicated list of documents with the max score
     # of all chunks associated with the document.
     documents_with_scores: list[DocumentWithMaxScore] = []
     for chunk_with_score in chunks_with_scores:
-        if chunk_with_score.score >= docs_shown_min_score:
+        if chunk_with_score.score >= chunks_shown_min_score:
             document = chunk_with_score.chunk.document
             existing_doc = next(
                 (d for d in documents_with_scores if d.document == document),
@@ -74,17 +74,17 @@ def _get_bem_documents_to_show(
     # Sort the list by score
     documents_with_scores.sort(key=lambda d: d.max_score, reverse=True)
 
-    # Only return the top docs_shown_max_num documents
-    return [d.document for d in documents_with_scores[:docs_shown_max_num]]
+    # Only return the top chunks_shown_max_num documents
+    return [d.document for d in documents_with_scores[:chunks_shown_max_num]]
 
 
 def format_bem_documents(
-    docs_shown_max_num: int,
-    docs_shown_min_score: float,
+    chunks_shown_max_num: int,
+    chunks_shown_min_score: float,
     chunks_with_scores: Sequence[ChunkWithScore],
 ) -> str:
     documents = _get_bem_documents_to_show(
-        docs_shown_max_num, docs_shown_min_score, chunks_with_scores
+        chunks_shown_max_num, chunks_shown_min_score, chunks_with_scores
     )
     formatted_documents = "".join([f"<li>{document.name}</li>" for document in documents])
     return f"<h3>Source(s)</h3><ul>{formatted_documents}</ul>"

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -25,7 +25,7 @@ def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enabl
 
     chunks_with_scores = _get_chunks_with_scores()
     html = format_guru_cards(
-        docs_shown_max_num=2, docs_shown_min_score=0.0, chunks_with_scores=chunks_with_scores
+        chunks_shown_max_num=2, chunks_shown_min_score=0.0, chunks_with_scores=chunks_with_scores
     )
     assert len(_unique_accordion_ids(html)) == len(chunks_with_scores)
     assert "Related Guru cards" in html
@@ -37,7 +37,7 @@ def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enabl
 
     # Check that a second call doesn't re-use the IDs
     next_html = format_guru_cards(
-        docs_shown_max_num=2, docs_shown_min_score=0.0, chunks_with_scores=chunks_with_scores
+        chunks_shown_max_num=2, chunks_shown_min_score=0.0, chunks_with_scores=chunks_with_scores
     )
     assert len(_unique_accordion_ids(html + next_html)) == 2 * len(chunks_with_scores)
 
@@ -50,16 +50,18 @@ def _chunks_with_scores():
     ]
 
 
-def test_format_guru_cards_given_docs_shown_max_num():
+def test_format_guru_cards_given_chunks_shown_max_num():
     html = format_guru_cards(
-        docs_shown_max_num=2, docs_shown_min_score=0.8, chunks_with_scores=_chunks_with_scores()
+        chunks_shown_max_num=2, chunks_shown_min_score=0.8, chunks_with_scores=_chunks_with_scores()
     )
     assert len(_unique_accordion_ids(html)) == 2
 
 
-def test_format_guru_cards_given_docs_shown_max_num_and_min_score():
+def test_format_guru_cards_given_chunks_shown_max_num_and_min_score():
     html = format_guru_cards(
-        docs_shown_max_num=2, docs_shown_min_score=0.91, chunks_with_scores=_chunks_with_scores()
+        chunks_shown_max_num=2,
+        chunks_shown_min_score=0.91,
+        chunks_with_scores=_chunks_with_scores(),
     )
     assert len(_unique_accordion_ids(html)) == 1
 
@@ -68,14 +70,14 @@ def test_format_bem_documents():
     docs = DocumentFactory.build_batch(4)
 
     chunks_with_scores = [
-        # This document is ignored because below docs_shown_min_score
+        # This document is ignored because below chunks_shown_min_score
         ChunkWithScore(ChunkFactory.build(document=docs[0]), 0.90),
-        # This document is excluded because docs_shown_max_num = 2,
+        # This document is excluded because chunks_shown_max_num = 2,
         # and it has the lowest score of the three documents with chunks over
-        # the docs_shown_min_score threshold
+        # the chunks_shown_min_score threshold
         ChunkWithScore(ChunkFactory.build(document=docs[1]), 0.92),
         # This document is included because a chunk puts
-        # it over the docs_shown_min_score threshold
+        # it over the chunks_shown_min_score threshold
         ChunkWithScore(ChunkFactory.build(document=docs[2]), 0.90),
         ChunkWithScore(ChunkFactory.build(document=docs[2]), 0.93),
         # This document is included, but only once
@@ -85,6 +87,6 @@ def test_format_bem_documents():
     ]
 
     html = format_bem_documents(
-        docs_shown_max_num=2, docs_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
+        chunks_shown_max_num=2, chunks_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
     assert html == f"<h3>Source(s)</h3><ul><li>{docs[3].name}</li><li>{docs[2].name}</li></ul>"


### PR DESCRIPTION
## Ticket

https://nava.slack.com/archives/C06DP498D1D/p1723490546680209

## Changes

- Rename `docs_shown_*` variable to `chunks_shown_*` to avoid confusion with `Document` DB entities
- Update their description in the UI

## Testing

No behavior change.