### PR TITLE
fix: Include all headers in batch CSV generation

### DIFF
--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -26,7 +26,10 @@ async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
             row.update(data)
 
         # Update fieldnames to include new columns
-        all_fieldnames = list(reader.fieldnames) + list(processed_data[0].keys())
+        all_fieldnames = list(reader.fieldnames) + [key for p in processed_data for key in p.keys()]
+        # De-duplicate while preserving order -- ignore linter warning that seen.add always returns None
+        seen = set()
+        all_fieldnames = [f for f in all_fieldnames if not (f in seen or seen.add(f))]  # type: ignore
 
     result_file = tempfile.NamedTemporaryFile(delete=False, mode="w", newline="", encoding="utf-8")
     writer = csv.DictWriter(result_file, fieldnames=all_fieldnames)

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -26,11 +26,11 @@ async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
             row.update(data)
 
         # Update fieldnames to include new columns
-        all_fieldnames = {
+        all_fieldnames_dict = {
             f: None
             for f in list(reader.fieldnames) + [key for p in processed_data for key in p.keys()]
         }
-        all_fieldnames = list(all_fieldnames.keys())
+        all_fieldnames = list(all_fieldnames_dict.keys())
 
     result_file = tempfile.NamedTemporaryFile(delete=False, mode="w", newline="", encoding="utf-8")
     writer = csv.DictWriter(result_file, fieldnames=all_fieldnames)

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -26,7 +26,10 @@ async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
             row.update(data)
 
         # Update fieldnames to include new columns
-        all_fieldnames = {f: None for f in list(reader.fieldnames) + [key for p in processed_data for key in p.keys()]}
+        all_fieldnames = {
+            f: None
+            for f in list(reader.fieldnames) + [key for p in processed_data for key in p.keys()]
+        }
         all_fieldnames = list(all_fieldnames.keys())
 
     result_file = tempfile.NamedTemporaryFile(delete=False, mode="w", newline="", encoding="utf-8")

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -26,10 +26,8 @@ async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
             row.update(data)
 
         # Update fieldnames to include new columns
-        all_fieldnames = list(reader.fieldnames) + [key for p in processed_data for key in p.keys()]
-        # De-duplicate while preserving order -- ignore linter warning that seen.add always returns None
-        seen = set()
-        all_fieldnames = [f for f in all_fieldnames if not (f in seen or seen.add(f))]  # type: ignore
+        all_fieldnames = {f: None for f in list(reader.fieldnames) + [key for p in processed_data for key in p.keys()]}
+        all_fieldnames = list(all_fieldnames.keys())
 
     result_file = tempfile.NamedTemporaryFile(delete=False, mode="w", newline="", encoding="utf-8")
     writer = csv.DictWriter(result_file, fieldnames=all_fieldnames)

--- a/app/tests/src/test_batch_process.py
+++ b/app/tests/src/test_batch_process.py
@@ -40,16 +40,18 @@ async def test_batch_process_invalid(invalid_csv, engine):
 @pytest.mark.asyncio
 async def test_batch_process(monkeypatch, sample_csv, engine):
     def mock__process_question(question, engine):
-        return {"answer": f"Answer to {question}", "field_2": "value_2"}
+        if question == "What is AI?":
+            return {"answer": "Answer to What is AI?", "field_2": "value_2"}
+        return {"answer": "Answer to Second question", "field_3": "value_3"}
 
     monkeypatch.setattr("src.batch_process._process_question", mock__process_question)
 
     result = await batch_process(sample_csv, engine)
     with open(result) as f:
         assert f.read() == (
-            "question,metadata,answer,field_2\n"
-            "What is AI?,some metadata,Answer to What is AI?,value_2\n"
-            "Second question,other metadata,Answer to Second question,value_2\n"
+            "question,metadata,answer,field_2,field_3\n"
+            "What is AI?,some metadata,Answer to What is AI?,value_2,\n"
+            "Second question,other metadata,Answer to Second question,,value_3\n"
         )
 
 


### PR DESCRIPTION
## Ticket

n/a


## Changes
 - Instead of gathering the keys from the first processed row of the CSV, gather all of the keys from all of the rows (since later rows may have more keys if they have more citations)

## Testing
Added coverage to the test for this function. The test will now fail if the change is reverted
