### PR TITLE
feat: Show document.dataset in UI; fix: citation markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ To load a JSON file containing Guru cards in your local environment, from within
 make ingest-guru-cards DATASET_ID=dataset_identifier BENEFIT_PROGRAM=SNAP BENEFIT_REGION=Michigan FILEPATH=path/to/some_cards.json
 ```
 
+Note that the DATASET_ID `dataset_identifier` will be used in the chatbot web UI to prefix each citation, so use a user-friendly identifier like "CA EDD".
+
 To load the BEM pdfs in your local environment, from within `/app`:
 
 ```bash
@@ -57,7 +59,7 @@ Scrape web pages and save to a JSON file, for example:
 poetry run scrape-edd-web
 ```
 
-To load into the vector database, see sections above but use `make ingest-edd-web DATASET_ID=edd-web BENEFIT_PROGRAM=employment BENEFIT_REGION=California FILEPATH=src/ingestion/edd_scrapings.json`.
+To load into the vector database, see sections above but use `make ingest-edd-web DATASET_ID="CA EDD" BENEFIT_PROGRAM=employment BENEFIT_REGION=California FILEPATH=src/ingestion/edd_scrapings.json`.
 
 ## Batch processing
 

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -173,5 +173,5 @@ class CaEddWebEngine(BaseEngine):
 
     engine_id: str = "ca-edd-web"
     name: str = "CA EDD Web Chat Engine"
-    datasets = ["ca-edd-web"]
+    datasets = ["CA EDD"]
     formatter = staticmethod(format_web_subsections)

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -160,7 +160,7 @@ def build_accordions(
                     class="usa-accordion__button"
                     aria-expanded="false"
                     aria-controls="a-{_accordion_id}">
-                    {",".join(citation_numbers)}. {document.name}
+                    {",".join(citation_numbers)}. {document.dataset}: {document.name}
                 </button>
             </h4>
             <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -138,7 +138,7 @@ def build_accordions(
                 citation_numbers.append(chunk_subsection.id)
                 citation_body += (
                     f"<div>Citation #{chunk_subsection.id}: </div>"
-                    f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{chunk_subsection.text}</div>'
+                    f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{to_html(chunk_subsection.text)}</div>'
                 )
                 # generated citation links for BEM redirect to specific pages
                 if data_source == "BEM":


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-534

## Changes

* Show `document.dataset` in the UI citations
* Updated README.md

## Testing
Re-ingest with the correct `DATASET_ID` (30 mins):
```
cd app
DEBUG_SCRAPINGS=true poetry run scrape-edd-web
# Enable saving chunks to `chunks-log` subfolder
touch SAVE_CHUNKS
make ingest-edd-web DATASET_ID="CA EDD" BENEFIT_PROGRAM=employment BENEFIT_REGION=California FILEPATH=src/ingestion/edd_scrapings.json
```
or update your DB (1 second):
`update "document" set dataset='CA EDD' where dataset ='ca-edd-web'`

<img width="818" alt="image" src="https://github.com/user-attachments/assets/f19f18d6-1a87-4bf3-9b7a-e24c13905870">

After [fix citation_subsection.text conversion to html](https://github.com/navapbc/labs-decision-support-tool/pull/125/commits/ef6e3979283c453e42903a7bf810af1ed38671d6):
<img width="774" alt="image" src="https://github.com/user-attachments/assets/a6b79d8a-cd36-4e37-9ec1-e57d03a4372e">

