### PR TITLE
fix: Render citation headings HTML on same line as div

### DIFF
--- a/app/src/format.py
+++ b/app/src/format.py
@@ -160,7 +160,9 @@ def format_web_subsections(
         _accordion_id += 1
         chunk = citation.chunk
         citation_headings = (
-            f"<div><b>{' → '.join(chunk.headings)}</b></div>" if chunk.headings else ""
+            f"<div><b>{' → '.join(chunk.headings)}</b></div>"
+            if chunk.headings
+            else "<div>&nbsp;</div>"
         )
         formatted_subsection = to_html(citation.text)
 
@@ -181,7 +183,8 @@ def format_web_subsections(
                     {citation.id}. {chunk.document.name}
                 </button>
             </h4>
-            <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>{citation_headings}
+            <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>
+                {citation_headings}
                 <div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_subsection}</div>
                 {citation_link}
             </div>

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -181,8 +181,7 @@ def format_web_subsections(
                     {citation.id}. {chunk.document.name}
                 </button>
             </h4>
-            <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>
-                {citation_headings}
+            <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>{citation_headings}
                 <div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{formatted_subsection}</div>
                 {citation_link}
             </div>


### PR DESCRIPTION
## Ticket

n/a

## Changes
Render `{citation_headings}`  to avoid an empty line, which causes Chainlit to render what follows as markdown instead of HTML.

## Testing
Without change:
<img width="546" alt="Screenshot 2024-10-23 at 2 00 07 PM" src="https://github.com/user-attachments/assets/2346e46a-ca47-4aa5-9e82-1ac6f1728fab">

With change:

<img width="542" alt="Screenshot 2024-10-23 at 2 00 15 PM" src="https://github.com/user-attachments/assets/8f03176a-3a06-472b-a52f-6258e8c451cd">
