### PR TITLE
feat: Use separate Literal project for API

### DIFF
--- a/app/src/app_config.py
+++ b/app/src/app_config.py
@@ -37,6 +37,8 @@ class AppConfig(PydanticBaseEnvConfig):
 
     # Starts the chat API if set to True
     enable_chat_api: bool = True
+    # If set, used instead of LITERAL_API_KEY for API
+    literal_api_key_for_api: str | None = None
 
     def db_session(self) -> db.Session:
         return db.PostgresDBClient().get_session()

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -42,6 +42,8 @@ def literalai() -> AsyncLiteralClient:
     This needs to be a function so that it's not immediately instantiated upon
     import of this module and so that it can mocked in tests.
     """
+    if app_config.literal_api_key_for_api:
+        return AsyncLiteralClient(api_key=app_config.literal_api_key_for_api)
     return AsyncLiteralClient()
 
 

--- a/infra/app/app-config/env-config/environment-variables.tf
+++ b/infra/app/app-config/env-config/environment-variables.tf
@@ -40,5 +40,9 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/${var.app_name}-${var.environment}/LITERAL_API_KEY"
     }
+    LITERAL_API_KEY_FOR_API = {
+      manage_method     = "manual"
+      secret_store_name = "/${var.app_name}-${var.environment}/LITERAL_API_KEY_FOR_API"
+    }
   }
 }


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-666


## Changes
 - Set up new project in Literal
 - Add new secret to AWS Parameter Store, `LITERAL_API_KEY_FOR_API`
 - If this env variable is set, use it for the Literal client used by the API

## Context for reviewers
 - This better isolates usage of the API in preparation for a pilot

## Testing
Setting the variable locally, a query via the API appears in the Literal dashboard:
<img width="1141" alt="Screenshot 2024-12-31 at 11 43 12 AM" src="https://github.com/user-attachments/assets/fb7395ea-e33f-4163-a73e-149cdd4f8523" />
<img width="500" alt="Screenshot 2024-12-31 at 11 43 21 AM" src="https://github.com/user-attachments/assets/23dc1279-7154-4359-8b5e-615087f4d05a" />

Here is the variable set in the AWS parameter store:
<img width="832" alt="Screenshot 2024-12-31 at 11 43 32 AM" src="https://github.com/user-attachments/assets/6ef4b37a-6bce-46fe-90cc-62e5772c00e6" />


