### PR TITLE
fix: Merge list items only if they have the same heading

### DIFF
--- a/app/src/ingestion/get_grouped_texts.py
+++ b/app/src/ingestion/get_grouped_texts.py
@@ -6,6 +6,9 @@ logger = logging.getLogger(__name__)
 
 
 def should_merge_list_text(text: EnrichedText, next_text: EnrichedText) -> bool:
+    if text.headings != next_text.headings:
+        return False
+
     if next_text.type != TextType.LIST_ITEM:
         return False
 
@@ -33,14 +36,6 @@ def get_grouped_texts(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:
             # Append the current text to the previous one
             previous_text.text += "\n" + current_text.text
             previous_text.type = TextType.LIST
-
-            # Headings should match for list items
-            if current_text.headings != previous_text.headings:
-                logger.warning(
-                    "Warning: Headings don't match for list items: %s %s",
-                    previous_text.text,
-                    current_text.text,
-                )
         else:
             # If it's not merged, just add it as a new element
             grouped_texts.append(current_text)

--- a/app/tests/src/ingestion/test_get_grouped_texts.py
+++ b/app/tests/src/ingestion/test_get_grouped_texts.py
@@ -56,6 +56,11 @@ def test_concatenate_list_items():
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Overview", level=1)],
         ),
+        EnrichedText(
+            text="New list item in new section.",
+            type=TextType.LIST_ITEM,
+            headings=[Heading(title="Section 1", level=1)],
+        ),
     ]
 
     result = get_grouped_texts(texts)
@@ -80,5 +85,10 @@ def test_concatenate_list_items():
             text="Narrative starting a new list: \nFirst item in new list.\nSecond item in new list.",
             type=TextType.LIST,
             headings=[Heading(title="Overview", level=1)],
+        ),
+        EnrichedText(
+            text="New list item in new section.",
+            type=TextType.LIST_ITEM,
+            headings=[Heading(title="Section 1", level=1)],
         ),
     ]


### PR DESCRIPTION

## Changes

Merge list items only if they have the same heading, instead of logging a warning when they have different headings.

## Testing

Updated test_concatenate_list_items() to include LIST_ITEM in new heading that should not be merged.