### PR TITLE
fix: Prevent citations from being rendered inline by Chainlit

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -106,7 +106,7 @@ _WIDGET_FACTORIES = {
         label="Number of citations to retrieve for generating LLM response",
         initial=default_value,
         min=0,
-        max=10,
+        max=50,
         step=1,
     ),
     "retrieval_k_min_score": lambda initial_value: Slider(

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -106,7 +106,10 @@ class GuruSnapEngine(BaseEngine):
 
 
 class BridgesEligibilityManualEngine(BaseEngine):
+    retrieval_k: int = 10
     retrieval_k_min_score: float = -1
+
+    # Note: currently not used
     chunks_shown_min_score: float = -1
     chunks_shown_max_num: int = 8
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -116,7 +116,11 @@ def format_bem_subsections(
             </div>
         </div>"""
 
-    return response_with_citations + citations_html
+    # This heading is important to prevent Chainlit from embedding citations_html
+    # as the next part of a a list in response_with_citations
+    if citations_html:
+        return response_with_citations + "<h3>Source(s)</h3>" + citations_html
+    return response_with_citations
 
 
 def format_bem_documents(


### PR DESCRIPTION
## Ticket

n/a

## Changes
 - Add an h3 element between the LLM response and the citations HTML
 - Unrelated change: increase the UI slider max for retrieved citations


## Context for reviewers
 - Without a heading, if the LLM response ends in list items, Chainlit will render the following HTML as another list bullet.


## Testing
Example bug:
<img width="505" alt="Screenshot 2024-09-24 at 11 57 53 AM" src="https://github.com/user-attachments/assets/fcd1fc64-a50b-4fbe-9bf4-e5cf95c99887">

After fixing:
<img width="515" alt="Screenshot 2024-09-24 at 11 57 59 AM" src="https://github.com/user-attachments/assets/838b5ea9-9524-4380-868a-eb7b3d6b231d">
