### PR TITLE
refactor: Exclude user's latest message from chat_history

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -153,10 +153,11 @@ _WIDGET_FACTORIES = {
 }
 
 
-def get_raw_chat_history(messages: list[cl.Message]) -> ChatHistory:
+def extract_raw_chat_history(messages: list[cl.Message]) -> ChatHistory:
     raw_chat_history: ChatHistory = []
     for message in messages:
         if message.type == "assistant_message":
+            # Response to the user's query
             raw_chat_history.append(
                 {
                     "role": "assistant",
@@ -168,8 +169,10 @@ def get_raw_chat_history(messages: list[cl.Message]) -> ChatHistory:
                 }
             )
         elif message.type == "user_message":
+            # User's query
             raw_chat_history.append({"role": "user", "content": message.content})
         else:
+            # System message for high-level framing that governs the assistant response
             raw_chat_history.append({"role": "system", "content": message.content})
     return raw_chat_history
 
@@ -178,7 +181,8 @@ def get_raw_chat_history(messages: list[cl.Message]) -> ChatHistory:
 async def on_message(message: cl.Message) -> None:
     logger.info("Received: %r", message.content)
     chat_context = cl.chat_context.get()
-    chat_history = get_raw_chat_history(chat_context)
+    # chat_context has the user query as the last item; exclude it from the chat history
+    chat_history = extract_raw_chat_history(chat_context[:-1])
 
     engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
 

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -172,8 +172,7 @@ def extract_raw_chat_history(messages: list[cl.Message]) -> ChatHistory:
             # User's query
             raw_chat_history.append({"role": "user", "content": message.content})
         else:
-            # System message for high-level framing that governs the assistant response
-            raw_chat_history.append({"role": "system", "content": message.content})
+            logger.warning("Unexpected message type: %s: %r", message.type, message.content)
     return raw_chat_history
 
 

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -95,9 +95,7 @@ def generate(
             },
         )
 
-    # chat_history has the user query as the last item, but we want to insert the context first
     if chat_history:
-        chat_history.pop()
         messages.extend(chat_history)
 
     messages.append({"content": query, "role": "user"})

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -82,6 +82,7 @@ def generate(
     messages = [
         {
             "content": system_prompt,
+            # System message for high-level framing that governs the assistant response
             "role": "system",
         }
     ]

--- a/app/tests/src/test_chainlit.py
+++ b/app/tests/src/test_chainlit.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 from src import chainlit, chat_engine
-from src.chainlit import _get_retrieval_metadata, get_raw_chat_history
+from src.chainlit import _get_retrieval_metadata, extract_raw_chat_history
 from src.chat_engine import OnMessageResult
 from src.db.models.document import Subsection
 from src.generate import PROMPT
@@ -61,7 +61,7 @@ def test__get_retrieval_metadata(chunks_with_scores):
     ]
 
 
-def test__get_raw_chat_history():
+def test__extract_raw_chat_history():
     clMessage1 = MagicMock()
     clMessage2 = MagicMock()
     clMessage3 = MagicMock()
@@ -97,7 +97,7 @@ def test__get_raw_chat_history():
     )
     message = [clMessage1, clMessage2, clMessage3]
 
-    assert get_raw_chat_history(message) == [
+    assert extract_raw_chat_history(message) == [
         {"role": "assistant", "content": "CA EDD Web Chat Engine started "},
         {"role": "user", "content": "can you tell me about income eligibility?"},
         {

--- a/app/tests/src/test_generate.py
+++ b/app/tests/src/test_generate.py
@@ -117,7 +117,6 @@ def test_generate_with_history(monkeypatch):
     history = [
         {"content": "some query", "role": "user"},
         {"content": "<div> answer</div>", "role": "assistant"},
-        {"content": "some other query", "role": "user"},
     ]
     expected_response = (
         'Called gpt-4o with [{"content": "' + PROMPT + '", "role": "system"}, '


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1732130712387439)

## Changes

* Move `chat_history.pop()` to `chainlit.py`
* Exclude `system` messages from the return value of `extract_raw_chat_history()` since we provide `system` messages in `generate()`.

## Testing

No behavior change