### PR TITLE
bug: citation duplicates and accordion overflow

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -169,7 +169,7 @@ def _get_retrieval_metadata(chunks_with_scores: Sequence[ChunkWithScore]) -> dic
         "chunks": [
             {
                 "document.name": chunk_with_score.chunk.document.name,
-                "chunk.id": chunk_with_score.chunk.id,
+                "chunk.id": str(chunk_with_score.chunk.id),
                 "score": chunk_with_score.score,
             }
             for chunk_with_score in chunks_with_scores

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -103,8 +103,8 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
         internal_citation = ""
         _accordion_id += 1
         for index, chunk in enumerate(documents[document], start=1):
-            formatted_chunk = chunk.chunk.content.splitlines()
-            formatted_chunk = " ".join(formatted_chunk)
+            chunk_lines = chunk.chunk.content.splitlines()
+            formatted_chunk = " ".join(chunk_lines)
             formatted_chunk = re.sub(r"\t+", "", formatted_chunk).strip()
             formatted_chunk = f"<p>{formatted_chunk} </p>" if formatted_chunk else ""
             citation = f"<h4>Citation #{index} (score: {str(chunk.score)})</h4>"

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -103,7 +103,9 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
         internal_citation = ""
         _accordion_id += 1
         for index, chunk in enumerate(documents[document], start=1):
-            formatted_chunk = re.sub(r"\n+", "\n", chunk.chunk.content).strip()
+            formatted_chunk = chunk.chunk.content.splitlines()
+            formatted_chunk = " ".join(formatted_chunk)
+            formatted_chunk = re.sub(r"\t+", "", formatted_chunk).strip()
             formatted_chunk = f"<p>{formatted_chunk} </p>" if formatted_chunk else ""
             citation = f"<h4>Citation #{index} (score: {str(chunk.score)})</h4>"
             similarity_score = f"<p>Similarity Score: {str(chunk.score)}</p>"

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -99,8 +99,8 @@ def _format_to_accordion_html(document: Document, score: float) -> str:
 def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkWithScore]]) -> str:
     global _accordion_id
     html = ""
-    internal_citation = ""
     for document in documents:
+        internal_citation = ""
         _accordion_id += 1
         for index, chunk in enumerate(documents[document], start=1):
             formatted_chunk = re.sub(r"\n+", "\n", chunk.chunk.content).strip()

--- a/app/tests/src/test_chainlit.py
+++ b/app/tests/src/test_chainlit.py
@@ -24,17 +24,17 @@ def test__get_retrieval_metadata(chunks_with_scores):
         "chunks": [
             {
                 "document.name": chunks_with_scores[0].chunk.document.name,
-                "chunk.id": chunks_with_scores[0].chunk.id,
+                "chunk.id": str(chunks_with_scores[0].chunk.id),
                 "score": chunks_with_scores[0].score,
             },
             {
                 "document.name": chunks_with_scores[1].chunk.document.name,
-                "chunk.id": chunks_with_scores[1].chunk.id,
+                "chunk.id": str(chunks_with_scores[1].chunk.id),
                 "score": chunks_with_scores[1].score,
             },
             {
                 "document.name": chunks_with_scores[2].chunk.document.name,
-                "chunk.id": chunks_with_scores[2].chunk.id,
+                "chunk.id": str(chunks_with_scores[2].chunk.id),
                 "score": chunks_with_scores[2].score,
             },
         ]

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -93,9 +93,10 @@ def test_format_bem_documents():
         chunks_shown_max_num=2, chunks_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
 
-    assert docs[0].content not in html
-    assert docs[1].content not in html
-    assert docs[3].content in html
+    print(html)
+    assert docs[0].content.replace("\n", " ") not in html
+    assert docs[1].content.replace("\n", " ") not in html
+    assert docs[3].content.replace("\n", " ") in html
     assert "Citation #2" in html
     assert "Citation #3" not in html
     assert "<p>Similarity Score: 0.95</p>" in html

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -93,7 +93,6 @@ def test_format_bem_documents():
         chunks_shown_max_num=2, chunks_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
 
-    print(html)
     assert docs[0].content.replace("\n", " ") not in html
     assert docs[1].content.replace("\n", " ") not in html
     assert docs[3].content.replace("\n", " ") in html


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-399 


## Changes
> added internal citation to inside of loop to avoid dups
> adjusted substitution code for line breaks 

## Testing

<img width="821" alt="Screenshot 2024-08-13 at 12 38 18 PM" src="https://github.com/user-attachments/assets/94e7d3a2-b590-411f-85eb-7180a513a34e">
<img width="800" alt="Screenshot 2024-08-13 at 12 38 12 PM" src="https://github.com/user-attachments/assets/fb196b0c-5faa-4bac-92fc-349d5683acc2">
<img width="800" alt="Screenshot 2024-08-13 at 12 36 39 PM" src="https://github.com/user-attachments/assets/c5514b7a-1ceb-4db0-82f6-55a4005a2b35">

Navigate to http://localhost:8000/chat/?engine=bridges-eligibility-manual
Adjust min citation params to -1
Queries to test
- This client's grandmother just moved in, how do they add them to the case?
- Client lives with a roommate, can they get SNAP separately?