### PR TITLE
fix: Citations UI: Show single arrow for missing middle headings

### DIFF
--- a/app/src/format.py
+++ b/app/src/format.py
@@ -159,11 +159,7 @@ def format_web_subsections(
     for _, citation in remapped_citations.items():
         _accordion_id += 1
         chunk = citation.chunk
-        citation_headings = (
-            f"<div><b>{' → '.join(chunk.headings)}</b></div>"
-            if chunk.headings
-            else "<div>&nbsp;</div>"
-        )
+        citation_headings = _get_breadcrumb_html(chunk.headings)
         formatted_subsection = to_html(citation.text)
 
         citation_link = ""
@@ -201,6 +197,13 @@ def format_web_subsections(
             + "</div>"
         )
     return "<div>" + response_with_citations + "</div>"
+
+
+def _get_breadcrumb_html(headings: Sequence[str] | None) -> str:
+    if not headings:
+        return "<div>&nbsp;</div>"
+
+    return f"<div><b>{' → '.join(h for h in headings if h)}</b></div>"
 
 
 ChunkWithCitation = tuple[Chunk, Sequence[Subsection]]

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -7,6 +7,7 @@ from src.db.models.document import Chunk, ChunkWithScore, Document, Subsection
 from src.format import (
     _add_ellipses,
     _format_to_accordion_html,
+    _get_breadcrumb_html,
     _group_by_document_and_chunks,
     format_bem_documents,
     format_bem_subsections,
@@ -230,3 +231,14 @@ def test__group_by_document_and_chunks():
             (chunk_list[3], [subsections[4]]),
         ],
     }
+
+
+def test__get_breadcrumb_html():
+    headings = []
+    assert _get_breadcrumb_html(headings) == "<div>&nbsp;</div>"
+
+    headings = ["Heading 1", "Heading 2", "Heading 3"]
+    assert _get_breadcrumb_html(headings) == "<div><b>Heading 1 → Heading 2 → Heading 3</b></div>"
+
+    headings = ["Heading 1", "", "Heading 3"]
+    assert _get_breadcrumb_html(headings) == "<div><b>Heading 1 → Heading 3</b></div>"


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1729789701680649?thread_ts=1729780302.454019&cid=C06DP498D1D)

When the EDD webpage skips from H1 to H3 without any H2 heading, the breadcrumb shows 2 consecutive arrows:
![image](https://github.com/user-attachments/assets/8879889b-962f-4665-bcc0-2d2f71593f4b)

## Changes

Don't show 2 consecutive arrows when a heading is missing. Instead, show a single arrow between headings.

## Testing

Added unit test
