### PR TITLE
fix: Address BEM PDF ingestion error cases with bigger chunks

### DIFF
--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -203,16 +203,26 @@ def _split_into_chunks(document: Document, grouped_texts: list[EnrichedText]) ->
         token_count = len(embedding_model.tokenizer.tokenize(paragraph.text))
         if token_count > embedding_model.max_seq_length:
             # Split the text into chunks of approximately equal length by characters,
-            # which doesn't necessarily mean equal number of tokens, but close enough
-            num_of_splits = math.ceil(token_count / embedding_model.max_seq_length)
-            char_limit_per_split = math.ceil(len(paragraph.text) / num_of_splits)
+            # which doesn't necessarily mean equal number of tokens, but close enough.
+            # The arbitrary 1.2 tolerance factor tries to account for higher token counts per chunk when text is split.
+            num_of_splits = math.ceil((token_count * 1.2) / embedding_model.max_seq_length)
+            char_limit_per_split = math.ceil((len(paragraph.text)) / num_of_splits)
             if paragraph.type == TextType.LIST:
                 splits = split_list(paragraph.text, char_limit_per_split)
             elif paragraph.type == TextType.NARRATIVE_TEXT:
                 splits = split_paragraph(paragraph.text, char_limit_per_split)
+            elif paragraph.type == TextType.LIST_ITEM:
+                # 233B.pdf: bottom of page 7: list item has no introductory sentence
+                splits = split_list(paragraph.text, char_limit_per_split, has_intro_sentence=False)
             else:
-                raise ValueError(f"Unexpected element type: {paragraph.type}")
-            logger.info("Split long text into %i chunks: %s", len(splits), splits[0][:120])
+                raise ValueError(f"Unexpected element type: {paragraph.type}: {paragraph.text}")
+            logger.info(
+                "Split long text with length %i into %i chunks with %i char limit: %s ...",
+                len(paragraph.text),
+                len(splits),
+                char_limit_per_split,
+                splits[0][:120],
+            )
         else:
             splits = [paragraph.text]
 

--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -204,9 +204,9 @@ def _split_into_chunks(document: Document, grouped_texts: list[EnrichedText]) ->
         if token_count > embedding_model.max_seq_length:
             # Split the text into chunks of approximately equal length by characters,
             # which doesn't necessarily mean equal number of tokens, but close enough.
-            # The arbitrary 1.2 tolerance factor tries to account for higher token counts per chunk when text is split.
-            num_of_splits = math.ceil((token_count * 1.2) / embedding_model.max_seq_length)
-            char_limit_per_split = math.ceil((len(paragraph.text)) / num_of_splits)
+            # The arbitrary 1.5 tolerance factor tries to account for higher token counts per chunk when text is split.
+            num_of_splits = math.ceil((token_count * 1.5) / embedding_model.max_seq_length)
+            char_limit_per_split = math.ceil(len(paragraph.text) / num_of_splits)
             if paragraph.type == TextType.LIST:
                 splits = split_list(paragraph.text, char_limit_per_split)
             elif paragraph.type == TextType.NARRATIVE_TEXT:
@@ -217,12 +217,14 @@ def _split_into_chunks(document: Document, grouped_texts: list[EnrichedText]) ->
             else:
                 raise ValueError(f"Unexpected element type: {paragraph.type}: {paragraph.text}")
             logger.info(
-                "Split long text with length %i into %i chunks with %i char limit: %s ...",
+                "Split long text with length %i into %i chunks with %i char limit: [%s]: %s ...",
                 len(paragraph.text),
                 len(splits),
                 char_limit_per_split,
+                ",".join([str(len(split)) for split in splits]),
                 splits[0][:120],
             )
+
         else:
             splits = [paragraph.text]
 
@@ -257,7 +259,7 @@ def _add_embeddings(chunks: list[Chunk]) -> None:
         chunk.tokens = len(embedding_model.tokenizer.tokenize(chunk.content))
         assert (
             chunk.tokens <= embedding_model.max_seq_length
-        ), "Text too long for embedding model: {chunk.content[:100]}"
+        ), f"Text too long for embedding model: {chunk.tokens} tokens: {len(chunk.content)} chars: {chunk.content[:100]} ..."
 
 
 def _save_json(file_path: str, chunks: list[Chunk]) -> None:

--- a/app/src/ingestion/pdf_postprocess.py
+++ b/app/src/ingestion/pdf_postprocess.py
@@ -222,14 +222,14 @@ NestedHeadingTitles = tuple[str, ...]
 
 def _group_headings_text(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:
     grouped_texts_by_headings: dict[NestedHeadingTitles, EnrichedText] = {}
-    for ind, markdown_text in enumerate(markdown_texts):
-        text_nested_headings: NestedHeadingTitles = tuple(
-            [h.title for h in markdown_texts[ind].headings]
-        )
+    for markdown_text in markdown_texts:
+        text_nested_headings: NestedHeadingTitles = tuple([h.title for h in markdown_text.headings])
         if text_nested_headings in grouped_texts_by_headings:
-            grouped_texts_by_headings[
-                text_nested_headings
-            ].text += f"\n\n{markdown_texts[ind].text}"
+            grouped_texts_by_headings[text_nested_headings].text += f"\n\n{markdown_text.text}"
+
+            # Grouping any text with a NarrativeText type makes the whole group a NarrativeText type
+            if markdown_text.type == TextType.NARRATIVE_TEXT:
+                grouped_texts_by_headings[text_nested_headings].type = markdown_text.type
         else:
             grouped_texts_by_headings[text_nested_headings] = EnrichedText(
                 text=markdown_text.text,

--- a/app/src/ingestion/pdf_postprocess.py
+++ b/app/src/ingestion/pdf_postprocess.py
@@ -164,13 +164,7 @@ def _should_merge_list_text(text: EnrichedText, next_text: EnrichedText) -> bool
     if text.headings != next_text.headings:
         return False
 
-    if next_text.type != TextType.LIST_ITEM:
-        return False
-
-    if text.type in [TextType.LIST_ITEM, TextType.LIST]:
-        return True
-
-    return text.type == TextType.NARRATIVE_TEXT and text.text.rstrip().endswith(":")
+    return next_text.type == TextType.LIST_ITEM
 
 
 def _group_list_texts(markdown_texts: list[EnrichedText]) -> list[EnrichedText]:

--- a/app/src/util/string_utils.py
+++ b/app/src/util/string_utils.py
@@ -47,10 +47,15 @@ def split_paragraph(text: str, char_limit: int) -> list[str]:
     # Use the nltk sentence tokenizer to split the text into sentences
     # Could use spacy instead for more customization
     sents = sent_tokenize(text)
+    if len(sents) == 1:
+        # 400.pdf page 73 has tables that result in large paragraphs
+        sents = text.split("\n\n")
+        return _join_up_to(sents, char_limit, delimiter="\n\n")
+
     return _join_up_to(sents, char_limit)
 
 
-def split_list(text: str, char_limit: int) -> list[str]:
+def split_list(text: str, char_limit: int, has_intro_sentence: bool = True) -> list[str]:
     """
     Split text containing a list of items into chunks having up to a character limit each.
     The first line is treated as an introductory sentence, which will be repeated as the first line of each chunk.
@@ -59,8 +64,12 @@ def split_list(text: str, char_limit: int) -> list[str]:
     _prep_nltk_tokenizer()
 
     lines = text.split("\n")
-    intro_sentence = lines[0]
-    list_items = lines[1:]
+    if has_intro_sentence:
+        intro_sentence = lines[0]
+        list_items = lines[1:]
+    else:
+        intro_sentence = ""
+        list_items = lines
 
     # len(lines) accounts for the number of newline characters
     list_items_char_limit = char_limit - len(intro_sentence) - len(lines)

--- a/app/src/util/string_utils.py
+++ b/app/src/util/string_utils.py
@@ -89,13 +89,14 @@ def _join_up_to(lines: list[str], char_limit: int, delimiter: str = " ") -> list
         test_chunk = delimiter.join([chunk, line]) if chunk else line
         if len(test_chunk) > char_limit:
             # Don't use test_chunk; start a new chunk
-            chunks.append(chunk)
+            if chunk:
+                chunks.append(chunk)
             if len(line) < char_limit:
                 chunk = line
             else:
                 # Split into phrases; could use spacy instead for more robust splitting
-                words = re.split(r"([,;])", line)
-                logger.warning("Splitting sentence: %s", line)
+                words = re.split(r"([,;\n])", line)
+                logger.warning("Splitting sentence: %s", line[:120])
 
                 chunks += _join_up_to(words, char_limit=char_limit, delimiter="")
                 # Start new empty chunk

--- a/app/tests/src/ingestion/test_pdf_postprocess.py
+++ b/app/tests/src/ingestion/test_pdf_postprocess.py
@@ -218,7 +218,7 @@ def test_concatenate_list_items():
 
     assert result == [
         EnrichedText(
-            text="Introduction.\n\nFirst item.\nSecond item.\n\nAnother narrative text.\n\nNarrative starting a new list: \nFirst item in new list.\nSecond item in new list.",
+            text="Introduction.\nFirst item.\nSecond item.\n\nAnother narrative text.\n\nNarrative starting a new list: \nFirst item in new list.\nSecond item in new list.",
             type=TextType.NARRATIVE_TEXT,
             headings=[Heading(title="Overview", level=1, pageno=1)],
             page_number=1,


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1726761922331469)

PR #79 resulted in bigger chunks and more use of `split_paragraph()` and `split_list()`, which revealed some outlier error cases.

## Changes

- Account for higher token counts per chunk when text is split by adding a 20% fudge factor
- Always merge LIST_ITEMs with the prior text, regardless if it doesn't end with `:`
- Account for lists with no introductory sentence
- Correctly split parsed tables, which are not grouped into a single paragraph

## Testing

Ingest all the BEM pdfs and check chunks