### PR TITLE
perf: Set default sources to 50 for EDD bot

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -129,7 +129,7 @@ class BridgesEligibilityManualEngine(BaseEngine):
 
 
 class CaEddWebEngine(BaseEngine):
-    retrieval_k: int = 10
+    retrieval_k: int = 50
     retrieval_k_min_score: float = -1
 
     # Note: currently not used


### PR DESCRIPTION
- [ ] Update PR Title to follow this pattern: `[INTENT]: [MESSAGE]`

## Ticket
n/a


## Changes
Set default to retrieve 50 chunks


## Context for reviewers
 - The LLM now decides what it wants to cite, so pulling more sources rather than fewer is hypothesized to be better

## Testing
E.g.:
<img width="544" alt="Screenshot 2024-10-17 at 2 09 13 PM" src="https://github.com/user-attachments/assets/efc15c17-dac1-47a1-9fa9-6ebd138debdb">
