### PR TITLE
fix: Add heuristics and fixes to improve BEM pdf parsing

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -21,8 +21,6 @@ RUN apt-get update \
     wget \
     # These are required by unstructured
     python3-opencv \
-    poppler-utils \
-    tesseract-ocr \
     # Reduce the image size by clear apt cached lists
     # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
     && rm -fr /var/lib/apt/lists/* \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -14,11 +14,15 @@ RUN apt-get update \
     # Install security updates
     # https://pythonspeed.com/articles/security-updates-in-docker/
     && apt-get upgrade --yes \
-    && apt-get install python3-opencv --no-install-recommends --yes \
+    && apt-get install --no-install-recommends --yes \
     build-essential \
     libpq-dev \
     postgresql \
     wget \
+    # These are required by unstructured
+    python3-opencv \
+    poppler-utils \
+    tesseract-ocr \
     # Reduce the image size by clear apt cached lists
     # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
     && rm -fr /var/lib/apt/lists/* \

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -94,7 +94,7 @@ def _parse_pdf(file: BinaryIO, file_path: str) -> list[EnrichedText]:
 
 
 def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
-    unstuctured_elem_list = partition_pdf(file=file, strategy="hi_res")
+    unstuctured_elem_list = partition_pdf(file=file, strategy="fast")
     enrich_text_list = []
 
     outline: list[Heading] = pdf_utils.extract_outline(file)

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -77,10 +77,14 @@ def _parse_pdf(file: BinaryIO) -> list[EnrichedText]:
     enriched_texts = _enrich_texts(file)
     with open("enriched_texts.log", "w") as log_file:
         pprint(enriched_texts, log_file, width=200)
-    stylings = extract_stylings(file)
-    associate_stylings(enriched_texts, stylings)
-    with open("styled_enriched_texts.log", "w") as log_file:
-        pprint(enriched_texts, log_file, width=200)
+    try:
+        stylings = extract_stylings(file)
+        associate_stylings(enriched_texts, stylings)
+        with open("styled_enriched_texts.log", "w") as log_file:
+            pprint(enriched_texts, log_file, width=200)
+    except Exception as e:
+        # 101.pdf is a large collection of tables that's hard to parse
+        logger.warning("Failed to extract and associate stylings: %s", e)
     markdown_texts = add_markdown(enriched_texts)
     grouped_texts = group_texts(markdown_texts)
     with open("grouped_texts.log", "w") as log_file:

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -76,7 +76,7 @@ def _ingest_bem_pdfs(
 def _parse_pdf(file: BinaryIO) -> list[EnrichedText]:
     enriched_texts = _enrich_texts(file)
     with open("enriched_texts.log", "w") as log_file:
-        pprint(enriched_texts, log_file, width=200)
+        pprint(list(enumerate(enriched_texts)), log_file, width=200)
     try:
         stylings = extract_stylings(file)
         associate_stylings(enriched_texts, stylings)

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -119,8 +119,8 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
                 continue
 
         # Sometimes Unstructured splits a ListItem into an empty ListItem
-        # and then either a NarrativeText,  UncategorizedText, or Title --
-        # for example, BEM 100 page 8 or page 13
+        # and then either a NarrativeText, UncategorizedText, or Title
+        # For example, BEM 100 page 8 or page 13
         if element.category == "ListItem" and not element.text:
             prev_element_was_empty_list_item = True
             continue
@@ -136,7 +136,7 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
 
         # UncategorizedText is frequently just NarrativeText that looks strange,
         # e.g., "45 CFR 400.45 - 400.69 and 400.90 - 400.107"
-        # 167.pdf -- unstructured recognizes an Address
+        # In 167.pdf, Unstructured recognizes an Address.
         if element.category in ["UncategorizedText", "Address"]:
             element.category = "NarrativeText"
 

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -141,7 +141,8 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
 
         # UncategorizedText is frequently just NarrativeText that looks strange,
         # e.g., "45 CFR 400.45 - 400.69 and 400.90 - 400.107"
-        if element.category == "UncategorizedText":
+        # 167.pdf -- unstructured recognizes an Address
+        if element.category in ["UncategorizedText", "Address"]:
             element.category = "NarrativeText"
 
         try:

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -112,8 +112,9 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
             continue
 
         if element.category == "Title":
-            current_headings = _get_current_heading(outline, element, current_headings)
-            continue
+            if next_heading := _next_heading(outline, element, current_headings):
+                current_headings = next_heading
+                continue
 
         try:
             enriched_text_item = EnrichedText(
@@ -144,9 +145,9 @@ def _match_heading(
     return None
 
 
-def _get_current_heading(
+def _next_heading(
     outline: list[Heading], element: Element, current_headings: list[Heading]
-) -> list[Heading]:
+) -> list[Heading] | None:
     if heading := _match_heading(outline, element.text, element.metadata.page_number):
         if heading.level == 1:
             current_headings = [heading]
@@ -156,6 +157,9 @@ def _get_current_heading(
                 current_headings.append(heading)
     else:
         logger.warning(f"Unable to match header: {element.text}, {element.metadata.page_number}")
+        # for heading in outline:
+        #     logger.warning(f"Available header: {heading.title}, {heading.pageno}")
+        return None
     return current_headings
 
 

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -4,6 +4,7 @@ import re
 import sys
 import uuid
 from typing import BinaryIO
+from pprint import pprint
 
 from smart_open import open as smart_open
 from unstructured.documents.elements import Element
@@ -74,10 +75,14 @@ def _ingest_bem_pdfs(
 
 def _parse_pdf(file: BinaryIO) -> list[EnrichedText]:
     enriched_texts = _enrich_texts(file)
+    with open("enriched_texts.log", "w") as log_file:
+        pprint(enriched_texts, log_file, width=200)
     stylings = extract_stylings(file)
     associate_stylings(enriched_texts, stylings)
     markdown_texts = add_markdown(enriched_texts)
     grouped_texts = group_texts(markdown_texts)
+    with open("grouped_texts.log", "w") as log_file:
+        pprint(list(enumerate(grouped_texts)), log_file, width=200)
 
     # Assign unique ids to each grouped text before they get split into chunks
     for text in grouped_texts:
@@ -198,7 +203,6 @@ def _save_json(file_path: str, chunks: list[Chunk]) -> None:
     chunks_as_json = [chunk.to_json() for chunk in chunks]
 
     with smart_open(file_path + ".json", "w") as file:
-        print(json.dumps(chunks_as_json))
         file.write(json.dumps(chunks_as_json))
 
 

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -133,7 +133,10 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
             if element.category in ("NarrativeText", "UncategorizedText", "Title"):
                 element.category = "ListItem"
             else:
-                logger.warning(f"Empty list item not followed by NarrativeText, UncategorizedText, or Title, {element.metadata.page_number}")
+                logger.warning(
+                    "Empty list item not followed by NarrativeText, UncategorizedText, or Title; page %i",
+                    element.metadata.page_number,
+                )
             prev_element_was_empty_list_item = False
 
         # UncategorizedText is frequently just NarrativeText that looks strange,
@@ -152,7 +155,10 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
             enrich_text_list.append(enriched_text_item)
         except ValueError:
             logger.warning(
-                f"{element.category} is not an accepted TextType, {element.text}, {element.metadata.page_number}"
+                "%s is not an accepted TextType; page %i: '%s'",
+                element.category,
+                element.metadata.page_number,
+                element.text,
             )
     return enrich_text_list
 

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -3,8 +3,8 @@ import logging
 import re
 import sys
 import uuid
-from typing import BinaryIO
 from pprint import pprint
+from typing import BinaryIO
 
 from smart_open import open as smart_open
 from unstructured.documents.elements import Element
@@ -79,6 +79,8 @@ def _parse_pdf(file: BinaryIO) -> list[EnrichedText]:
         pprint(enriched_texts, log_file, width=200)
     stylings = extract_stylings(file)
     associate_stylings(enriched_texts, stylings)
+    with open("styled_enriched_texts.log", "w") as log_file:
+        pprint(enriched_texts, log_file, width=200)
     markdown_texts = add_markdown(enriched_texts)
     grouped_texts = group_texts(markdown_texts)
     with open("grouped_texts.log", "w") as log_file:

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -99,7 +99,7 @@ def _parse_pdf(file: BinaryIO) -> list[EnrichedText]:
 
 
 def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
-    unstuctured_elem_list = partition_pdf(file=file, strategy="fast")
+    unstuctured_elem_list = partition_pdf(file=file, strategy="hi_res")
     enrich_text_list = []
 
     outline: list[Heading] = pdf_utils.extract_outline(file)

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -46,7 +46,7 @@ def _ingest_bem_pdfs(
     doc_attribs: dict[str, str],
     save_json: bool = True,
 ) -> None:
-    file_list = get_files(pdf_file_dir)
+    file_list = sorted(get_files(pdf_file_dir))
 
     logger.info(
         "Processing PDFs in %s using %s with %s",

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -43,6 +43,7 @@ def _ingest_bem_pdfs(
     db_session: db.Session,
     pdf_file_dir: str,
     doc_attribs: dict[str, str],
+    save_json: bool = True,
 ) -> None:
     file_list = get_files(pdf_file_dir)
 
@@ -67,7 +68,8 @@ def _ingest_bem_pdfs(
             _add_embeddings(chunks)
             db_session.add_all(chunks)
 
-            _save_json(file_path, chunks)
+            if save_json:
+                _save_json(file_path, chunks)
 
 
 def _parse_pdf(file: BinaryIO) -> list[EnrichedText]:
@@ -176,9 +178,7 @@ def split_into_chunks(document: Document, grouped_texts: list[EnrichedText]) -> 
     return chunks
 
 
-def _add_embeddings(
-    chunks: list[Chunk],
-) -> None:
+def _add_embeddings(chunks: list[Chunk]) -> None:
     embedding_model = app_config.sentence_transformer
 
     # Generate all the embeddings in parallel for speed
@@ -198,6 +198,7 @@ def _save_json(file_path: str, chunks: list[Chunk]) -> None:
     chunks_as_json = [chunk.to_json() for chunk in chunks]
 
     with smart_open(file_path + ".json", "w") as file:
+        print(json.dumps(chunks_as_json))
         file.write(json.dumps(chunks_as_json))
 
 

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -132,6 +132,11 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
                 logger.warning(f"Empty list item not followed by NarrativeText, UncategorizedText, or Title, {element.metadata.page_number}")
             prev_element_was_empty_list_item = False
 
+        # UncategorizedText is frequently just NarrativeText that looks strange,
+        # e.g., "45 CFR 400.45 - 400.69 and 400.90 - 400.107"
+        if element.category == "UncategorizedText":
+            element.category = "NarrativeText"
+
         try:
             enriched_text_item = EnrichedText(
                 text=element.text,
@@ -172,9 +177,10 @@ def _next_heading(
                 current_headings = current_headings[: heading.level - 1]
                 current_headings.append(heading)
     else:
-        logger.warning(f"Unable to match header: {element.text}, {element.metadata.page_number}")
+        # This is no longer a warning because it's expected for single-line bold body text
+        # logger.warning(f"Unable to match heading: {element.text}, {element.metadata.page_number}")
         # for heading in outline:
-        #     logger.warning(f"Available header: {heading.title}, {heading.pageno}")
+        #     logger.warning(f"Available heading: {heading.title}, {heading.pageno}")
         return None
     return current_headings
 

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -113,13 +113,15 @@ def _enrich_texts(file: BinaryIO) -> list[EnrichedText]:
 
         if element.category == "Title":
             current_headings = _get_current_heading(outline, element, current_headings)
+            continue
+
         try:
             enriched_text_item = EnrichedText(
                 text=element.text,
                 type=TextType(element.category),
                 page_number=element.metadata.page_number,
                 headings=current_headings,
-                id=element._element_id,
+                id=element.id,
             )
             enrich_text_list.append(enriched_text_item)
         except ValueError:

--- a/app/src/ingestion/pdf_elements.py
+++ b/app/src/ingestion/pdf_elements.py
@@ -10,6 +10,8 @@ class TextType(StrEnum):
     NARRATIVE_TEXT = "NarrativeText"
     LIST_ITEM = "ListItem"
     LIST = "List"
+    # For Title elements that cannot be found as a heading in the outline
+    TITLE = "Title"
 
 
 @dataclass

--- a/app/src/ingestion/pdf_postprocess.py
+++ b/app/src/ingestion/pdf_postprocess.py
@@ -62,16 +62,21 @@ def _apply_stylings(e_text: EnrichedText) -> EnrichedText:
 
 def _apply_bold_styling(text: str, styling: Styling) -> str | None:
     # Replace only the first occurrence of the styling text
-    markdown_text = text.replace(styling.text, f"**{styling.text}**", 1)
+    # Unstructured will strip() texts, so we need to strip the styling text as well
+    styled_text = styling.text.strip()
+    markdown_text = text.replace(styled_text, f"**{styled_text}**", 1)
     if markdown_text == text:
         return None
 
     # Warn if the styling text occurs multiple times
-    replaced_all = text.replace(styling.text, f"**{styling.text}**")
-    if replaced_all != text:
+    replaced_all = text.replace(styled_text, f"**{styled_text}**")
+
+    if replaced_all != markdown_text:
+        print("A:", styled_text)
+        print("B:", replaced_all)
         logger.warning(
-            "Styling text %s occurs multiple times; only applied to the first occurrence: '%s'",
-            styling.text,
+            "Styling text '%s' occurs multiple times; only applied to the first occurrence: '%s'",
+            styled_text,
             text,
         )
     return markdown_text

--- a/app/src/ingestion/pdf_postprocess.py
+++ b/app/src/ingestion/pdf_postprocess.py
@@ -163,7 +163,7 @@ def _group_list_texts(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:
     for current_text in markdown_texts[1:]:
         previous_text = grouped_texts[-1]
 
-        # Unstructured text sometimes splits a bullet from it's text;
+        # Unstructured text sometimes splits a bullet from its text;
         # merge them back together
         if (
             previous_text.text.endswith("    - ")

--- a/app/src/ingestion/pdf_postprocess.py
+++ b/app/src/ingestion/pdf_postprocess.py
@@ -151,6 +151,16 @@ def _group_list_texts(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:
     for current_text in markdown_texts[1:]:
         previous_text = grouped_texts[-1]
 
+        # Unstructured text sometimes splits a bullet from it's text
+        # https://nava.slack.com/archives/C06DP498D1D/p1725396917417349?thread_ts=1725395128.529479&cid=C06DP498D1D
+        if (
+            previous_text.text.endswith("    - ")
+            and previous_text.type in [TextType.LIST_ITEM, TextType.LIST]
+            and current_text.type == TextType.NARRATIVE_TEXT
+        ):
+            previous_text.text += current_text.text
+            continue
+
         if _should_merge_list_text(previous_text, current_text):
             # Append the current text to the previous one
             previous_text.text += "\n" + current_text.text

--- a/app/src/ingestion/pdf_postprocess.py
+++ b/app/src/ingestion/pdf_postprocess.py
@@ -163,8 +163,8 @@ def _group_list_texts(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:
     for current_text in markdown_texts[1:]:
         previous_text = grouped_texts[-1]
 
-        # Unstructured text sometimes splits a bullet from it's text
-        # https://nava.slack.com/archives/C06DP498D1D/p1725396917417349?thread_ts=1725395128.529479&cid=C06DP498D1D
+        # Unstructured text sometimes splits a bullet from it's text;
+        # merge them back together
         if (
             previous_text.text.endswith("    - ")
             and previous_text.type in [TextType.LIST_ITEM, TextType.LIST]

--- a/app/src/ingestion/pdf_postprocess.py
+++ b/app/src/ingestion/pdf_postprocess.py
@@ -177,8 +177,8 @@ def _group_list_texts(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:
     return grouped_texts
 
 
-def _should_merge_text(text: EnrichedText, next_text: EnrichedText) -> bool:
-    "Merges texts that are split across consecutive pages"
+def _should_merge_text_split_across_pages(text: EnrichedText, next_text: EnrichedText) -> bool:
+    "Check for texts that are split across consecutive pages"
     if text.headings != next_text.headings:
         return False
 
@@ -201,9 +201,15 @@ def group_texts(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:
     for e_text in lists_merged[1:]:
         prev_text = grouped_texts[-1]
 
-        if _should_merge_text(prev_text, e_text):
+        if _should_merge_text_split_across_pages(prev_text, e_text):
             prev_text.text += " " + e_text.text
-        else:
-            grouped_texts.append(e_text)
+            continue
+
+        if prev_text.type == TextType.TITLE:
+            prev_text.text += "\n\n" + e_text.text
+            prev_text.type = e_text.type
+            continue
+
+        grouped_texts.append(e_text)
 
     return grouped_texts

--- a/app/src/ingestion/pdf_stylings.py
+++ b/app/src/ingestion/pdf_stylings.py
@@ -271,7 +271,7 @@ class OutlineAwarePdfParser:
                 if subtype == "/'Footer'":
                     return self._extract_text_in_zone(elem, PageZone.FOOTER)
 
-            logger.info("Ignoring Artifact: %s", elem.toxml())
+            logger.debug("Ignoring Artifact: %s", elem.toxml())
             return None
 
         if elem.tagName == "P":

--- a/app/tests/src/ingestion/test_pdf_postprocess.py
+++ b/app/tests/src/ingestion/test_pdf_postprocess.py
@@ -253,7 +253,7 @@ def test__apply_stylings():
         EnrichedText(  # Substring with ending space should be bolded
             text="Second occurrence - twelve month disqualification. The "
             "closure reason will be **CDC not eligible due to 12 month "
-            "penalty period. **",  # ending space is intentional
+            "penalty period.** ",  # ending space is intentional
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="Disqualifications", level=1, pageno=2)],
             page_number=3,
@@ -262,7 +262,7 @@ def test__apply_stylings():
         texts[3],
         texts[4],
         EnrichedText(  # Multiple substrings match
-            text="**CDC **- CDC",
+            text="**CDC** - CDC",
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="legal base", level=1, pageno=4)],
             page_number=4,

--- a/app/tests/src/test_ingest_bem_pdfs.py
+++ b/app/tests/src/test_ingest_bem_pdfs.py
@@ -131,7 +131,7 @@ def test__ingest_bem_pdfs(caplog, app_config, db_session, policy_s3_file, file_l
         assert bold_styled_chunk.content == expected_text
 
         title_chunk = document.chunks[22]
-        assert title_chunk.content == "**CDC**"
+        assert title_chunk.content.startswith("**CDC**\n\nThe Child Care and Development Block")
         assert title_chunk.headings == ["legal base"]
         assert title_chunk.page_number == 4
 

--- a/app/tests/src/test_ingest_bem_pdfs.py
+++ b/app/tests/src/test_ingest_bem_pdfs.py
@@ -66,7 +66,7 @@ def mock_elements():
     ]
 
 
-@pytest.mark.parametrize("file_location", ["local"])
+@pytest.mark.parametrize("file_location", ["local", "s3"])
 def test__ingest_bem_pdfs(caplog, app_config, db_session, policy_s3_file, file_location):
     db_session.execute(delete(Document))
 
@@ -134,8 +134,6 @@ def test__ingest_bem_pdfs(caplog, app_config, db_session, policy_s3_file, file_l
         assert title_chunk.content.startswith("**CDC**\n\nThe Child Care and Development Block")
         assert title_chunk.headings == ["legal base"]
         assert title_chunk.page_number == 4
-
-        # assert False
 
 
 def test__enrich_text():

--- a/app/tests/src/test_ingest_bem_pdfs.py
+++ b/app/tests/src/test_ingest_bem_pdfs.py
@@ -66,7 +66,7 @@ def mock_elements():
     ]
 
 
-@pytest.mark.parametrize("file_location", ["local", "s3"])
+@pytest.mark.parametrize("file_location", ["local"])
 def test__ingest_bem_pdfs(caplog, app_config, db_session, policy_s3_file, file_location):
     db_session.execute(delete(Document))
 
@@ -120,6 +120,16 @@ def test__ingest_bem_pdfs(caplog, app_config, db_session, policy_s3_file, file_l
             "Intentional Program Violations",
         ]
         assert list_type_chunk.page_number == 2
+
+        bold_styled_chunk = document.chunks[12]
+        expected_text = (
+            "Providers determined to have committed an IPV may serve the following penalties:\n"
+            "    - First occurrence - six month disqualification. The closure reason will be **CDC not eligible due to 6 month penalty period**.\n"
+            "    - Second occurrence - twelve month disqualification. The closure reason will be **CDC not eligible due to 12 month penalty period.**\n"
+            "    - Third occurrence - lifetime disqualification. The closure reason will be **CDC not eligible due to lifetime penalty.**"
+        )
+        assert bold_styled_chunk.content == expected_text
+        # assert False
 
 
 def test__enrich_text():

--- a/app/tests/src/test_ingest_bem_pdfs.py
+++ b/app/tests/src/test_ingest_bem_pdfs.py
@@ -142,7 +142,7 @@ def test__enrich_text():
     with smart_open(_707_PDF_PATH, "rb") as file:
         enriched_text_list = _enrich_texts(file)
 
-        assert len(enriched_text_list) == 46
+        assert len(enriched_text_list) == 40
         first_enriched_text_item = enriched_text_list[0]
         assert isinstance(first_enriched_text_item, EnrichedText)
         assert first_enriched_text_item.headings == [Heading(title="Overview", level=1, pageno=1)]
@@ -154,7 +154,7 @@ def test__enrich_text():
             Heading(title="Time and Attendance Review  Process", level=1, pageno=1),
             Heading(title="Provider Errors", level=2, pageno=1),
         ]
-        assert other_enriched_text_item.type == "NarrativeText"
+        assert other_enriched_text_item.type == "ListItem"
         assert other_enriched_text_item.page_number == 2
 
 

--- a/app/tests/src/test_ingest_bem_pdfs.py
+++ b/app/tests/src/test_ingest_bem_pdfs.py
@@ -105,6 +105,22 @@ def test__ingest_bem_pdfs(caplog, app_config, db_session, policy_s3_file, file_l
         assert third_chunk.headings == ["Rule Violations"]
         assert third_chunk.page_number == 1
 
+        list_type_chunk = document.chunks[10]
+        assert list_type_chunk.content == (
+            "The following are examples of IPVs:\n"
+            "    - Billing for children while they are in school.\n"
+            "    - Two instances of failing to respond to requests for records.\n"
+            "    - Two instances of providing care in the wrong location.\n"
+            "    - Billing for children no longer in care.\n"
+            "    - Knowingly billing for children not in care or more hours than children were in care.\n"
+            "    - Maintaining records that do not accurately reflect the time children were in care."
+        )
+        assert list_type_chunk.headings == [
+            "Time and Attendance Review  Process",
+            "Intentional Program Violations",
+        ]
+        assert list_type_chunk.page_number == 2
+
 
 def test__enrich_text():
     with smart_open(_707_PDF_PATH, "rb") as file:


### PR DESCRIPTION
## Ticket

- [Heuristic 1](https://nava.slack.com/archives/C06DP498D1D/p1725396917417349?thread_ts=1725395128.529479&cid=C06DP498D1D): if a `ListItem` or `List` ends with a bullet, merge with the next element.

## Changes

- [add more assertions to check text and headings](https://github.com/navapbc/labs-decision-support-tool/commit/8935ba12952994324a311c78cfdf862e227295e9)
- heuristic 1: [merge text ending with bullet with next element](https://github.com/navapbc/labs-decision-support-tool/pull/71/commits/121181c792e9d54cd7fa631ede3d05cf9b32c8f0)
- fix: [unstructured will strip() texts, so we need to strip the styling text as well](https://github.com/navapbc/labs-decision-support-tool/pull/71/commits/7a4897f96d8da29332b07c6dc25c1fc09c334771)
- [fix processing Title elements to not cause warning](https://github.com/navapbc/labs-decision-support-tool/pull/71/commits/3f58d508398f52ad517fb2574a3cd0101e667b51)
- [if a Title element cannot be found as a heading in the outline, include it as a Title element](https://github.com/navapbc/labs-decision-support-tool/pull/71/commits/6dfd8148c656c2bc61ad693fe5d23ad8e344b03a)
   - heuristic 2: [group each Title element with the next element](https://github.com/navapbc/labs-decision-support-tool/pull/71/commits/52591df14751736a60a085064e9b31115588bce6)
- ... and more -- see commit history below.

## Testing

Updated `test__ingest_bem_pdfs`