### PR TITLE
test: Use 707.pdf to test ingest_bem_pdfs.py

### DIFF
--- a/app/tests/src/test_ingest_bem_pdfs.py
+++ b/app/tests/src/test_ingest_bem_pdfs.py
@@ -11,25 +11,27 @@ from tests.src.test_ingest_policy_pdfs import doc_attribs
 
 @pytest.fixture
 def policy_s3_file(mock_s3_bucket_resource):
-    data = smart_open("/app/tests/docs/100.pdf", "rb")
-    mock_s3_bucket_resource.put_object(Body=data, Key="100.pdf")
+    data = smart_open("/app/tests/src/util/707.pdf", "rb")
+    mock_s3_bucket_resource.put_object(Body=data, Key="707.pdf")
     return "s3://test_bucket/"
 
 
 @pytest.mark.parametrize("file_location", ["local", "s3"])
 def test__get_bem_title(file_location, policy_s3_file):
-    file_path = policy_s3_file + "100.pdf" if file_location == "s3" else "/app/tests/docs/100.pdf"
+    file_path = (
+        policy_s3_file + "707.pdf" if file_location == "s3" else "/app/tests/src/util/707.pdf"
+    )
     with smart_open(file_path, "rb") as file:
-        assert _get_bem_title(file, file_path) == "BEM 100: INTRODUCTION"
+        assert _get_bem_title(file, file_path) == "BEM 707: TIME AND ATTENDANCE REVIEWS"
 
 
 @pytest.mark.parametrize("file_location", ["local", "s3"])
-def test__ingest_policy_pdfs(caplog, app_config, db_session, policy_s3_file, file_location):
+def test__ingest_bem_pdfs(caplog, app_config, db_session, policy_s3_file, file_location):
     db_session.execute(delete(Document))
 
     with caplog.at_level(logging.INFO):
         if file_location == "local":
-            _ingest_bem_pdfs(db_session, "/app/tests/docs/", doc_attribs)
+            _ingest_bem_pdfs(db_session, "/app/tests/src/util/", doc_attribs)
         else:
             _ingest_bem_pdfs(db_session, policy_s3_file, doc_attribs)
 
@@ -39,7 +41,7 @@ def test__ingest_policy_pdfs(caplog, app_config, db_session, policy_s3_file, fil
         assert document.program == "test_benefit_program"
         assert document.region == "Michigan"
 
-        assert document.name == "BEM 100: INTRODUCTION"
+        assert document.name == "BEM 707: TIME AND ATTENDANCE REVIEWS"
 
         # TODO: Test Document.content
         # assert "Temporary Assistance to Needy Families" in document.content


### PR DESCRIPTION
## Ticket

https://nava.slack.com/archives/C06DP498D1D/p1725380936499099?thread_ts=1725375586.922079&cid=C06DP498D1D

The cropped 100.pdf used for testing stripped the outline metadata, which is why I [use a new complete file](https://github.com/navapbc/labs-decision-support-tool/blob/903bab7acb82f7d54b2aac696dcedcdbb053bf8f/app/tests/src/util/test_pdf_utils.py#L23) when testing anything that uses the PDF outline.

## Changes

Use 707.pdf to test ingest_bem_pdfs.py

