### PR TITLE
ci: Use python:3.12-slim for Docker image

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,7 +4,7 @@
 # The build stage that will be used to deploy to the various environments
 # needs to be called `release` in order to integrate with the repo's
 # top-level Makefile
-FROM python:3-slim AS base
+FROM python:3.12-slim AS base
 
 # Install poetry, the package manager.
 # https://python-poetry.org

--- a/docs/decisions/infra/0007-database-migration-architecture.md
+++ b/docs/decisions/infra/0007-database-migration-architecture.md
@@ -33,7 +33,7 @@ Questions that need to be addressed:
 
 Run migrations from an ECS task using the same container image that is used for running the web service. Require a `db-migrate` script in the application container image that performs the migration. When running the migration task using [AWS CLI's run-task command](https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html), use the `--overrides` option to override the command to the `db-migrate` command.
 
-Default to rolling forward instead of rolling back when issues arise (See [Pitfalls with SQL rollbacks and automated database deployments](https://octopus.com/blog/database-rollbacks-pitfalls)). Do not support rolling back out of the box, but still project teams to easily implement database rollbacks through the mechanism of running an application-specific database rollback script through a general purpose `run-command` script.
+Default to rolling forward instead of rolling back when issues arise (search Pitfalls with SQL rollbacks and automated database deployments). Do not support rolling back out of the box, but still project teams to easily implement database rollbacks through the mechanism of running an application-specific database rollback script through a general purpose `run-command` script.
 
 Pros
 


### PR DESCRIPTION
## Ticket

PR checks are [failing](https://github.com/navapbc/labs-decision-support-tool/actions/runs/11237920089/job/31241445501?pr=89#step:3:2670) due to:
```
The specified Python version (3.13.0) is not supported by the project (>=3.12,<3.13).
Please choose a compatible version or loosen the python constraint specified in the pyproject.toml file.
```
I was able to replicate locally via make build.
What's causing the problem? What changed?

Hypothesis: The [Docker container image](https://hub.docker.com/_/python/tags?name=3-slim) was updated to Python 3.13 overnight.

## Changes

Pin Python version to `python:3.12-slim` for Docker image.

## Testing

PR checks should pass.