### PR TITLE
feat: Merges texts that are split across consecutive pages

### DIFF
--- a/app/src/ingestion/pdf_elements.py
+++ b/app/src/ingestion/pdf_elements.py
@@ -13,6 +13,13 @@ class TextType(Enum):
 
 
 @dataclass
+class Link:
+    start_index: int
+    text: str
+    url: str
+
+
+@dataclass
 class EnrichedText:
     text: str
     type: TextType
@@ -20,3 +27,4 @@ class EnrichedText:
     page_number: int | None = None
     id: str | None = None
     stylings: List[Styling] | None = None
+    links: List[Link] | None = None

--- a/app/tests/src/ingestion/test_pdf_postprocess.py
+++ b/app/tests/src/ingestion/test_pdf_postprocess.py
@@ -1,4 +1,5 @@
 import logging
+
 from src.ingestion.pdf_elements import EnrichedText, Heading, Link, TextType
 from src.ingestion.pdf_postprocess import (
     _add_link_markdown,
@@ -21,6 +22,7 @@ def test_add_markdown():
             text="First item.",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Section 3", level=1)],
+            links=[Link(start_index=6, text="item", url="http://www.michigan.gov")],
         ),
         EnrichedText(
             text="Second item.",
@@ -48,7 +50,7 @@ def test_add_markdown():
             headings=[Heading(title="Section 3", level=1)],
         ),
         EnrichedText(
-            text="    - First item.",
+            text="    - First [item](http://www.michigan.gov).",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Section 3", level=1)],
         ),
@@ -291,9 +293,6 @@ def text_with_links():
 
 
 def test__add_link_markdown(caplog):
-    texts = text_with_links()
-    print(">>>> ", texts[0].text.index("http://www.michigan.gov"))
-    print(">>>> ", texts[1].text.index("MDHHS Policy Manuals"))
     with caplog.at_level(logging.WARNING):
         markdown_texts = [_add_link_markdown(enriched_text) for enriched_text in text_with_links()]
 

--- a/app/tests/src/ingestion/test_pdf_postprocess.py
+++ b/app/tests/src/ingestion/test_pdf_postprocess.py
@@ -1,5 +1,7 @@
-from src.ingestion.pdf_elements import EnrichedText, Heading, TextType
+import logging
+from src.ingestion.pdf_elements import EnrichedText, Heading, Link, TextType
 from src.ingestion.pdf_postprocess import (
+    _add_link_markdown,
     _apply_stylings,
     add_markdown,
     associate_stylings,
@@ -243,5 +245,81 @@ def test__apply_stylings():
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="legal base", level=1, pageno=4)],
             page_number=4,
+        ),
+    ]
+
+
+def text_with_links():
+    return [
+        EnrichedText(
+            text="Each state must submit a state plan for FIP. State plans are located at http://www.michigan.gov.",
+            type=TextType.NARRATIVE_TEXT,
+            headings=[Heading(title="Family Independence Program (FIP)", level=2, pageno=1)],
+            links=[
+                Link(start_index=72, text="http://www.michigan.gov", url="http://www.michigan.gov"),
+                Link(
+                    start_index=0,
+                    text="A substring that is not in the text",
+                    url="http://www.michigan.gov",
+                ),
+            ],
+        ),
+        EnrichedText(
+            text="The MDHHS policy manuals are available to the public at the Michigan "
+            "Department of Health and Human Services internet site under MDHHS "
+            "Policy Manuals; see BAM 310, Confidentiality, regarding the release "
+            "of specific information pertaining to clients.",
+            type=TextType.NARRATIVE_TEXT,
+            headings=[
+                Heading(title="Revisions", level=1, pageno=7),
+                Heading(title="Public Access to Manuals", level=2, pageno=7),
+            ],
+            links=[
+                Link(
+                    start_index=4,
+                    text="MDHHS policy manuals",
+                    url="http://www.michigan.gov/mdhhs",
+                ),
+                Link(
+                    start_index=129,
+                    text="MDHHS Policy Manuals",
+                    url="http://www.michigan.gov/mdhhs",
+                ),
+            ],
+        ),
+    ]
+
+
+def test__add_link_markdown(caplog):
+    texts = text_with_links()
+    print(">>>> ", texts[0].text.index("http://www.michigan.gov"))
+    print(">>>> ", texts[1].text.index("MDHHS Policy Manuals"))
+    with caplog.at_level(logging.WARNING):
+        markdown_texts = [_add_link_markdown(enriched_text) for enriched_text in text_with_links()]
+
+    assert "Link text 'A substring that is not in the text' not found in:" in caplog.messages[0]
+    assert markdown_texts == [
+        EnrichedText(
+            text="Each state must submit a state plan for FIP. State plans are located at [http://www.michigan.gov](http://www.michigan.gov).",
+            type=TextType.NARRATIVE_TEXT,
+            headings=[Heading(title="Family Independence Program (FIP)", level=2, pageno=1)],
+            links=[
+                Link(
+                    start_index=0,
+                    text="A substring that is not in the text",
+                    url="http://www.michigan.gov",
+                ),
+            ],
+        ),
+        EnrichedText(
+            text="The [MDHHS policy manuals](http://www.michigan.gov/mdhhs) are available to the public at the Michigan "
+            "Department of Health and Human Services internet site under [MDHHS "
+            "Policy Manuals](http://www.michigan.gov/mdhhs); see BAM 310, Confidentiality, regarding the release "
+            "of specific information pertaining to clients.",
+            type=TextType.NARRATIVE_TEXT,
+            headings=[
+                Heading(title="Revisions", level=1, pageno=7),
+                Heading(title="Public Access to Manuals", level=2, pageno=7),
+            ],
         ),
     ]

--- a/app/tests/src/ingestion/test_pdf_postprocess.py
+++ b/app/tests/src/ingestion/test_pdf_postprocess.py
@@ -86,41 +86,55 @@ def test_concatenate_list_items():
             text="Introduction.",
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="First item.",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="Second item.",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="Another narrative text.",
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="Narrative starting a new list: ",  # ending space is intentional
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="First item in new list.",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="Second item in new list.",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
-            text="New list item in new section.",
+            text="New list item in new section",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Section 1", level=1)],
+            page_number=1,
+        ),
+        EnrichedText(
+            text="with continuing sentence on next page",
+            type=TextType.NARRATIVE_TEXT,
+            headings=[Heading(title="Section 1", level=1)],
+            page_number=2,
         ),
     ]
 
@@ -131,26 +145,31 @@ def test_concatenate_list_items():
             text="Introduction.",
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="First item.\nSecond item.",
             type=TextType.LIST,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="Another narrative text.",
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
             text="Narrative starting a new list: \nFirst item in new list.\nSecond item in new list.",
             type=TextType.LIST,
             headings=[Heading(title="Overview", level=1)],
+            page_number=1,
         ),
         EnrichedText(
-            text="New list item in new section.",
+            text="New list item in new section with continuing sentence on next page",
             type=TextType.LIST_ITEM,
             headings=[Heading(title="Section 1", level=1)],
+            page_number=1,
         ),
     ]
 


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-425

## Changes

Added `_should_merge_text()` that merges texts (`NarrativeText` or `List`) that are split across consecutive pages

## Testing

Updated test for `group_texts()`