### PR TITLE
fix: Ignore all EDD social-media-toolkit webpages

### DIFF
--- a/app/src/ingestion/edd/spiders/edd_spider.py
+++ b/app/src/ingestion/edd/spiders/edd_spider.py
@@ -42,7 +42,7 @@ class EddSpider(CrawlSpider):
                     # Exclude WSINs (Workforce Services Information Notices)
                     "en/jobs_and_training/Information_Notices/wsin",
                     # Irrelevant pages
-                    r"en/disability/paid-family-leave/.*/social-media-toolkit",
+                    r"en/.*social-media-toolkit",
                 ),
                 allow_domains=allowed_domains,
                 deny_domains=(


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1729707559404419)

## Changes

Ignore all EDD page ending in `social-media-toolkit`. They have complex tables; we'll address them later if needed.


## Testing

```
DEBUG_SCRAPINGS=true poetry run scrape-edd-web
make ingest-edd-web DATASET_ID=ca-edd-web BENEFIT_PROGRAM=employment BENEFIT_REGION=California FILEPATH=src/ingestion/edd_scrapings.json
```