### PR TITLE
fix: Rejoin headings with the subsequent first paragraph

### DIFF
--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -26,7 +26,24 @@ citation_factory = CitationFactory()
 
 
 def default_chunk_splitter(chunk: Chunk) -> list[str]:
-    return chunk.content.split("\n\n")
+    splits = [split for split in chunk.content.split("\n\n") if split]
+    # Rejoin headings with the subsequent first paragraph
+    better_splits = []
+    skip_next = False
+    for i, split in enumerate(splits):
+        if skip_next:
+            skip_next = False
+            continue
+
+        next_split = splits[i + 1] if i + 1 < len(splits) else None
+        if next_split and split.startswith("#") and not next_split.startswith("#"):
+            better_splits.append(f"{split}\n{next_split}")
+            skip_next = True
+            continue
+
+        better_splits.append(split)
+
+    return better_splits
 
 
 def split_into_subsections(

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -89,7 +89,8 @@ def test_default_chunk_splitter():
             "\n\n"
             "### Heading without next paragraph\n\n"
             "## Last Heading\n\n"
-            "Last paragraph."
+            "Last paragraph.\n\n"
+            "## Last Heading without next paragraph\n"
         )
     )
     assert default_chunk_splitter(chunk) == [
@@ -99,4 +100,5 @@ def test_default_chunk_splitter():
         "### Heading with empty next paragraph",
         "### Heading without next paragraph",
         "## Last Heading\nLast paragraph.",
+        "## Last Heading without next paragraph\n",
     ]

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -3,6 +3,7 @@ import pytest
 from src.citations import (
     CitationFactory,
     create_prompt_context,
+    default_chunk_splitter,
     remap_citation_ids,
     split_into_subsections,
 )
@@ -75,3 +76,27 @@ def test_remap_citation_ids(subsections):
         subsections[1].id: subsections[1]._replace(id="1"),
         subsections[0].id: subsections[0]._replace(id="2"),
     }
+
+
+def test_default_chunk_splitter():
+    chunk = ChunkFactory.build(
+        content=(
+            "## My Heading\n\n"
+            "First paragraph.\n\n"
+            "Paragraph two.\n\n"
+            "And paragraph 3\n\n"
+            "### Heading with empty next paragraph\n\n"
+            "\n\n"
+            "### Heading without next paragraph\n\n"
+            "## Last Heading\n\n"
+            "Last paragraph."
+        )
+    )
+    assert default_chunk_splitter(chunk) == [
+        "## My Heading\nFirst paragraph.",
+        "Paragraph two.",
+        "And paragraph 3",
+        "### Heading with empty next paragraph",
+        "### Heading without next paragraph",
+        "## Last Heading\nLast paragraph.",
+    ]


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-510

## Changes

Rejoin headings with the subsequent first paragraph so that headings are not cited by themselves.

## Testing

Updated unit test