### PR TITLE
fix: Setup Terraform before AWS credentials

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials
         with:

--- a/.github/workflows/check-infra-auth.yml
+++ b/.github/workflows/check-infra-auth.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:


### PR DESCRIPTION
## Ticket

n/a

## Changes
 - Install Terraform on action host


## Context for reviewers
 - Two actions call the AWS credentials action which relies on Terraform, but the latest version of Ubuntu does not include Terraform by default


## Testing