### PR TITLE
feat: Make temperature configurable and set default to 0.0

### DIFF
--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -30,6 +30,7 @@ class AppConfig(PydanticBaseEnvConfig):
 
     # Default chat engine
     chat_engine: str = "guru-snap"
+    temperature: float = 0.0
 
     # Default LLM model
     llm: str | None = None

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from litellm import completion
 
+from src.app_config import app_config
+
 logger = logging.getLogger(__name__)
 
 PROMPT = """Provide answers in plain language written at the average American reading level.
@@ -73,7 +75,9 @@ def generate(
     messages.append({"content": query, "role": "user"})
 
     logger.info("Calling %s for query: %s with context:\n%s", llm, query, context_text)
-    response = completion(model=llm, messages=messages, **completion_args(llm))
+    response = completion(
+        model=llm, messages=messages, **completion_args(llm), temperature=app_config.temperature
+    )
 
     return response["choices"][0]["message"]["content"]
 

--- a/app/tests/mock/mock_completion.py
+++ b/app/tests/mock/mock_completion.py
@@ -3,7 +3,7 @@ import json
 from litellm import completion
 
 
-def mock_completion(model, messages):
+def mock_completion(model, messages, **kwargs):
     # Convert the messages list of dictionaries to a string
     messages = json.dumps(messages, sort_keys=True)
     # Strip generated JSON of escaped newlines to make it simple to compare with prompts


### PR DESCRIPTION
## Ticket

n/a -- quick change from our conversation during team time yesterday

## Changes
Set temperature to 0.0 for more repeatability

## Testing
Tricky to test because OpenAI doesn't actually respect temperatures of 0 (it will still be somewhat non-deterministic). I ran the same question through multiple times and did observe more consistent responses with the setting explicitly at 0.

Zero -- note the "key points" phrasing is consistent:
<img width="548" alt="Screenshot 2024-10-16 at 12 21 36 PM" src="https://github.com/user-attachments/assets/a888e4a0-5c25-48cb-90cb-a289dc224598">
<img width="537" alt="Screenshot 2024-10-16 at 12 25 39 PM" src="https://github.com/user-attachments/assets/258e9eb5-01f9-481c-ac1e-6e597b5ce05f">


Non-zero, either set explicitly to 1 or omitted from the API call:
<img width="542" alt="Screenshot 2024-10-16 at 12 23 29 PM" src="https://github.com/user-attachments/assets/b7d65dad-a317-4be9-a68f-8234d64a70b0">
<img width="544" alt="Screenshot 2024-10-16 at 12 25 28 PM" src="https://github.com/user-attachments/assets/d15e2455-ee4e-4211-862e-89c52789213b">
