### PR TITLE
feature: Log metadata for retrieved chunks

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -9,6 +9,7 @@ import src.adapters.db as db
 import tests.src.db.models.factories as factories
 from src.app_config import AppConfig
 from src.db import models
+from src.db.models.document import ChunkWithScore
 from src.util.local import load_local_env_vars
 from tests.lib import db_testing
 from tests.mock.mock_sentence_transformer import MockSentenceTransformer
@@ -156,3 +157,12 @@ def mock_s3_bucket_resource(mock_s3):
 @pytest.fixture
 def mock_s3_bucket(mock_s3_bucket_resource):
     yield mock_s3_bucket_resource.name
+
+
+@pytest.fixture
+def chunks_with_scores():
+    return [
+        ChunkWithScore(factories.ChunkFactory.build(), 0.99),
+        ChunkWithScore(factories.ChunkFactory.build(), 0.90),
+        ChunkWithScore(factories.ChunkFactory.build(), 0.85),
+    ]

--- a/app/tests/src/test_chainlit.py
+++ b/app/tests/src/test_chainlit.py
@@ -1,4 +1,5 @@
 from src import chainlit, chat_engine
+from src.chainlit import _get_retrieval_metadata
 
 
 def test_url_query_values(monkeypatch):
@@ -16,3 +17,25 @@ def test_url_query_values(monkeypatch):
     # Only 1 query parameter remains
     assert len(query_values) == 1
     assert query_values["someunknownparam"] == "42"
+
+
+def test__get_retrieval_metadata(chunks_with_scores):
+    assert _get_retrieval_metadata(chunks_with_scores) == {
+        "chunks": [
+            {
+                "document.name": chunks_with_scores[0].chunk.document.name,
+                "chunk.id": chunks_with_scores[0].chunk.id,
+                "score": chunks_with_scores[0].score,
+            },
+            {
+                "document.name": chunks_with_scores[1].chunk.document.name,
+                "chunk.id": chunks_with_scores[1].chunk.id,
+                "score": chunks_with_scores[1].score,
+            },
+            {
+                "document.name": chunks_with_scores[2].chunk.document.name,
+                "chunk.id": chunks_with_scores[2].chunk.id,
+                "score": chunks_with_scores[2].score,
+            },
+        ]
+    }

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -42,26 +42,18 @@ def test_format_guru_cards_with_score(monkeypatch, app_config, db_session, enabl
     assert len(_unique_accordion_ids(html + next_html)) == 2 * len(chunks_with_scores)
 
 
-def _chunks_with_scores():
-    return [
-        ChunkWithScore(ChunkFactory.build(), 0.99),
-        ChunkWithScore(ChunkFactory.build(), 0.90),
-        ChunkWithScore(ChunkFactory.build(), 0.85),
-    ]
-
-
-def test_format_guru_cards_given_chunks_shown_max_num():
+def test_format_guru_cards_given_chunks_shown_max_num(chunks_with_scores):
     html = format_guru_cards(
-        chunks_shown_max_num=2, chunks_shown_min_score=0.8, chunks_with_scores=_chunks_with_scores()
+        chunks_shown_max_num=2, chunks_shown_min_score=0.8, chunks_with_scores=chunks_with_scores
     )
     assert len(_unique_accordion_ids(html)) == 2
 
 
-def test_format_guru_cards_given_chunks_shown_max_num_and_min_score():
+def test_format_guru_cards_given_chunks_shown_max_num_and_min_score(chunks_with_scores):
     html = format_guru_cards(
         chunks_shown_max_num=2,
         chunks_shown_min_score=0.91,
-        chunks_with_scores=_chunks_with_scores(),
+        chunks_with_scores=chunks_with_scores,
     )
     assert len(_unique_accordion_ids(html)) == 1
 

--- a/app/tests/src/test_generate.py
+++ b/app/tests/src/test_generate.py
@@ -2,10 +2,8 @@ import os
 
 import ollama
 
-from src.db.models.document import ChunkWithScore
 from src.generate import PROMPT, generate, get_models
 from tests.mock import mock_completion
-from tests.src.db.models.factories import ChunkFactory
 
 
 def ollama_model_list():
@@ -113,13 +111,13 @@ def test_generate(monkeypatch):
     assert generate("gpt-4o", "some query") == expected_response
 
 
-def test_generate_with_context_with_score(monkeypatch):
+def test_generate_with_context_with_score(monkeypatch, chunks_with_scores):
     monkeypatch.setattr("src.generate.completion", mock_completion.mock_completion)
-    context = [
-        ChunkWithScore(ChunkFactory.build(), 0.2000),
-        ChunkWithScore(ChunkFactory.build(), -0.3000),
-    ]
-    context_text = f"{context[0].chunk.document.name}\n{context[0].chunk.content}\n\n{context[1].chunk.document.name}\n{context[1].chunk.content}"
+    context_text = (
+        f"{chunks_with_scores[0].chunk.document.name}\n{chunks_with_scores[0].chunk.content}\n\n"
+        + f"{chunks_with_scores[1].chunk.document.name}\n{chunks_with_scores[1].chunk.content}\n\n"
+        + f"{chunks_with_scores[2].chunk.document.name}\n{chunks_with_scores[2].chunk.content}"
+    )
     expected_response = (
         'Called gpt-4o with [{"content": "'
         + PROMPT
@@ -127,4 +125,4 @@ def test_generate_with_context_with_score(monkeypatch):
         + context_text
         + '", "role": "system"}, {"content": "some query", "role": "user"}]'
     )
-    assert generate("gpt-4o", "some query", context=context) == expected_response
+    assert generate("gpt-4o", "some query", context=chunks_with_scores) == expected_response


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-373


## Changes
 - Log each retrieved chunk's document name, ID, and similarity score to the query in the metadata for Chainlit


## Context for reviewers
 - n/a

## Testing
Removing the cast to str for settings is safe:
<img width="413" alt="image" src="https://github.com/user-attachments/assets/acbf149d-439f-4549-9414-dc36f2e89e52">

Metadata in LiteralAI dashboard:
<img width="714" alt="image" src="https://github.com/user-attachments/assets/89eee446-8f6a-42f3-87ee-29468db57330">
