### PR TITLE
fix: Resolve incomplete URLs

### DIFF
--- a/app/src/util/string_utils.py
+++ b/app/src/util/string_utils.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from typing import Optional
+from urllib.parse import urlparse
 
 import nltk
 from nltk.tokenize import sent_tokenize
@@ -109,3 +110,16 @@ def _join_up_to(lines: list[str], char_limit: int, delimiter: str = " ") -> list
 
     assert all(len(chunk) <= char_limit for chunk in chunks)
     return chunks
+
+
+def resolve_urls(base_url: str, markdown: str) -> str:
+    "Replace non-absolute URLs in markdown with absolute URLs."
+    parsed = urlparse(base_url)
+    domain_prefix = parsed.scheme + "://" + parsed.netloc + "/"
+    # Scenario 1: link starts with '/' like "/en/unemployment/"
+    # Prepend the domain prefix to the link
+    markdown = re.sub(r"\]\(\/", rf"]({domain_prefix}", markdown)
+    # Scenario 2: link does not start with '/' or "http://" or "https://", like "unemployment/"
+    # Insert the base URL of the web page before the link
+    markdown = re.sub(r"\]\((?!\/|https?:\/\/)", rf"]({base_url}", markdown)
+    return markdown

--- a/app/src/util/string_utils.py
+++ b/app/src/util/string_utils.py
@@ -121,5 +121,7 @@ def resolve_urls(base_url: str, markdown: str) -> str:
     markdown = re.sub(r"\]\(\/", rf"]({domain_prefix}", markdown)
     # Scenario 2: link does not start with '/' or "http://" or "https://", like "unemployment/"
     # Insert the base URL of the web page before the link
+    if not base_url.endswith("/"):
+        base_url += "/"
     markdown = re.sub(r"\]\((?!\/|https?:\/\/)", rf"]({base_url}", markdown)
     return markdown

--- a/app/tests/src/util/test_string_utils.py
+++ b/app/tests/src/util/test_string_utils.py
@@ -35,3 +35,21 @@ def test_split_list():
         ),
         ("Following are list items:\n    - This is a third sentence."),
     ]
+
+
+def test_resolve_urls_scenario1():
+    base_url = "https://example.com"
+    markdown = "[This is a link](/relative/path) and [another](https://example.com/absolute/path)"
+    assert (
+        string_utils.resolve_urls(base_url, markdown)
+        == "[This is a link](https://example.com/relative/path) and [another](https://example.com/absolute/path)"
+    )
+
+
+def test_resolve_urls_scenario2():
+    base_url = "https://example.com/some_webpage"
+    markdown = "[This is a link](relative/path) and [another](path2/index.html)"
+    assert (
+        string_utils.resolve_urls(base_url, markdown)
+        == "[This is a link](https://example.com/some_webpage/relative/path) and [another](https://example.com/some_webpage/path2/index.html)"
+    )


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-536

## Changes

Added regex to replace incomplete URLs with absolute URLs.

## Context for reviewers

Scrapy does not appear to have a built-in feature for this based on:
- https://github.com/scrapy/scrapy/issues/548

Tried to update the `href` attributes on `<a>` HTML tags, but I couldn't update the `response` object besides `.drop()`.

## Testing

Run `DEBUG_SCRAPINGS=true poetry run scrape-edd-web`
Search for relative links (i.e., text with `](/` or `]([a-g,i-z]` etc):
```
grep '](/' src/ingestion/pretty-edd_scrapings.json
grep ']([a-g,i-z]' src/ingestion/pretty-edd_scrapings.json

# brew install grep # this installs GNU grep for macs
ggrep -P '\]\((?!http)' src/ingestion/pretty-edd_scrapings.json
```
