### PR TITLE
fix ci: Set test coverage thresholds

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -56,3 +56,6 @@ jobs:
           sourceDir: app
           coverageFile: app/coverage_report.xml
           token: ${{ secrets.GITHUB_TOKEN }}
+          thresholdAll: 0.8
+          thresholdNew: 0.9
+          thresholdModified: 0.8


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1727795570823389)

## Changes

Set test coverage thresholds.
The PR check will fail if thresholds aren't met.

## Testing

Tested here: https://github.com/navapbc/labs-decision-support-tool/pull/83#issuecomment-2386124218
which now shows a red status.