### PR TITLE
fix: Handle blank sublist for EDD ingest

### DIFF
--- a/app/src/ingest_edd_web.py
+++ b/app/src/ingest_edd_web.py
@@ -195,6 +195,8 @@ def _fix_input_markdown(markdown: str) -> str:
     # nested sublist '+' created without parent list; incorrect markdown from scraping?
     # in https://edd.ca.gov/en/disability/Employer_Physician-Practitioner_Automated_Phone_Information_System/
     markdown = markdown.replace("* + ", "    + ")
+    # Blank sublist in https://edd.ca.gov/en/unemployment/Employer_Information/
+    markdown = markdown.replace("* +\n", "")
     return markdown
 
 


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1732056132833719?thread_ts=1732047718.603639&cid=C06DP498D1D)


## Changes

fix: Handle blank sublist for EDD ingest of https://edd.ca.gov/en/unemployment/Employer_Information/
![image](https://github.com/user-attachments/assets/f4ef82b6-a90c-4d77-b669-b7a8e2be6f7c)

