### PR TITLE
fix: Show only two nested headers

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -39,3 +39,6 @@ documents/
 
 .ipynb_checkpoints
 
+# Chainlit translation files
+.chainlit/translations/*.json
+!.chainlit/translations/en-US.json

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -159,7 +159,7 @@ def format_web_subsections(
     for _, citation in remapped_citations.items():
         _accordion_id += 1
         chunk = citation.chunk
-        citation_headings = _get_breadcrumb_html(chunk.headings)
+        citation_headings = _get_breadcrumb_html(chunk.headings, chunk.document.name)
         formatted_subsection = to_html(citation.text)
 
         citation_link = ""
@@ -199,11 +199,21 @@ def format_web_subsections(
     return "<div>" + response_with_citations + "</div>"
 
 
-def _get_breadcrumb_html(headings: Sequence[str] | None) -> str:
+def _get_breadcrumb_html(headings: Sequence[str] | None, document_name: str) -> str:
     if not headings:
         return "<div>&nbsp;</div>"
 
-    return f"<div><b>{' → '.join(h for h in headings if h)}</b></div>"
+    # Skip empty headings
+    headings = [h for h in headings if h]
+
+    # Only show last two headings
+    headings = headings[-2:]
+
+    # Don't repeat document name
+    if headings[0] == document_name:
+        headings = headings[1:]
+
+    return f"<div><b>{' → '.join(headings)}</b></div>"
 
 
 ChunkWithCitation = tuple[Chunk, Sequence[Subsection]]

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -235,10 +235,16 @@ def test__group_by_document_and_chunks():
 
 def test__get_breadcrumb_html():
     headings = []
-    assert _get_breadcrumb_html(headings) == "<div>&nbsp;</div>"
+    assert _get_breadcrumb_html(headings, "Doc name") == "<div>&nbsp;</div>"
 
+    # Omit first heading
     headings = ["Heading 1", "Heading 2", "Heading 3"]
-    assert _get_breadcrumb_html(headings) == "<div><b>Heading 1 → Heading 2 → Heading 3</b></div>"
+    assert _get_breadcrumb_html(headings, "Doc name") == "<div><b>Heading 2 → Heading 3</b></div>"
 
+    # Omit empty headings
     headings = ["Heading 1", "", "Heading 3"]
-    assert _get_breadcrumb_html(headings) == "<div><b>Heading 1 → Heading 3</b></div>"
+    assert _get_breadcrumb_html(headings, "Doc name") == "<div><b>Heading 1 → Heading 3</b></div>"
+
+    # Omit headings that match doc name
+    headings = ["Doc name", "Heading 2"]
+    assert _get_breadcrumb_html(headings, "Doc name") == "<div><b>Heading 2</b></div>"


### PR DESCRIPTION
## Ticket

n/a

## Changes
 - Show only the deepest two headers
 - If the top of the two deepest is the same as the document name, skip it
 - Unrelated change: gitignore Chainlit translation files (not sure what process is generating these)


## Context for reviewers
From quick Slack conversation with design: https://nava.slack.com/archives/C06ETE82UHM/p1729864998665799