### PR TITLE
fix: Handle table markdown formatting in assertion

### DIFF
--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -24,11 +24,15 @@ class CitationFactory:
             self.next_id = lambda: f"{prefix}{self.counter.__next__()}"
 
     def create_citation(self, chunk: Chunk, text: str, text_headings: Sequence[str]) -> Subsection:
-        # Check that text is in chunk.content, ignoring whitespace
-        assert re.sub(r"\s+", " ", text) in re.sub(
-            r"\s+", " ", chunk.content
-        ), f"Text {text!r} not found in chunk {chunk.content!r}"
+        if not self._text_in_chunk(text, chunk):
+            logger.warning("Text not found in chunk: %r\n%r", text, chunk.content)
         return Subsection(self.next_id(), chunk, text, text_headings)
+
+    def _text_in_chunk(self, text: str, chunk: Chunk) -> bool:
+        # Check that text is in chunk.content, ignoring whitespace and dashes
+        stripped_text = re.sub(r"\s+|-", "", text)
+        stripped_chunk_text = re.sub(r"\s+|-", "", chunk.content)
+        return stripped_text in stripped_chunk_text
 
 
 citation_factory = CitationFactory()

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -15,8 +15,14 @@ from tests.src.db.models.factories import ChunkFactory
 
 @pytest.fixture
 def chunks():
-    chunks = ChunkFactory.build_batch(2)
+    chunks = ChunkFactory.build_batch(3)
     chunks[0].content = "This is the first chunk.\n\nWith two subsections"
+    chunks[2].content = (
+        "Chunk with a table\n\n"
+        "| Header 1 | Header 2 |\n"
+        "| -------- | -------- |\n"
+        "| Value 1  | Value 2  |"
+    )
     return chunks
 
 
@@ -53,7 +59,19 @@ Content: With two subsections
 Citation: citation-3
 Document name: {chunks[1].document.name}
 Headings: {" > ".join(chunks[1].headings)}
-Content: {chunks[1].content}"""
+Content: {chunks[1].content}
+
+Citation: citation-4
+Document name: {chunks[2].document.name}
+Headings: {" > ".join(chunks[2].headings)}
+Content: Chunk with a table
+
+Citation: citation-5
+Document name: {chunks[2].document.name}
+Headings: {" > ".join(chunks[2].headings)}
+Content: | Header 1 | Header 2 |
+| -------- | -------- |
+| Value 1  | Value 2  |"""
     )
 
 
@@ -67,6 +85,12 @@ def test_get_context(chunks, subsections):
     assert subsections[2].id == "citation-3"
     assert subsections[2].chunk == chunks[1]
     assert subsections[2].text == chunks[1].content
+    assert subsections[3].text == "Chunk with a table"
+    assert subsections[4].text == (
+        "| Header 1 | Header 2 |\n"  #
+        "| -------- | -------- |\n"  #
+        "| Value 1  | Value 2  |"
+    )
 
 
 def test_remap_citation_ids(subsections):


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06ETE82UHM/p1733771384506999?thread_ts=1733771029.694449&cid=C06ETE82UHM)

## Changes

- Ignore dashes (for table markdown text) as well as spaces when checking if subsection text is in the chunk text.
- Also downgrade to a `log.warning` (rather than `assert`) since this check occurs during user interaction

## Testing

Added unit test