### PR TITLE
perf: Increase CPU and memory of ECS tasks

### DIFF
--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -10,8 +10,8 @@ module "dev_config" {
   enable_https                    = true
   has_database                    = true
   has_incident_management_service = local.has_incident_management_service
-  service_cpu                     = 1024
-  service_memory                  = 4096
+  service_cpu                     = 2048
+  service_memory                  = 8192
 
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html


### PR DESCRIPTION
## Ticket

n/a


## Changes
 - Update default CPU and memory for ECS tasks such as data ingestion run in the `dev` environment


## Context for reviewers
 - The web ingestion task runs out of memory with the default of 4GB.