### PR TITLE
fix: Remove use of getopt for ingestion

### DIFF
--- a/app/src/util/ingest_utils.py
+++ b/app/src/util/ingest_utils.py
@@ -1,4 +1,3 @@
-import getopt
 import json
 import logging
 import re
@@ -36,10 +35,7 @@ def process_and_ingest_sys_args(argv: list[str], logger: Logger, ingestion_call:
         )
         return
 
-    _, args = getopt.getopt(
-        argv[1:], shortopts="", longopts=["DATASET_ID BENEFIT_PROGRAM BENEFIT_REGION FILEPATH)"]
-    )
-
+    args = argv[1:]
     dataset_id = args[0]
     benefit_program = args[1]
     benefit_region = args[2]


### PR DESCRIPTION
## Ticket

Related to https://navalabs.atlassian.net/browse/DST-564

## Changes

Remove use of `getopt` for ingestion since we're not using any [getopt options](https://docs.python.org/3/library/getopt.html) -- we're using "arguments" only.

## Testing

No behavior change. 
Run some ingestion command.