### PR TITLE
refactor: Use FormattingConfig in format.py

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -199,7 +199,8 @@ async def on_message(message: cl.Message) -> None:
             lambda: engine.on_message(question=message.content, chat_history=chat_history)
         )()
         logger.info("Response: %s", result.response)
-        if hasattr(engine, "formatter"):
+        if engine.formatter:
+            # This block is to accommodate the old Guru chat engine
             msg_content = engine.formatter(
                 chunks_shown_max_num=engine.chunks_shown_max_num,
                 chunks_shown_min_score=engine.chunks_shown_min_score,

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -207,7 +207,6 @@ async def on_message(message: cl.Message) -> None:
                 chunks_with_scores=result.chunks_with_scores,
                 subsections=result.subsections,
                 raw_response=result.response,
-                config=engine.formatting_config,
             )
         else:
             msg_content = build_accordions(

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -11,6 +11,7 @@ from src import chat_engine
 from src.app_config import app_config
 from src.batch_process import batch_process
 from src.chat_engine import ChatEngineInterface, OnMessageResult
+from src.format import build_accordions
 from src.generate import get_models
 from src.login import require_login
 
@@ -198,13 +199,21 @@ async def on_message(message: cl.Message) -> None:
             lambda: engine.on_message(question=message.content, chat_history=chat_history)
         )()
         logger.info("Response: %s", result.response)
-        msg_content = engine.formatter(
-            chunks_shown_max_num=engine.chunks_shown_max_num,
-            chunks_shown_min_score=engine.chunks_shown_min_score,
-            chunks_with_scores=result.chunks_with_scores,
-            subsections=result.subsections,
-            raw_response=result.response,
-        )
+        if hasattr(engine, "formatter"):
+            msg_content = engine.formatter(
+                chunks_shown_max_num=engine.chunks_shown_max_num,
+                chunks_shown_min_score=engine.chunks_shown_min_score,
+                chunks_with_scores=result.chunks_with_scores,
+                subsections=result.subsections,
+                raw_response=result.response,
+                config=engine.formatting_config,
+            )
+        else:
+            msg_content = build_accordions(
+                subsections=result.subsections,
+                raw_response=result.response,
+                config=engine.formatting_config,
+            )
 
         await cl.Message(
             content=msg_content,

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -171,7 +171,7 @@ class BridgesEligibilityManualEngine(BaseEngine):
 
 
 class CaEddWebEngine(BaseEngine):
-    retrieval_k: int = 5
+    retrieval_k: int = 50
     retrieval_k_min_score: float = -1
 
     # Note: currently not used

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -5,7 +5,7 @@ from typing import Callable, Sequence
 
 from src.citations import CitationFactory, create_prompt_context, split_into_subsections
 from src.db.models.document import ChunkWithScore, Subsection
-from src.format import format_bem_subsections, format_guru_cards, format_web_subsections
+from src.format import BemFormattingConfig, FormattingConfig, format_guru_cards
 from src.generate import PROMPT, MessageAttributes, analyze_message, generate
 from src.retrieve import retrieve_with_scores
 from src.util.class_utils import all_subclasses
@@ -25,7 +25,9 @@ class ChatEngineInterface(ABC):
     engine_id: str
     name: str
 
-    # Function for formatting responses
+    # Configuration for formatting responses
+    formatting_config: FormattingConfig
+    # Function for formatting responses instead of the default
     formatter: Callable
 
     # Thresholds that determine which retrieved documents are shown in the UI
@@ -83,6 +85,8 @@ class BaseEngine(ChatEngineInterface):
         "chunks_shown_min_score",
         "system_prompt",
     ]
+
+    formatting_config = FormattingConfig()
 
     def on_message(self, question: str, chat_history: list[dict[str, str]]) -> OnMessageResult:
         attributes = analyze_message(self.llm, question)
@@ -160,11 +164,12 @@ class BridgesEligibilityManualEngine(BaseEngine):
     engine_id: str = "bridges-eligibility-manual"
     name: str = "Michigan Bridges Eligibility Manual Chat Engine"
     datasets = ["bridges-eligibility-manual"]
-    formatter = staticmethod(format_bem_subsections)
+
+    formatting_config = BemFormattingConfig()
 
 
 class CaEddWebEngine(BaseEngine):
-    retrieval_k: int = 50
+    retrieval_k: int = 5
     retrieval_k_min_score: float = -1
 
     # Note: currently not used
@@ -174,4 +179,3 @@ class CaEddWebEngine(BaseEngine):
     engine_id: str = "ca-edd-web"
     name: str = "CA EDD Web Chat Engine"
     datasets = ["CA EDD"]
-    formatter = staticmethod(format_web_subsections)

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -27,8 +27,10 @@ class ChatEngineInterface(ABC):
 
     # Configuration for formatting responses
     formatting_config: FormattingConfig
+
     # Function for formatting responses instead of the default
-    formatter: Callable
+    # Only used by the old Guru chat engine
+    formatter: Callable | None = None
 
     # Thresholds that determine which retrieved documents are shown in the UI
     chunks_shown_max_num: int = 5

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -19,6 +19,47 @@ logger = logging.getLogger(__name__)
 _accordion_id = random.randint(0, 1000000)
 
 
+class FormattingConfig:
+    "Default formatting configuration"
+    def __init__(self) -> None:
+        self.add_citation_link_per_subsection = False
+
+    def return_citation_link(self, chunk: Chunk) -> str:
+        if chunk.document.source:
+            return f"<p>Source: <a href={chunk.document.source!r}>{chunk.document.source}</a></p>"
+        return ""
+
+    def get_superscript_link(self, chunk: Chunk) -> str:
+        return chunk.document.source if chunk.document.source else "#"
+
+    def build_accordion_body(self, citation_body: str) -> str:
+        return to_html(citation_body)
+
+
+class BemFormattingConfig(FormattingConfig):
+    "BEM-specific formatting configuration"
+    def __init__(self) -> None:
+        self.add_citation_link_per_subsection = True
+
+    def return_citation_link(self, chunk: Chunk) -> str:
+        bem_url_for_page = get_bem_url(chunk.document.name)
+        if chunk.page_number:
+            bem_url_for_page += "#page=" + str(chunk.page_number)
+        return (
+            f"<p><a href={bem_url_for_page!r}>Open document to page {chunk.page_number}</a></p>"
+            if chunk.page_number
+            else ""
+        )
+
+    def get_superscript_link(self, chunk: Chunk) -> str:
+        link = get_bem_url(chunk.document.name) if "BEM" in chunk.document.name else "#"
+        link += "#page=" + str(chunk.page_number) if chunk.page_number else ""
+        return link
+
+    def build_accordion_body(self, citation_body: str) -> str:
+        return to_html(replace_bem_with_link(citation_body))
+
+
 def format_guru_cards(
     chunks_shown_max_num: int,
     chunks_shown_min_score: float,
@@ -26,7 +67,7 @@ def format_guru_cards(
     subsections: Sequence[Subsection],
     raw_response: str,
 ) -> str:
-    response_with_citations = reify_citations(raw_response, subsections, data_source="Guru")
+    response_with_citations = reify_citations(raw_response, subsections, FormattingConfig())
 
     cards_html = ""
     for chunk_with_score in chunks_with_scores[:chunks_shown_max_num]:
@@ -84,36 +125,13 @@ def format_bem_subsections(
     subsections: Sequence[Subsection],
     raw_response: str,
 ) -> str:
-    return build_accordions(subsections=subsections, raw_response=raw_response, data_source="BEM")
-
-
-def build_accordion_body(citation_body: str, source: str) -> str:
-    if source == "BEM":
-        return to_html(replace_bem_with_link(citation_body))
-    else:
-        return to_html(citation_body)
-
-
-def return_citation_link(chunk: Chunk, data_source: str) -> str:
-    if data_source == "BEM":
-        bem_url_for_page = get_bem_url(chunk.document.name)
-        if chunk.page_number:
-            bem_url_for_page += "#page=" + str(chunk.page_number)
-        return (
-            f"<p><a href={bem_url_for_page!r}>Open document to page {chunk.page_number}</a></p>"
-            if chunk.page_number
-            else ""
-        )
-    else:
-        if chunk.document.source:
-            return f"<p>Source: <a href={chunk.document.source!r}>{chunk.document.source}</a></p>"
-    return ""
+    return build_accordions(
+        subsections=subsections, raw_response=raw_response, config=BemFormattingConfig()
+    )
 
 
 def build_accordions(
-    subsections: Sequence[Subsection],
-    raw_response: str,
-    data_source: str,
+    subsections: Sequence[Subsection], raw_response: str, config: FormattingConfig
 ) -> str:
     global _accordion_id
 
@@ -133,25 +151,23 @@ def build_accordions(
                 citation_body += f"<b>{citation_headings}</b>"
                 rendered_heading = citation_headings
 
-            citation_link = return_citation_link(chunk, data_source=data_source)
+            citation_link = config.return_citation_link(chunk)
             for chunk_subsection in subsection_list:
                 citation_numbers.append(chunk_subsection.id)
                 citation_body += (
                     f"<div>Citation #{chunk_subsection.id}: </div>"
                     f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{to_html(chunk_subsection.text)}</div>'
                 )
-                # generated citation links for BEM redirect to specific pages
-                if data_source == "BEM":
+                if config.add_citation_link_per_subsection:
+                    # generated citation links for BEM redirect to specific pages
                     citation_body += f"<div>{citation_link}</div>"
-        # if webpage, return source link once
-        if data_source != "BEM":
+
+        if not config.add_citation_link_per_subsection:
+            # return source link once
             citation_body += f"<div>{citation_link}</div>"
 
         _accordion_id += 1
-        formatted_citation_body = build_accordion_body(
-            citation_body=citation_body,
-            source=data_source,
-        )
+        formatted_citation_body = config.build_accordion_body(citation_body)
         citations_html += f"""
         <div class="usa-accordion" id=accordion-{_accordion_id}>
             <h4 class="usa-accordion__heading">
@@ -170,9 +186,7 @@ def build_accordions(
 
     # This heading is important to prevent Chainlit from embedding citations_html
     # as the next part of a a list in response_with_citations
-    response_with_citations = to_html(
-        _add_citation_links(raw_response, remapped_citations, data_source)
-    )
+    response_with_citations = to_html(_add_citation_links(raw_response, remapped_citations, config))
     if citations_html:
         return (
             "<div>"
@@ -191,7 +205,9 @@ def format_web_subsections(
     subsections: Sequence[Subsection],
     raw_response: str,
 ) -> str:
-    return build_accordions(subsections=subsections, raw_response=raw_response, data_source="EDD")
+    return build_accordions(
+        subsections=subsections, raw_response=raw_response, config=FormattingConfig()
+    )
 
 
 def _get_breadcrumb_html(headings: Sequence[str] | None, document_name: str) -> str:
@@ -241,7 +257,7 @@ def format_bem_documents(
     subsections: Sequence[Subsection],
     raw_response: str,
 ) -> str:
-    response_with_citations = reify_citations(raw_response, subsections, data_source="BEM")
+    response_with_citations = reify_citations(raw_response, subsections, BemFormattingConfig())
 
     documents = _get_bem_documents_to_show(
         chunks_shown_max_num, chunks_shown_min_score, list(chunks_with_scores)
@@ -353,9 +369,11 @@ def _add_ellipses(chunk: Chunk) -> str:
     return chunk_content
 
 
-def reify_citations(response: str, subsections: Sequence[Subsection], data_source: str) -> str:
+def reify_citations(
+    response: str, subsections: Sequence[Subsection], config: FormattingConfig
+) -> str:
     remapped_citations = remap_citation_ids(subsections, response)
-    return _add_citation_links(response, remapped_citations, data_source)
+    return _add_citation_links(response, remapped_citations, config)
 
 
 _footnote_id = random.randint(0, 1000000)
@@ -363,7 +381,7 @@ _footnote_index = 0
 
 
 def _add_citation_links(
-    response: str, remapped_citations: dict[str, Subsection], data_source: str
+    response: str, remapped_citations: dict[str, Subsection], config: FormattingConfig
 ) -> str:
     global _footnote_id
     _footnote_id += 1
@@ -380,11 +398,7 @@ def _add_citation_links(
             return ""
 
         chunk = remapped_citations[citation_id].chunk
-        if data_source == "BEM":
-            link = get_bem_url(chunk.document.name) if "BEM" in chunk.document.name else "#"
-            link += "#page=" + str(chunk.page_number) if chunk.page_number else ""
-        else:
-            link = chunk.document.source if chunk.document.source else "#"
+        link = config.get_superscript_link(chunk)
 
         citation = f"<sup><a href={link!r}>{remapped_citations[citation_id].id}</a>&nbsp;</sup>"
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -170,7 +170,9 @@ def build_accordions(
 
     # This heading is important to prevent Chainlit from embedding citations_html
     # as the next part of a a list in response_with_citations
-    response_with_citations = to_html(_add_citation_links(raw_response, remapped_citations, data_source))
+    response_with_citations = to_html(
+        _add_citation_links(raw_response, remapped_citations, data_source)
+    )
     if citations_html:
         return (
             "<div>"
@@ -360,7 +362,9 @@ _footnote_id = random.randint(0, 1000000)
 _footnote_index = 0
 
 
-def _add_citation_links(response: str, remapped_citations: dict[str, Subsection], data_source: str) -> str:
+def _add_citation_links(
+    response: str, remapped_citations: dict[str, Subsection], data_source: str
+) -> str:
     global _footnote_id
     _footnote_id += 1
     footnote_list = []

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -26,7 +26,7 @@ def format_guru_cards(
     subsections: Sequence[Subsection],
     raw_response: str,
 ) -> str:
-    response_with_citations = reify_citations(raw_response, subsections)
+    response_with_citations = reify_citations(raw_response, subsections, data_source="Guru")
 
     cards_html = ""
     for chunk_with_score in chunks_with_scores[:chunks_shown_max_num]:
@@ -170,7 +170,7 @@ def build_accordions(
 
     # This heading is important to prevent Chainlit from embedding citations_html
     # as the next part of a a list in response_with_citations
-    response_with_citations = to_html(_add_citation_links(raw_response, remapped_citations))
+    response_with_citations = to_html(_add_citation_links(raw_response, remapped_citations, data_source))
     if citations_html:
         return (
             "<div>"
@@ -239,7 +239,7 @@ def format_bem_documents(
     subsections: Sequence[Subsection],
     raw_response: str,
 ) -> str:
-    response_with_citations = reify_citations(raw_response, subsections)
+    response_with_citations = reify_citations(raw_response, subsections, data_source="BEM")
 
     documents = _get_bem_documents_to_show(
         chunks_shown_max_num, chunks_shown_min_score, list(chunks_with_scores)
@@ -351,16 +351,16 @@ def _add_ellipses(chunk: Chunk) -> str:
     return chunk_content
 
 
-def reify_citations(response: str, subsections: Sequence[Subsection]) -> str:
+def reify_citations(response: str, subsections: Sequence[Subsection], data_source: str) -> str:
     remapped_citations = remap_citation_ids(subsections, response)
-    return _add_citation_links(response, remapped_citations)
+    return _add_citation_links(response, remapped_citations, data_source)
 
 
 _footnote_id = random.randint(0, 1000000)
 _footnote_index = 0
 
 
-def _add_citation_links(response: str, remapped_citations: dict[str, Subsection]) -> str:
+def _add_citation_links(response: str, remapped_citations: dict[str, Subsection], data_source: str) -> str:
     global _footnote_id
     _footnote_id += 1
     footnote_list = []
@@ -376,14 +376,18 @@ def _add_citation_links(response: str, remapped_citations: dict[str, Subsection]
             return ""
 
         chunk = remapped_citations[citation_id].chunk
-        bem_link = get_bem_url(chunk.document.name) if "BEM" in chunk.document.name else "#"
-        bem_link += "#page=" + str(chunk.page_number) if chunk.page_number else ""
-        citation = f"<sup><a href={bem_link!r}>{remapped_citations[citation_id].id}</a>&nbsp;</sup>"
+        if data_source == "BEM":
+            link = get_bem_url(chunk.document.name) if "BEM" in chunk.document.name else "#"
+            link += "#page=" + str(chunk.page_number) if chunk.page_number else ""
+        else:
+            link = chunk.document.source if chunk.document.source else "#"
+
+        citation = f"<sup><a href={link!r}>{remapped_citations[citation_id].id}</a>&nbsp;</sup>"
 
         global _footnote_index
         _footnote_index += 1
         footnote_list.append(
-            f"<a style='text-decoration:none' href={bem_link!r}><sup id={_footnote_id!r}>{_footnote_index}. {chunk.document.name}</sup></a>"
+            f"<a style='text-decoration:none' href={link!r}><sup id={_footnote_id!r}>{_footnote_index}. {chunk.document.name}</sup></a>"
         )
         return citation
 

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -21,6 +21,7 @@ _accordion_id = random.randint(0, 1000000)
 
 class FormattingConfig:
     "Default formatting configuration"
+
     def __init__(self) -> None:
         self.add_citation_link_per_subsection = False
 
@@ -38,6 +39,7 @@ class FormattingConfig:
 
 class BemFormattingConfig(FormattingConfig):
     "BEM-specific formatting configuration"
+
     def __init__(self) -> None:
         self.add_citation_link_per_subsection = True
 

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -5,6 +5,8 @@ from sqlalchemy import delete
 from src.citations import CitationFactory, split_into_subsections
 from src.db.models.document import Chunk, ChunkWithScore, Document, Subsection
 from src.format import (
+    BemFormattingConfig,
+    FormattingConfig,
     _add_ellipses,
     _format_to_accordion_html,
     _get_breadcrumb_html,
@@ -15,7 +17,6 @@ from src.format import (
     format_web_subsections,
     reify_citations,
     replace_citation_ids,
-    return_citation_link,
 )
 from src.retrieve import retrieve_with_scores
 from tests.src.db.models.factories import ChunkFactory, DocumentFactory
@@ -184,14 +185,15 @@ def test_reify_citations():
     chunks = ChunkFactory.build_batch(2)
     chunks[0].content = "This is the first chunk.\n\nWith two subsections"
     subsections = split_into_subsections(chunks, factory=CitationFactory())
+    config = FormattingConfig()
 
-    assert reify_citations("This is a citation (citation-0)", [], "") == "This is a citation "
+    assert reify_citations("This is a citation (citation-0)", [], config) == "This is a citation "
 
     assert (
         reify_citations(
             f"This is a citation ({subsections[0].id}) and another ({subsections[1].id}).",
             subsections,
-            "",
+            config,
         )
         == "This is a citation <sup><a href='#'>1</a>&nbsp;</sup> and another <sup><a href='#'>2</a>&nbsp;</sup>."
     )
@@ -264,12 +266,12 @@ def test__return_citation_link():
     chunk_list[1].document = doc[1]
     chunk_list[1].page_number = 3
 
-    bem_link = return_citation_link(chunk_list[0], "BEM")
+    bem_link = BemFormattingConfig().return_citation_link(chunk_list[0])
 
     assert "Open document to page 3" in bem_link
     assert "Source" not in bem_link
 
-    web_link = return_citation_link(chunk_list[1], "EDD")
+    web_link = FormattingConfig().return_citation_link(chunk_list[1])
     assert "page 3" not in web_link
     assert "Source" in web_link
 

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -161,7 +161,7 @@ def test__add_ellipses():
     )
 
 
-def test_format_bem_subsections(chunks_with_scores):
+def test_build_accordions_for_bem(chunks_with_scores):
     subsections = to_subsections(chunks_with_scores)
 
     config = BemFormattingConfig()
@@ -277,7 +277,7 @@ def test__return_citation_link():
     assert "Source" in web_link
 
 
-def test__format_web_subsections(chunks_with_scores):
+def test_build_accordions(chunks_with_scores):
     subsections = to_subsections(chunks_with_scores)
 
     config = FormattingConfig()

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -16,6 +16,7 @@ from src.format import (
     reify_citations,
     replace_citation_ids,
     return_citation_link,
+
 )
 from src.retrieve import retrieve_with_scores
 from tests.src.db.models.factories import ChunkFactory, DocumentFactory
@@ -185,12 +186,13 @@ def test_reify_citations():
     chunks[0].content = "This is the first chunk.\n\nWith two subsections"
     subsections = split_into_subsections(chunks, factory=CitationFactory())
 
-    assert reify_citations("This is a citation (citation-0)", []) == "This is a citation "
+    assert reify_citations("This is a citation (citation-0)", [], "") == "This is a citation "
 
     assert (
         reify_citations(
             f"This is a citation ({subsections[0].id}) and another ({subsections[1].id}).",
             subsections,
+            ""
         )
         == "This is a citation <sup><a href='#'>1</a>&nbsp;</sup> and another <sup><a href='#'>2</a>&nbsp;</sup>."
     )

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -16,7 +16,6 @@ from src.format import (
     reify_citations,
     replace_citation_ids,
     return_citation_link,
-
 )
 from src.retrieve import retrieve_with_scores
 from tests.src.db.models.factories import ChunkFactory, DocumentFactory
@@ -192,7 +191,7 @@ def test_reify_citations():
         reify_citations(
             f"This is a citation ({subsections[0].id}) and another ({subsections[1].id}).",
             subsections,
-            ""
+            "",
         )
         == "This is a citation <sup><a href='#'>1</a>&nbsp;</sup> and another <sup><a href='#'>2</a>&nbsp;</sup>."
     )

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -7,14 +7,13 @@ from src.db.models.document import Chunk, ChunkWithScore, Document, Subsection
 from src.format import (
     BemFormattingConfig,
     FormattingConfig,
-    _add_ellipses,
-    _format_to_accordion_html,
+    _add_ellipses_for_bem,
+    _format_guru_to_accordion_html,
     _get_breadcrumb_html,
     _group_by_document_and_chunks,
+    build_accordions,
     format_bem_documents,
-    format_bem_subsections,
     format_guru_cards,
-    format_web_subsections,
     reify_citations,
     replace_citation_ids,
 )
@@ -92,12 +91,12 @@ def test_format_guru_cards_given_chunks_shown_max_num_and_min_score(chunks_with_
     assert len(_unique_accordion_ids(html)) == 1
 
 
-def test__format_to_accordion_html(app_config, db_session, enable_factory_create):
+def test__format_guru_to_accordion_html(app_config, db_session, enable_factory_create):
     db_session.execute(delete(Document))
     chunks_with_scores = _get_chunks_with_scores()
     document = chunks_with_scores[0].chunk.document
     score = 0.92
-    html = _format_to_accordion_html(document=document, score=score)
+    html = _format_guru_to_accordion_html(document=document, score=score)
     assert document.name in html
     assert document.content in html
     assert "<p>Similarity Score: 0.92</p>" in html
@@ -142,42 +141,44 @@ def test_format_bem_documents():
 
 def test__add_ellipses():
     one_chunk = Chunk(num_splits=0, split_index=0, content="This is the only chunk.")
-    assert _add_ellipses(one_chunk) == "This is the only chunk."
+    assert _add_ellipses_for_bem(one_chunk) == "This is the only chunk."
 
     first_chunk = Chunk(num_splits=3, split_index=0, content="This is the first chunk of 3.")
-    assert _add_ellipses(first_chunk) == "This is the first chunk of 3. ..."
+    assert _add_ellipses_for_bem(first_chunk) == "This is the first chunk of 3. ..."
 
     middle_chunk = Chunk(num_splits=3, split_index=2, content="This is a chunk in between.")
-    assert _add_ellipses(middle_chunk) == "... This is a chunk in between. ..."
+    assert _add_ellipses_for_bem(middle_chunk) == "... This is a chunk in between. ..."
 
     last_chunk = Chunk(num_splits=3, split_index=3, content="This is the last chunk.")
-    assert _add_ellipses(last_chunk) == "... This is the last chunk."
+    assert _add_ellipses_for_bem(last_chunk) == "... This is the last chunk."
 
     multiple_ellipses = Chunk(
         num_splits=3, split_index=0, content="This is a chunk with multiple ellipses......"
     )
-    assert _add_ellipses(multiple_ellipses) == "This is a chunk with multiple ellipses...... ..."
+    assert (
+        _add_ellipses_for_bem(multiple_ellipses)
+        == "This is a chunk with multiple ellipses...... ..."
+    )
 
 
 def test_format_bem_subsections(chunks_with_scores):
     subsections = to_subsections(chunks_with_scores)
 
-    assert format_bem_subsections(0, 0, chunks_with_scores, subsections, "") == "<div></div>"
+    config = BemFormattingConfig()
+    assert build_accordions(subsections, "", config) == "<div></div>"
     assert (
-        format_bem_subsections(0, 0, [], [], "Non-existant citation: (citation-0)")
+        build_accordions([], "Non-existant citation: (citation-0)", config)
         == "<div><p>Non-existant citation: </p></div>"
     )
 
     assert (
-        format_bem_subsections(0, 0, [], [], "List intro sentence: \n- item 1\n- item 2")
+        build_accordions([], "List intro sentence: \n- item 1\n- item 2", config)
         == "<div><p>List intro sentence: </p>\n<ul>\n<li>item 1</li>\n<li>item 2</li>\n</ul></div>"
     )
 
     chunks_with_scores[0].chunk.document.name = "BEM 100: Intro"
     chunks_with_scores[1].chunk.document.name = "BEM 101: Another"
-    html = format_bem_subsections(
-        0, 0, chunks_with_scores, subsections, "Some real citations: (citation-1) (citation-2)"
-    )
+    html = build_accordions(subsections, "Some real citations: (citation-1) (citation-2)", config)
     assert len(_unique_accordion_ids(html)) == 2
 
 
@@ -279,22 +280,19 @@ def test__return_citation_link():
 def test__format_web_subsections(chunks_with_scores):
     subsections = to_subsections(chunks_with_scores)
 
-    assert format_web_subsections(0, 0, chunks_with_scores, subsections, "") == "<div></div>"
+    config = FormattingConfig()
+    assert build_accordions(subsections, "", config) == "<div></div>"
     assert (
-        format_web_subsections(0, 0, [], [], "Non-existant citation: (citation-0)")
+        build_accordions([], "Non-existant citation: (citation-0)", config)
         == "<div><p>Non-existant citation: </p></div>"
     )
 
     assert (
-        format_web_subsections(0, 0, [], [], "List intro sentence: \n- item 1\n- item 2")
+        build_accordions([], "List intro sentence: \n- item 1\n- item 2", config)
         == "<div><p>List intro sentence: </p>\n<ul>\n<li>item 1</li>\n<li>item 2</li>\n</ul></div>"
     )
 
-    chunks_with_scores[0].chunk.document.name = "Your State Disability Insurance (SDI)"
-    chunks_with_scores[1].chunk.document.name = "Your State Disability Insurance (SDI): Another"
-    html = format_web_subsections(
-        0, 0, chunks_with_scores, subsections, "Some real citations: (citation-1) (citation-2)"
-    )
+    html = build_accordions(subsections, "Some real citations: (citation-1) (citation-2)", config)
     assert len(_unique_accordion_ids(html)) == 2
 
 


### PR DESCRIPTION
## Ticket

Related to #128

## Changes

Refactor to use `FormattingConfig` and `BemFormattingConfig` instead of `if-then` blocks.
