### PR TITLE
fix: Retry waiting for service to be stable

### DIFF
--- a/bin/deploy-release
+++ b/bin/deploy-release
@@ -25,6 +25,12 @@ echo "::endgroup::"
 cluster_name=$(terraform -chdir="infra/$app_name/service" output -raw service_cluster_name)
 service_name=$(terraform -chdir="infra/$app_name/service" output -raw service_name)
 echo "Wait for service $service_name to become stable"
-aws ecs wait services-stable --cluster "$cluster_name" --services "$service_name"
+wait_for_service_stability() {
+  aws ecs wait services-stable --cluster "${cluster_name}" --services "${service_name}"
+}
+if ! wait_for_service_stability; then
+  echo "Retrying"
+  wait_for_service_stability
+fi
 
 echo "Completed $app_name deploy of $image_tag to $environment"


### PR DESCRIPTION
## Ticket

n/a

## Changes

Ports over this PR: https://github.com/navapbc/template-infra/pull/761

TL;DR - our service takes about ~11 minutes to become stable, but the AWS command won't wait for longer than 10 minutes, so we run it a second time if the first one fails.


## Testing

See linked PR above