### PR TITLE
bug: set message_in_english key to optional

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -125,9 +125,17 @@ class BaseEngine(ChatEngineInterface):
         attributes: MessageAttributes,
         chat_history: Optional[ChatHistory] = None,
     ) -> OnMessageResult:
-        question_for_retrieval = (
-            question if attributes.is_in_english else attributes.message_in_english
-        )
+
+        if attributes.is_in_english:
+            question_for_retrieval = question
+        elif not attributes.message_in_english:
+            question_for_retrieval = question
+            logger.error(
+                "Message_in_english was omitted even though a translation was expected for: %s",
+                question,
+            )
+        else:
+            question_for_retrieval = attributes.message_in_english
 
         chunks_with_scores = retrieve_with_scores(
             question_for_retrieval,

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -117,7 +117,7 @@ def completion_args(llm: str) -> dict[str, Any]:
 class MessageAttributes(BaseModel):
     original_language: str
     is_in_english: bool
-    message_in_english: Optional[str]
+    message_in_english: Optional[str] = None
     needs_context: bool
 
 

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 from litellm import completion
 from pydantic import BaseModel
@@ -117,7 +117,7 @@ def completion_args(llm: str) -> dict[str, Any]:
 class MessageAttributes(BaseModel):
     original_language: str
     is_in_english: bool
-    message_in_english: str
+    message_in_english: Optional[str]
     needs_context: bool
 
 

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -1,5 +1,5 @@
 from src import chat_engine
-from src.chat_engine import CaEddWebEngine, ImagineLaEngine, BaseEngine
+from src.chat_engine import CaEddWebEngine, ImagineLaEngine
 from src.generate import MessageAttributes
 from tests.mock import mock_completion
 

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -47,4 +47,3 @@ def test_build_response(monkeypatch, caplog):
         "Message_in_english was omitted even though a translation was expected"
         in logger_message.message
     )
-    monkeypatch.undo()


### PR DESCRIPTION
## Ticket

N/A

## Changes
> set `message_in_english` key to optional to avoid crashes like this
![Screenshot 2024-12-19 at 4 10 31 PM](https://github.com/user-attachments/assets/dc42de1f-454a-4e1a-a6bf-48dde6eb9a9a)

## Testing

1. open chatbot at localhost:8000/chat
2. enter query `what tax credits are available to families with young children`
3. should not return error above