### PR TITLE
feat: Update citation UI

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -108,6 +108,10 @@ class GuruSnapEngine(BaseEngine):
 
 
 class BridgesEligibilityManualEngine(BaseEngine):
+    retrieval_k_min_score: float = -1
+    chunks_shown_min_score: float = -1
+    chunks_shown_max_num: int = 8
+
     engine_id: str = "bridges-eligibility-manual"
     name: str = "Michigan Bridges Eligibility Manual Chat Engine"
     datasets = ["bridges-eligibility-manual"]

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -40,12 +40,15 @@ def add_citations(response: str, chunks: list[Chunk]) -> str:
 
         chunk = chunks[index]
         bem_link = _get_bem_url(chunk.document.name) if "BEM" in chunk.document.name else "#"
-        citation = f".<sup><a href={bem_link!r} id={_footnote_id!r}>{_footnote_index}</a></sup>"
+        bem_link += "#page=" + str(chunk.page_number) if chunk.page_number else ""
+        citation = f"<sup><a href={bem_link!r} id={_footnote_id!r}>{index + 1}</a>&nbsp;</sup>"
         footnote_list.append(
             f"<a style='text-decoration:none' href={bem_link!r}><sup id={_footnote_id!r}>{_footnote_index}. {chunk.document.name}</sup></a>"
         )
         return citation
 
     # Replace all instances of (chunk-<index>), where <index> is a number
-    added_citations = re.sub(r"\(chunk-(\d+)\).", replace_citation, response)
-    return added_citations + "</br>" + "</br>".join(footnote_list)
+    added_citations = re.sub(r"\(chunk-(\d+)\)", replace_citation, response)
+
+    # For now, don't show footnote list
+    return added_citations  # + "</br>" + "</br>".join(footnote_list)

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -41,7 +41,7 @@ def add_citations(response: str, chunks: list[Chunk]) -> str:
         chunk = chunks[index]
         bem_link = _get_bem_url(chunk.document.name) if "BEM" in chunk.document.name else "#"
         bem_link += "#page=" + str(chunk.page_number) if chunk.page_number else ""
-        citation = f"<sup><a href={bem_link!r} id={_footnote_id!r}>{index + 1}</a>&nbsp;</sup>"
+        citation = f"<sup><a href={bem_link!r}>{index + 1}</a>&nbsp;</sup>"
         footnote_list.append(
             f"<a style='text-decoration:none' href={bem_link!r}><sup id={_footnote_id!r}>{_footnote_index}. {chunk.document.name}</sup></a>"
         )

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -152,7 +152,7 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
                 </div>
             </div>"""  # noqa: B907
 
-    return "<h3>Source(s)</h3>" + html if html else ""
+    return "\n<h3>Source(s)</h3>" + html if html else ""
 
 
 def _get_bem_url(text: str) -> str:

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -114,7 +114,7 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
             formatted_chunk = _replace_bem_with_link(chunk.content)
 
             # Adjust markdown for lists so Chainlit renders correctly
-            formatted_chunk = formatted_chunk.replace(r"^    - ", "- ")
+            formatted_chunk = re.sub('^    - ', "- ", formatted_chunk, flags=re.MULTILINE)
             if formatted_chunk.startswith("- "):
                 formatted_chunk = "\n" + formatted_chunk
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -118,7 +118,9 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
             if formatted_chunk.startswith("- "):
                 formatted_chunk = "\n" + formatted_chunk
 
-            bem_url_for_page = _get_bem_url(document.name) + "#page=" + str(chunk.page_number)
+            bem_url_for_page = _get_bem_url(document.name)
+            if chunk.page_number:
+                bem_url_for_page += "#page=" + str(chunk.page_number)
 
             citation_heading = f"<h4>Citation {citation_number}:</h4>"
             chunk_headings = "<p>" + " → ".join(chunk.headings) + "</p>" if chunk.headings else ""

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -126,7 +126,11 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
             chunk_headings = "<p>" + " → ".join(chunk.headings) + "</p>" if chunk.headings else ""
             citation_body = f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_chunk}</div>'
             citation_link = (
-                f"<p><a href={bem_url_for_page!r}>Open document to page {chunk.page_number}</a></p>"
+                (
+                    f"<p><a href={bem_url_for_page!r}>Open document to page {chunk.page_number}</a></p>"
+                )
+                if chunk.page_number
+                else ""
             )
             citations += citation_heading + chunk_headings + citation_body + citation_link
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -104,20 +104,26 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
     html = ""
     citation_number = 1
     for document in documents:
-        internal_citation = ""
+        citations = ""
         _accordion_id += 1
 
         citation_number_start = citation_number
 
         for chunk_with_score in documents[document]:
             chunk = chunk_with_score.chunk
-            formatted_chunk = f"<p>{_replace_bem_with_link(chunk.content)} </p>"
+            formatted_chunk = _replace_bem_with_link(chunk.content)
 
-            citation = f"<h4>Citation {citation_number}:</h4>"
-            internal_citation += f"""{citation}<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_chunk}</div>"""
+            # Adjust markdown for lists so Chainlit renders correctly
+            formatted_chunk = formatted_chunk.replace("    - ", "- ")
+            if formatted_chunk.startswith("- "):
+                formatted_chunk = "\n" + formatted_chunk
+
             bem_url_for_page = _get_bem_url(document.name) + "#page=" + str(chunk.page_number)
-            internal_citation += (
-                f"<p><a href='{bem_url_for_page}'>Open document to page {chunk.page_number}</a></p>"
+
+            citation_heading = f"<h4>Citation {citation_number}:</h4>"
+            citations += f"""{citation_heading}<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_chunk}</div>"""
+            citations += (
+                f"<p><a href={bem_url_for_page!r}>Open document to page {chunk.page_number}</a></p>"
             )
 
             citation_number += 1
@@ -142,7 +148,7 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
                     </button>
                 </h4>
                 <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>
-                {internal_citation}
+                {citations}
                 </div>
             </div>"""  # noqa: B907
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -121,10 +121,12 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
             bem_url_for_page = _get_bem_url(document.name) + "#page=" + str(chunk.page_number)
 
             citation_heading = f"<h4>Citation {citation_number}:</h4>"
-            citations += f"""{citation_heading}<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_chunk}</div>"""
-            citations += (
+            chunk_headings = "<p>" + " → ".join(chunk.headings) + "</p>" if chunk.headings else ""
+            citation_body = f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_chunk}</div>'
+            citation_link = (
                 f"<p><a href={bem_url_for_page!r}>Open document to page {chunk.page_number}</a></p>"
             )
+            citations += citation_heading + chunk_headings + citation_body + citation_link
 
             citation_number += 1
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -114,7 +114,7 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
             formatted_chunk = _replace_bem_with_link(chunk.content)
 
             # Adjust markdown for lists so Chainlit renders correctly
-            formatted_chunk = formatted_chunk.replace("    - ", "- ")
+            formatted_chunk = formatted_chunk.replace(r"^    - ", "- ")
             if formatted_chunk.startswith("- "):
                 formatted_chunk = "\n" + formatted_chunk
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -114,7 +114,7 @@ def _format_to_accordion_group_html(documents: OrderedDict[Document, list[ChunkW
             formatted_chunk = _replace_bem_with_link(chunk.content)
 
             # Adjust markdown for lists so Chainlit renders correctly
-            formatted_chunk = re.sub('^    - ', "- ", formatted_chunk, flags=re.MULTILINE)
+            formatted_chunk = re.sub("^    - ", "- ", formatted_chunk, flags=re.MULTILINE)
             if formatted_chunk.startswith("- "):
                 formatted_chunk = "\n" + formatted_chunk
 

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -16,8 +16,8 @@ Keep your answers as similar to your knowledge text as you can
 When referencing the context, do not quote directly.
 Use the provided citation numbers (e.g., (chunk-0)) to indicate when you are drawing from the context.
 Do cite multiple sources at once, you can append citations like so: (chunk-0)(chunk-1), etc.
-Place the citations after any closing punctation for the sentence. 
-For example: "This is a sentence that draws on information from the context.(chunk-0)"
+Place the citations after any closing punctuation for the sentence.
+For example: 'This is a sentence that draws on information from the context.(chunk-0)'
 
 Example Answer:
 If the client and their roommate purchase and prepare food separately, they can be considered different SNAP (FAP) groups. For instance:

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -13,11 +13,15 @@ PROMPT = """Provide answers in plain language written at the average American re
 Use bullet points. Keep your answers brief, max of 5 sentences.
 Keep your answers as similar to your knowledge text as you can
 
-When referencing the context, do not quote directly. Use the provided citation numbers (e.g., (chunk-0)) to indicate when you are drawing from the context.
+When referencing the context, do not quote directly.
+Use the provided citation numbers (e.g., (chunk-0)) to indicate when you are drawing from the context.
+Do cite multiple sources at once, you can append citations like so: (chunk-0)(chunk-1), etc.
+Place the citations after any closing punctation for the sentence. 
+For example: "This is a sentence that draws on information from the context.(chunk-0)"
 
 Example Answer:
 If the client and their roommate purchase and prepare food separately, they can be considered different SNAP (FAP) groups. For instance:
-- They can be classified as different SNAP (FAP) groups if they purchase and prepare food separately (chunk-0).
+- They can be classified as different SNAP (FAP) groups if they purchase and prepare food separately.(chunk-1)(chunk-3)
 """
 
 

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -17,9 +17,14 @@ def test_get_context_for_prompt():
 
 
 def test_add_citations():
-    assert add_citations("This is a citation (chunk-0)", []) == "This is a citation (chunk-0)</br>"
+    assert add_citations("This is a citation (chunk-0)", []) == "This is a citation (chunk-0)"
 
     chunks = ChunkFactory.build_batch(2)
+    assert (
+        add_citations("This is a citation (chunk-0) and another (chunk-1).", chunks)
+        == "This is a citation <sup><a href='#'>1</a>&nbsp;</sup> and another <sup><a href='#'>2</a>&nbsp;</sup>."
+    )
+    """"
     assert all(
         text in add_citations("This is a citation (chunk-0) and another (chunk-1).", chunks)
         for text in [
@@ -29,3 +34,4 @@ def test_add_citations():
             chunks[1].document.name,
         ]
     )
+    """

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -102,12 +102,11 @@ def test_format_bem_documents():
         chunks_shown_max_num=2, chunks_shown_min_score=0.91, chunks_with_scores=chunks_with_scores
     )
 
-    assert docs[0].content.replace("\n", " ") not in html
-    assert docs[1].content.replace("\n", " ") not in html
-    assert docs[3].content.replace("\n", " ") in html
-    assert "Citation #2" in html
-    assert "Citation #3" not in html
-    assert "<p>Similarity Score: 0.95</p>" in html
+    assert docs[0].content not in html
+    assert docs[1].content not in html
+    assert docs[3].content in html
+    assert "Citation 2" in html
+    assert "Citation 3" not in html
 
 
 def test__get_bem_url():


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-435


## Changes
 - Slightly update LLM prompt:
    - to encourage `(chunk-0)(chunk-1)` style citations (which our code supports) rather than `(chunk-0,1)` (which the LLM invents)
    - to encourage adding citations after punctuation.
 - Remove similarity scores from UI
 - Set defaults for BEM engine similarity score cut off to -1, and match citations shown k with retrieval k (8)
 - Update citations UX to match the Figma prototype (see ticket for screenshot)
 - Add hotfix for proper markdown list rendering by Chainlit


## Context for reviewers
n/a

## Testing
<img width="491" alt="image" src="https://github.com/user-attachments/assets/0a642265-b264-4b76-919d-1a83ff597c76">
