### PR TITLE
feat: Add Imagine LA engine

### DIFF
--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -29,7 +29,7 @@ class AppConfig(PydanticBaseEnvConfig):
     embedding_model: str = "multi-qa-mpnet-base-cos-v1"
 
     # Default chat engine
-    chat_engine: str = "ca-edd-web"
+    chat_engine: str = "imagine-la"
     temperature: float = 0.0
 
     # Default LLM model

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -73,8 +73,8 @@ def __query_user_session(user_id: str) -> UserSession:
     Placeholder for creating/retrieving user's session from the DB, including settings and constraints
     """
     session = UserSession(
-        user=UserInfo(user_id, ["ca-edd-web"]),
-        chat_engine_settings=ChatEngineSettings("ca-edd-web"),
+        user=UserInfo(user_id, ["imagine-la"]),
+        chat_engine_settings=ChatEngineSettings("imagine-la"),
     )
     logger.info("Found user session for: %s", user_id)
     return session

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -202,3 +202,22 @@ If you can't find information about the user's prompt in your context, don't ans
 If a prompt is about an EDD program, but you can't tell which one, detect and clarify program ambiguity. Ask: "The EDD administers several programs such as State Disability Insurance (SDI), Paid Family Leave (PFL), and Unemployment Insurance (UI). I'm not sure which benefit program your prompt is about; could you let me know?"
 
 {PROMPT}"""
+
+
+class ImagineLaEngine(BaseEngine):
+    retrieval_k: int = 50
+    retrieval_k_min_score: float = -1
+
+    # Note: currently not used
+    chunks_shown_min_score: float = -1
+    chunks_shown_max_num: int = 8
+
+    engine_id: str = "imagine-la"
+    name: str = "Imagine LA Chat Engine"
+    datasets = ["CA EDD", "Imagine LA"]
+
+    system_prompt = f"""You are an assistant to navigators who support clients-such as claimants, beneficiaries, families, and individuals-during the screening, application, and receipt of public benefits in California.
+If you can't find information about the user's prompt in your context, don't answer it. If the user asks a question about a program not available in California, don't answer beyond pointing the user to the relevant trusted website for more information.
+If a prompt is about a benefit program, but you can't tell which one, detect and clarify program ambiguity. Ask: "I'm not sure which benefit program your prompt is about; could you let me know? If you don't know what benefit program might be helpful, you can also describe what you need and I can make a recommendation."
+
+{PROMPT}"""

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -197,7 +197,7 @@ class CaEddWebEngine(BaseEngine):
     name: str = "CA EDD Web Chat Engine"
     datasets = ["CA EDD"]
 
-    system_prompt = f"""You are an assistant to navigators who support clients-such as claimants, beneficiaries, families, and individuals-during the screening, application, and receipt of public benefits from California's Employment Development Department (EDD).
+    system_prompt = f"""You are an assistant to navigators who support clients (such as claimants, beneficiaries, families, and individuals) during the screening, application, and receipt of public benefits from California's Employment Development Department (EDD).
 If you can't find information about the user's prompt in your context, don't answer it. If the user asks a question about a program not delivered by California's Employment Development Department (EDD), don't answer beyond pointing the user to the relevant trusted website for more information. Don't answer questions about tax credits (such as EITC, CTC) or benefit programs not delivered by EDD.
 If a prompt is about an EDD program, but you can't tell which one, detect and clarify program ambiguity. Ask: "The EDD administers several programs such as State Disability Insurance (SDI), Paid Family Leave (PFL), and Unemployment Insurance (UI). I'm not sure which benefit program your prompt is about; could you let me know?"
 

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -53,7 +53,7 @@ def test_api_healthcheck(client):
 def test_api_engines(client):
     response = client.get("/api/engines?user_id=TestUser")
     assert response.status_code == 200
-    assert response.json() == ["ca-edd-web"]
+    assert response.json() == ["imagine-la"]
 
 
 def test_api_query(monkeypatch, client):


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-586


## Changes
 - Add new chat engine that pulls from both Imagine LA and EDD web datasets
 - Set as the default both for web and API interfaces


## Context for reviewers
 - This will be the engine we use for the pilot going forward
 - I'll seek input from design on how we can update the prompt here, I edited it to be generic to CA (rather than EDD specific) for now


## Testing
<img width="783" alt="image" src="https://github.com/user-attachments/assets/7785ed70-b9d7-45a6-bb2b-e2696a54e8ad">
