### PR TITLE
fix: Exclude WSIN webpages

### DIFF
--- a/app/src/ingestion/edd/spiders/edd_spider.py
+++ b/app/src/ingestion/edd/spiders/edd_spider.py
@@ -35,10 +35,12 @@ class EddSpider(CrawlSpider):
                     # "EPiServer/CMS/Content" links to CMS backend content
                     "EPiServer/CMS/Content",
                     # "/archived-news-releases-..." redirects to pdf files
-                    "en/about_edd/archived-news-releases",
-                    "en/about_edd/google-translate",
-                    "en/about_edd/news_releases",
+                    r"en/about_edd/archived.news.releases",
+                    r"en/about_edd/news.releases",
                     "en/newsroom",
+                    "en/about_edd/google-translate",
+                    # Exclude WSINs (Workforce Services Information Notices)
+                    "en/jobs_and_training/Information_Notices/wsin",
                 ),
                 allow_domains=allowed_domains,
                 deny_domains=(


### PR DESCRIPTION
## Ticket

Expanding on #100, exclude webpages related to WSINs (Workforce Services Information Notices)

## Changes

- exclude WSIN (Workforce Services Information Notice) webpages
- Use regex to exclude more irrelevant webpages

## Testing

`DEBUG_SCRAPINGS=true poetry run scrape-edd-web`
Reduces webpages to scrap to about 800 pages