### PR TITLE
feat: Utility to extract bolded text from PDFs

### DIFF
--- a/app/src/ingestion/pdf_stylings.py
+++ b/app/src/ingestion/pdf_stylings.py
@@ -261,7 +261,7 @@ class OutlineAwarePdfParser:
             raise e
 
     def _create_extracted_text(self, elem: Element) -> ExtractedText | None:
-        assert self.parsing_context.pageno, "pageno should be set at this point"
+        assert self.parsing_context.parano, "parano should be set at this point"
         if elem.tagName == "Artifact":
             if elem.getAttribute("Type") == "/'Pagination'":
                 subtype = elem.getAttribute("Subtype")

--- a/app/src/ingestion/pdf_stylings.py
+++ b/app/src/ingestion/pdf_stylings.py
@@ -173,7 +173,7 @@ class ParsingContext:
 
     def create_extracted_text(self, phrases: list[Phrase]) -> ExtractedText:
         assert self._zone, "zone is not set"
-        assert self.parano, "parano should be set at this point"
+        assert self.parano is not None, "parano should be set at this point"
         return ExtractedText(
             pageno=self.pageno,
             zone=self._zone,
@@ -236,6 +236,7 @@ class OutlineAwarePdfParser:
                 self.parsing_context.pageno = int(page_node.getAttribute("id")) + 1
                 assert self.parsing_context.pageno
                 logger.info("Processing page %i", self.parsing_context.pageno)
+                self.parsing_context.parano = 0
 
                 for page_elem in page_node.childNodes:
                     if isinstance(page_elem, Element):
@@ -261,7 +262,7 @@ class OutlineAwarePdfParser:
             raise e
 
     def _create_extracted_text(self, elem: Element) -> ExtractedText | None:
-        assert self.parsing_context.parano, "parano should be set at this point"
+        assert self.parsing_context.parano is not None, "parano should be set at this point"
         if elem.tagName == "Artifact":
             if elem.getAttribute("Type") == "/'Pagination'":
                 subtype = elem.getAttribute("Subtype")

--- a/app/src/ingestion/pdf_stylings.py
+++ b/app/src/ingestion/pdf_stylings.py
@@ -234,7 +234,7 @@ class OutlineAwarePdfParser:
         try:
             for page_node in root.getElementsByTagName("page"):
                 self.parsing_context.pageno = int(page_node.getAttribute("id")) + 1
-                assert self.parsing_context.parano
+                assert self.parsing_context.pageno
                 logger.info("Processing page %i", self.parsing_context.pageno)
 
                 for page_elem in page_node.childNodes:
@@ -261,7 +261,7 @@ class OutlineAwarePdfParser:
             raise e
 
     def _create_extracted_text(self, elem: Element) -> ExtractedText | None:
-        assert self.parsing_context.parano, "parano should be set at this point"
+        assert self.parsing_context.pageno, "pageno should be set at this point"
         if elem.tagName == "Artifact":
             if elem.getAttribute("Type") == "/'Pagination'":
                 subtype = elem.getAttribute("Subtype")

--- a/app/src/ingestion/pdf_stylings.py
+++ b/app/src/ingestion/pdf_stylings.py
@@ -117,7 +117,7 @@ class ParsingContext:
 
     # Paragraph number of the current text starting from 1 after each heading
     # Paragraph number is 0 for headings
-    parano: int = -1
+    parano: int | None = None
 
     _zone: PageZone | None = None
 
@@ -173,6 +173,7 @@ class ParsingContext:
 
     def create_extracted_text(self, phrases: list[Phrase]) -> ExtractedText:
         assert self._zone, "zone is not set"
+        assert self.parano, "parano should be set at this point"
         return ExtractedText(
             pageno=self.pageno,
             zone=self._zone,
@@ -233,6 +234,7 @@ class OutlineAwarePdfParser:
         try:
             for page_node in root.getElementsByTagName("page"):
                 self.parsing_context.pageno = int(page_node.getAttribute("id")) + 1
+                assert self.parsing_context.parano
                 logger.info("Processing page %i", self.parsing_context.pageno)
 
                 for page_elem in page_node.childNodes:
@@ -259,6 +261,7 @@ class OutlineAwarePdfParser:
             raise e
 
     def _create_extracted_text(self, elem: Element) -> ExtractedText | None:
+        assert self.parsing_context.parano, "parano should be set at this point"
         if elem.tagName == "Artifact":
             if elem.getAttribute("Type") == "/'Pagination'":
                 subtype = elem.getAttribute("Subtype")

--- a/app/src/util/pdf_tag_extractor.py
+++ b/app/src/util/pdf_tag_extractor.py
@@ -1,0 +1,395 @@
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from io import BytesIO
+from pprint import pprint
+from typing import BinaryIO, Optional
+from xml.dom import minidom
+from xml.dom.minidom import Element, Text
+
+from pdfminer.pdfcolor import PDFColorSpace
+from pdfminer.pdfdevice import PDFTextSeq, TagExtractor
+from pdfminer.pdfdocument import PDFDocument
+from pdfminer.pdfinterp import (
+    PDFGraphicState,
+    PDFPageInterpreter,
+    PDFResourceManager,
+    PDFStackT,
+    PDFTextState,
+)
+from pdfminer.pdfpage import PDFPage
+from pdfminer.psparser import PSLiteral
+
+from src.util.pdf_utils import Heading, as_pdf_doc, extract_outline, get_pdf_info
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Styling:
+    # The text with the style
+    text: str
+
+    # Page number where the styled text is located
+    pageno: int
+    # Nested parent headings where the styled text is located
+    headings: list[Heading]
+    # Other text before and after the styled text to help find the correct occurrence of the text
+    wider_text: str
+
+    # Style attributes
+    bold: bool = False
+
+
+def extract_stylings(pdf: BinaryIO | PDFDocument) -> list[Styling]:
+    parser = OutlineAwarePdfParser(pdf, BemTagExtractor)
+    xml_string = parser.extract_xml()
+    # len(xml_string.splitlines())
+    annotated_texts = parser.flatten_xml(xml_string)
+
+    stylings: list[Styling] = []
+    for _i, an_text in enumerate(annotated_texts):
+        # if an_text.pageno not in [2, 9]:
+        #     continue
+
+        join_phrases = " ".join([p.text for p in an_text.phrases])
+        wider_text = "_______________" if an_text.is_heading() else join_phrases
+        print(an_text, wider_text[:100])
+        for _phrase in an_text.phrases:
+            styling = Styling(
+                text=_phrase.text,
+                pageno=an_text.pageno,
+                headings=an_text.headings,
+                wider_text=wider_text,
+                bold=_phrase.bold,
+            )
+
+            if _phrase.bold:
+                stylings.append(styling)
+            # if _phrase.span:
+            #     stylings.append(styling)
+    return stylings
+
+
+class PageZone(Enum):
+    HEADER = "HEADER"
+    MAIN = "MAIN"
+    FOOTER = "FOOTER"
+
+
+@dataclass
+class Phrase:
+    "Phrase is a piece of text with optional styling. It is a part of a paragraph (ExtractedText)."
+    text: str
+    bold: bool = False
+    span: bool = False
+
+
+@dataclass
+class ExtractedText:
+    pageno: int
+    zone: PageZone
+    headings: list[Heading]
+    parano: int
+    phrases: list[Phrase]
+
+    def is_heading(self) -> bool:
+        return self.parano == 0
+
+    def __str__(self) -> str:
+        if self.is_heading() and self.headings:
+            last_heading = f"{self.headings[-1].level}:{self.headings[-1].title}"
+            return f"{self.pageno}.{self.parano} {last_heading}"
+        elif self.zone == PageZone.MAIN:
+            return f"  {self.pageno}.{self.parano} {self.zone}"
+        else:
+            return f"({self.pageno} {self.zone})"
+
+
+@dataclass
+class ParsingContext:
+    # Used to find headings in the PDF
+    heading_stack: list[Heading]
+
+    # The headings for the current text
+    parent_headings: list[Heading] = field(default_factory=list)
+
+    # Current page number
+    pageno: int = 0
+
+    # Paragraph number of the current text starting from 1 after each heading
+    # Paragraph number is 0 for headings
+    parano: int = -1
+
+    _zone: PageZone | None = None
+
+    def is_next_heading(self, phrases: list[Phrase]) -> Heading | None:
+        # If there are no headings left, it's not a heading
+        if not self.heading_stack:
+            return None
+
+        # Headings are expected to be the only text on the line or in a paragraph
+        if len(phrases) != 1:
+            return None
+
+        # Headings are almost always bold
+        phrase = phrases[0]
+        if not phrase.bold:
+            return None
+
+        # Page number should match that of the headings from the PDF outline
+        next_heading = self.heading_stack[-1]
+        if next_heading.pageno != self.pageno:
+            return None
+
+        # Use casefold() to make case-insensitive comparison
+        if phrase.text.strip().casefold() == next_heading.title.casefold():
+            return next_heading
+
+        return None
+
+    def set_next_heading(self) -> None:
+        next_heading = self.heading_stack.pop()
+        level = next_heading.level
+
+        # Update the parent_headings list with the new heading
+        if level > len(self.parent_headings):  # new subheading
+            self.parent_headings.append(next_heading)
+        else:
+            # Pop all subheadings (if any) until we reach level
+            while level < len(self.parent_headings):
+                self.parent_headings.pop()
+
+            # Then set the current heading
+            self.parent_headings[-1] = next_heading
+        assert level == len(self.parent_headings)
+
+        # Reset the paragraph number
+        self.parano = 0
+
+    @contextmanager
+    def page_zone_context(self, zone: PageZone):
+        self._zone = zone
+        yield
+        self._zone = None
+
+    def create_extracted_text(self, phrases: list[Phrase]) -> ExtractedText:
+        assert self._zone, "zone is not set"
+        return ExtractedText(
+            pageno=self.pageno,
+            zone=self._zone,
+            headings=self.parent_headings.copy(),
+            parano=self.parano,
+            phrases=phrases,
+        )
+
+
+class OutlineAwarePdfParser:
+    """"""
+
+    def __init__(self, pdf: BinaryIO | PDFDocument, tag_extractor_class):
+        self.tag_extractor_class = tag_extractor_class
+        self.disable_caching: bool = False
+        self.doc = as_pdf_doc(pdf)
+
+        # Get the PDF outline containing headings.
+        # We'll use it to find headings in the text as the PDF is processed.
+        self.parsing_context = ParsingContext(list(reversed(extract_outline(self.doc))))
+
+    # Adapted from pdfminer.high_level.py:extract_text_to_fp() used in pdf2txt.py
+    def _create_interpreter(
+        self, output_io: BytesIO, output_codec: str = "utf-8"
+    ) -> PDFPageInterpreter:
+        rsrcmgr = PDFResourceManager(caching=not self.disable_caching)
+        pdf_device = self.tag_extractor_class(rsrcmgr, outfp=output_io, codec=output_codec)
+        return PDFPageInterpreter(rsrcmgr, pdf_device)
+
+    def extract_xml(self, validate_xml: bool = False) -> str:
+        "Stage 1: Generate XML from the PDF using custom tag_extractor_class"
+        output_io = BytesIO()
+        interpreter = self._create_interpreter(output_io)
+        for page in PDFPage.create_pages(self.doc):
+            # As the interpreter reads the PDF, it will call methods on interpreter.device,
+            # which will write to output_io
+            interpreter.process_page(page)
+
+        # After done writing to output_io, go back to the beginning so we can read() it
+        output_io.seek(0)
+        # Wrap all tags in a root tag
+        xml_string = "<pdf>" + output_io.read().decode() + "</pdf>"
+
+        if validate_xml:
+            minidom.parseString(xml_string)  # nosec
+
+        return xml_string
+
+    def flatten_xml(self, xml_string: str) -> list[ExtractedText]:
+        "Stage 2: Flatten the extracted XML into ExtractedText"
+        pdf_info = get_pdf_info(self.doc, count_pages=True)
+        xml_doc = minidom.parseString(xml_string)  # nosec
+        root = xml_doc.documentElement
+        result: list[ExtractedText] = []
+        try:
+            for page_node in root.getElementsByTagName("page"):
+                self.parsing_context.pageno = int(page_node.getAttribute("id")) + 1
+                logger.info("Processing page %i", self.parsing_context.pageno)
+
+                for page_elem in page_node.childNodes:
+                    if isinstance(page_elem, Element):
+                        # An Element represents an XML tag
+                        if annotated_text := self._create_extracted_text(page_elem):
+                            result.append(annotated_text)
+                    elif isinstance(page_elem, Text):
+                        # A Text represents text content of an XML tag
+                        # When text is not wrapped in a <P> tag (eg, 210.pdf)
+                        with self.parsing_context.page_zone_context(PageZone.MAIN):
+                            if phrase := self._create_phrase(None, page_elem):
+                                self.parsing_context.parano += 1
+                                result.append(self.parsing_context.create_extracted_text([phrase]))
+
+            # Check that we've found all headings from the PDF outline
+            assert len(self.parsing_context.heading_stack) == 0, self.parsing_context.heading_stack
+            # Check that we've reached the last page
+            assert self.parsing_context.pageno == pdf_info.page_count
+            return result
+        except Exception as e:
+            print("Error processing XML:", pdf_info.title)
+            pprint(self.parsing_context)
+            raise e
+
+    def _create_extracted_text(self, elem: Element) -> ExtractedText | None:
+        if elem.tagName == "Artifact":
+            if elem.getAttribute("Type") == "/'Pagination'":
+                subtype = elem.getAttribute("Subtype")
+                if subtype == "/'Header'":
+                    return self._extract_text_in_zone(elem, PageZone.HEADER)
+                if subtype == "/'Footer'":
+                    return self._extract_text_in_zone(elem, PageZone.FOOTER)
+
+            logger.info("Ignoring Artifact: %s", elem.toxml())
+            return None
+
+        if elem.tagName == "P":
+            self.parsing_context.parano += 1
+
+        if elem.tagName in ["P", "BOLD", "Span"]:
+            return self._extract_text_in_zone(elem, PageZone.MAIN)
+
+        raise NotImplementedError(f"Unhandled top-level element: {elem.toxml()}")
+
+    def _extract_text_in_zone(self, elem: Element, zone: PageZone) -> ExtractedText | None:
+        "Create ExtractedTExt from top-level element on a page"
+        with self.parsing_context.page_zone_context(zone):
+            phrases: list[Phrase] = self._extract_phrases(elem)
+
+            if zone == PageZone.MAIN:
+                # Check for headings and update the parsing context
+                if self.parsing_context.is_next_heading(phrases):
+                    self.parsing_context.set_next_heading()
+
+            return self.parsing_context.create_extracted_text(phrases)
+
+    def _extract_phrases(self, elem: Element) -> list[Phrase]:
+        "Extract Phrases from lower-level (non-top-level) elements"
+        phrases: list[Phrase] = []
+        for child_node in elem.childNodes:
+            if isinstance(child_node, Element):
+                # Recurse and flatten the XML structure
+                phrases += self._extract_phrases(child_node)
+            elif isinstance(child_node, Text):
+                if phrase := self._create_phrase(elem, child_node):
+                    phrases.append(phrase)
+            else:
+                raise NotImplementedError(
+                    f"Unexpected elem: {type(child_node)}, {self.parsing_context}"
+                )
+        return phrases
+
+    def _create_phrase(self, parent_node: Element | None, child: Text) -> Phrase | None:
+        # Ignore whitespace
+        if not (child.data.strip()):
+            return None
+
+        bolded = bool(parent_node and parent_node.tagName == "BOLD")
+        spanned = bool(parent_node and parent_node.tagName == "Span")
+        # <Span> usually reflect a hyperlink; the child.data string is the hyperlinked words
+        # Refer to "Exploring hyperlink identification" section of https://github.com/navapbc/labs-decision-support-tool/blob/main/app/notebooks/pdfminer-exploration/pdfminer_extract_json.ipynb
+
+        return Phrase(text=child.data, bold=bolded, span=spanned)
+
+
+class BemTagExtractor(TagExtractor):
+    """
+    Methods in this class are called by the PDFPageInterpreter as it reads the PDF.
+    Adapted from pdfminer.pdfdevice.TagExtractor used by
+        pdfminer.high_level.py:extract_text_to_fp(), which is used in pdf2txt.py.
+    This class will write XML to the specified outfp.
+
+    do_*() methods refer to PDF Operators: https://pdfa.org/wp-content/uploads/2023/08/PDF-Operators-CheatSheet.pdf
+
+    """
+
+    def __init__(self, rsrcmgr: PDFResourceManager, outfp: BinaryIO, codec: str = "utf-8") -> None:
+        super().__init__(rsrcmgr, outfp, codec)
+
+        # Added the following in order to add the BOLD tag.
+        # This reflects the last fontname used for a given tag level
+        self._last_fontname_stack: list[str] = [""]
+
+    def render_string(
+        self,
+        textstate: PDFTextState,
+        seq: PDFTextSeq,
+        ncs: PDFColorSpace,
+        graphicstate: PDFGraphicState,
+    ) -> None:
+        "render_string() is called multiple times between each begin_tag() completion and before end_tag()"
+        font = textstate.font
+        assert font is not None
+
+        last_fontname = self._last_fontname_stack[-1]
+        if last_fontname != font.fontname:
+            if "Bold" in font.fontname and (not last_fontname or "Bold" not in last_fontname):
+                self._write("<BOLD>")
+            elif "Bold" in last_fontname and "Bold" not in font.fontname:
+                self._write("</BOLD>")
+        self._last_fontname_stack[-1] = font.fontname
+
+        # Following is copied from pdfminer.pdfdevice.TagExtractor.render_string()
+        super().render_string(textstate, seq, ncs, graphicstate)
+
+    def begin_tag(self, tag: PSLiteral, props: Optional[PDFStackT] = None) -> None:
+        # Workaround for Span tags that are not closed properly
+        # (i.e., BEM 101.pdf, 105.pdf, 203.pdf, 225.pdf, 400.pdf)
+        if self._stack and self._stack[-1].name == "Span":
+            self._stack.pop(-1)
+            self._write("</Span>")
+
+        self._last_fontname_stack.append("")
+
+        super().begin_tag(tag, props)
+
+    def end_tag(self) -> None:
+        if "Bold" in self._last_fontname_stack[-1]:
+            self._write("</BOLD>")
+
+        self._last_fontname_stack.pop(-1)
+
+        if not self._stack:
+            logger.warning(
+                "page %i: end_tag without matching begin_tag (ie, empty tag stack!); ignoring",
+                self.pageno,
+            )
+            return
+
+        super().end_tag()
+
+
+if __name__ == "__main__":
+    # logging.basicConfig(level=logging.DEBUG)
+    pdf_filename = "notebooks/bem_pdfs/100.pdf"
+    with open(pdf_filename, "rb") as fp:
+        _stylings = extract_stylings(fp)
+    print("===============")
+    # pprint(_stylings)

--- a/app/tests/src/ingestion/test_pdf_stylings.py
+++ b/app/tests/src/ingestion/test_pdf_stylings.py
@@ -38,11 +38,11 @@ all_expected_stylings = [
         bold=True,
     ),
     Styling(
-        text="CDC penalty period has ended. See BEM 704 for re-enroll-ment " "requirements.",
+        text="CDC penalty period has ended. See BEM 704 for re-enroll-ment requirements.",
         pageno=4,
         headings=[
             Heading(
-                title="Enrollment of a Provider after the Penalty " "Period has ended",
+                title="Enrollment of a Provider after the Penalty Period has ended",
                 level=1,
                 pageno=4,
             )

--- a/app/tests/src/ingestion/test_pdf_stylings.py
+++ b/app/tests/src/ingestion/test_pdf_stylings.py
@@ -1,0 +1,62 @@
+from src.ingestion.pdf_elements import Heading
+from src.ingestion.pdf_stylings import Styling, extract_stylings
+
+
+def test_extract_styles():
+    with open("/app/tests/src/util/707.pdf", "rb") as fp:
+        _stylings = extract_stylings(fp)
+
+    assert _stylings == all_expected_stylings
+
+
+all_expected_stylings = [
+    Styling(
+        text="CDC not eligible due to 6 month penalty period",
+        pageno=3,
+        headings=[Heading(title="Disqualifications", level=1, pageno=2)],
+        wider_text="• First occurrence - six month disqualification. The "
+        "closure reason will be CDC not eligible due to 6 month "
+        "penalty period. ",
+        bold=True,
+    ),
+    Styling(
+        text="CDC not eligible due to 12 month penalty period. ",
+        pageno=3,
+        headings=[Heading(title="Disqualifications", level=1, pageno=2)],
+        wider_text="• Second occurrence - twelve month disqualification. The "
+        "closure reason will be CDC not eligible due to 12 month "
+        "penalty period. ",
+        bold=True,
+    ),
+    Styling(
+        text="CDC not eligible due to lifetime penalty. ",
+        pageno=3,
+        headings=[Heading(title="Disqualifications", level=1, pageno=2)],
+        wider_text="• Third occurrence - lifetime disqualification. The "
+        "closure reason will be CDC not eligible due to lifetime "
+        "penalty. ",
+        bold=True,
+    ),
+    Styling(
+        text="CDC penalty period has ended. See BEM 704 for re-enroll-ment " "requirements.",
+        pageno=4,
+        headings=[
+            Heading(
+                title="Enrollment of a Provider after the Penalty " "Period has ended",
+                level=1,
+                pageno=4,
+            )
+        ],
+        wider_text="When the penalty period has ended, the closure reason "
+        "will change to CDC penalty period has ended. See BEM 704 "
+        "for re-enroll-ment requirements.",
+        bold=True,
+    ),
+    Styling(
+        text="CDC ",
+        pageno=4,
+        headings=[Heading(title="legal base", level=1, pageno=4)],
+        wider_text="CDC ",
+        bold=True,
+    ),
+]


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-413

## Changes

Added `app/src/ingestion/pdf_stylings.py` to provide `extract_stylings()` function that returns a list of Styling reflecting bolded text that is not a heading and not in the header or footer. For example:
```python
    Styling(
        text="CDC not eligible due to 6 month penalty period",
        pageno=3,
        headings=[Heading(title="Disqualifications", level=1, pageno=2)],
        wider_text="• First occurrence - six month disqualification. The "
        "closure reason will be CDC not eligible due to 6 month "
        "penalty period. ",
        bold=True,
    )
```
for
<img width="963" alt="image" src="https://github.com/user-attachments/assets/60f6f861-eff6-46da-92fd-d5453ca91a94">


## Testing

Added `test_pdf_stylings.py`