### PR TITLE
refactor: Add ingest_util.tokenize()

### DIFF
--- a/app/src/ingest_bem_pdfs.py
+++ b/app/src/ingest_bem_pdfs.py
@@ -18,7 +18,7 @@ from src.ingestion.pdf_postprocess import add_markdown, associate_stylings, grou
 from src.ingestion.pdf_stylings import extract_stylings
 from src.util import pdf_utils
 from src.util.file_util import get_files
-from src.util.ingest_utils import process_and_ingest_sys_args
+from src.util.ingest_utils import process_and_ingest_sys_args, tokenize
 from src.util.pdf_utils import Heading
 from src.util.string_utils import split_list, split_paragraph
 
@@ -196,7 +196,7 @@ def _split_into_chunks(document: Document, grouped_texts: list[EnrichedText]) ->
         assert paragraph.page_number is not None
 
         embedding_model = app_config.sentence_transformer
-        token_count = len(embedding_model.tokenizer.tokenize(paragraph.text))
+        token_count = len(tokenize(paragraph.text))
         if token_count > embedding_model.max_seq_length:
             # Split the text into chunks of approximately equal length by characters,
             # which doesn't necessarily mean equal number of tokens, but close enough.
@@ -252,7 +252,7 @@ def _add_embeddings(chunks: list[Chunk]) -> None:
 
     for i, chunk in enumerate(chunks):
         chunk.mpnet_embedding = embeddings[i]  # type: ignore
-        chunk.tokens = len(embedding_model.tokenizer.tokenize(chunk.content))
+        chunk.tokens = len(tokenize(chunk.content))
         assert (
             chunk.tokens <= embedding_model.max_seq_length
         ), f"Text too long for embedding model: {chunk.tokens} tokens: {len(chunk.content)} chars: {chunk.content[:100]} ..."

--- a/app/src/ingest_edd_web.py
+++ b/app/src/ingest_edd_web.py
@@ -7,7 +7,7 @@ from smart_open import open as smart_open
 from src.adapters import db
 from src.app_config import app_config
 from src.db.models.document import Chunk, Document
-from src.util.ingest_utils import process_and_ingest_sys_args
+from src.util.ingest_utils import process_and_ingest_sys_args, tokenize
 
 logger = logging.getLogger(__name__)
 
@@ -52,9 +52,7 @@ def _chunk_page(content: str) -> list[Chunk]:
     content_split_by_double_newlines = content.split("\n\n")
     subsections = [content_split_by_double_newlines[0]]
     for subsection in content_split_by_double_newlines[1:]:
-        tokens_with_new_subsection = len(
-            embedding_model.tokenizer.tokenize(subsections[-1] + subsection)
-        )
+        tokens_with_new_subsection = len(tokenize(subsections[-1] + subsection))
         if tokens_with_new_subsection < embedding_model.max_seq_length:
             subsections[-1] += "\n\n" + subsection
         else:
@@ -67,7 +65,7 @@ def _chunk_page(content: str) -> list[Chunk]:
         Chunk(
             content=subsection,
             mpnet_embedding=embedding,
-            tokens=len(embedding_model.tokenizer.tokenize(subsection)),
+            tokens=len(tokenize(subsection)),
         )
         for subsection, embedding in zip(subsections, subsection_embeddings, strict=True)
     ]

--- a/app/src/ingest_guru_cards.py
+++ b/app/src/ingest_guru_cards.py
@@ -8,7 +8,7 @@ from src.adapters import db
 from src.app_config import app_config
 from src.db.models.document import Chunk, Document
 from src.util.html import get_text_from_html
-from src.util.ingest_utils import process_and_ingest_sys_args
+from src.util.ingest_utils import process_and_ingest_sys_args, tokenize
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def _ingest_cards(
         db_session.add(document)
 
         embedding_model = app_config.sentence_transformer
-        tokens = len(embedding_model.tokenizer.tokenize(content))
+        tokens = len(tokenize(content))
         mpnet_embedding = embedding_model.encode(content, show_progress_bar=False)
         chunk = Chunk(
             document=document, content=content, tokens=tokens, mpnet_embedding=mpnet_embedding

--- a/app/src/ingest_policy_pdfs.py
+++ b/app/src/ingest_policy_pdfs.py
@@ -11,7 +11,7 @@ from src.adapters import db
 from src.app_config import app_config
 from src.db.models.document import Chunk, Document
 from src.util.file_util import get_files
-from src.util.ingest_utils import process_and_ingest_sys_args
+from src.util.ingest_utils import process_and_ingest_sys_args, tokenize
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ def process_chunk(text: str, document: Document, db_session: db.Session) -> None
         sentence = text[current_position : boundary_start + 1]
         current_position = boundary_end
 
-        token_count = len(embedding_model.tokenizer.tokenize(sentence))
+        token_count = len(tokenize(sentence))
 
         if current_token_count + token_count <= embedding_model.max_seq_length:
             current_chunk.append(sentence)

--- a/app/src/util/ingest_utils.py
+++ b/app/src/util/ingest_utils.py
@@ -4,6 +4,7 @@ from logging import Logger
 from typing import Callable
 
 from sqlalchemy import delete, select
+from transformers import PreTrainedTokenizerFast
 
 from src.adapters import db
 from src.app_config import app_config
@@ -58,3 +59,18 @@ def process_and_ingest_sys_args(argv: list[str], logger: Logger, ingestion_call:
         db_session.commit()
 
     logger.info("Finished processing")
+
+
+def tokenize(text: str) -> list[str]:
+    """
+    The add_special_tokens argument is specified in PreTrainedTokenizerFast.encode_plus(), parent class of MPNetTokenizerFast.
+    It defaults to True for encode_plus() but defaults to False for .tokenize().
+    Setting add_special_tokens=True will add the special tokens CLS(0) and SEP(2) to the beginning and end of the input text.
+    """
+    tokenizer = app_config.sentence_transformer.tokenizer
+    if isinstance(tokenizer, PreTrainedTokenizerFast):
+        return tokenizer.tokenize(text, add_special_tokens=True)
+    elif tokenizer.__class__.__name__ == "MockTokenizer":
+        return tokenizer.tokenize(text)
+
+    raise ValueError(f"Unexpected tokenizer: {tokenizer.__class__}")


### PR DESCRIPTION

## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1729194497470359)

## Changes

Account for start and end tokens when tokenizing and counting tokens.

## Testing

`sentence_transformer.tokenizer.tokenize(split, add_special_tokens=True)` adds the token padding `'<s>'` and `'</s>'`:
```
['<s>', '#', 'unemployment', 'insurance', '–', 'forms', 'and', 'publications', '#', '#', 'publications', '[', 'de', '127', '##5', '##b', ']', '(', 'https', ':', '/', '/', 'ed', '##d', '.', 'ca', '.', 'gov', '/', 'site', '##asse', '##ts', '/', 'files', '/', 'pdf', '_', 'pub', '_', 'ct', '##r', '/', 'de', '##12', '##75', '##b', '.', 'pdf', ')', '–', 'english', '|', '[', 'de', '127', '##5', '##b', '/', 'a', ']', '(', 'https', ':', '/', '/', 'ed', '##d', '.', 'ca', '.', 'gov', '/', 'site', '##asse', '##ts', '/', 'files', '/', 'pdf', '_', 'pub', '_', 'ct', '##r', '/', 'de', '##12', '##75', '##ba', '.', 'pdf', ')', '–', 'armenian', '</s>']
```
