### PR TITLE
fix: Use cl.make_async when calling synchronous batch_process

### DIFF
--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -9,7 +9,7 @@ from src.citations import simplify_citation_numbers
 logger = logging.getLogger(__name__)
 
 
-def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
+async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
     logger.info("Starting batch processing of file: %r", file_path)
     with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -62,7 +62,6 @@ async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
     logger.info("Batch processing complete. Results written to: %r", result_file.name)
     return result_file.name
 
-
 def _process_question(question: str, engine: ChatEngineInterface) -> dict[str, str | None]:
     logger.debug("Processing question: %r", question)
     result = engine.on_message(question=question, chat_history=[])
@@ -84,3 +83,4 @@ def _process_question(question: str, engine: ChatEngineInterface) -> dict[str, s
 
     logger.debug("Question processed with %d citations", len(final_result.subsections))
     return result_table
+

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -62,6 +62,7 @@ async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
     logger.info("Batch processing complete. Results written to: %r", result_file.name)
     return result_file.name
 
+
 def _process_question(question: str, engine: ChatEngineInterface) -> dict[str, str | None]:
     logger.debug("Processing question: %r", question)
     result = engine.on_message(question=question, chat_history=[])
@@ -83,4 +84,3 @@ def _process_question(question: str, engine: ChatEngineInterface) -> dict[str, s
 
     logger.debug("Question processed with %d citations", len(final_result.subsections))
     return result_table
-

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -9,7 +9,7 @@ from src.citations import simplify_citation_numbers
 logger = logging.getLogger(__name__)
 
 
-async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
+def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
     logger.info("Starting batch processing of file: %r", file_path)
     with open(file_path, mode="r", newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -251,7 +251,8 @@ def _get_retrieval_metadata(result: OnMessageResult) -> dict:
 async def _batch_proccessing(file: AskFileResponse) -> None:
     try:
         engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
-        result_file_path = await batch_process(file.path, engine)
+        # Make the synchronous batch_process function non-blocking
+        result_file_path = await cl.make_async(batch_process)(file.path, engine)
 
         # E.g., "abcd.csv" to "abcd_results.csv"
         result_file_name = file.name.removesuffix(".csv") + "_results.csv"

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -251,7 +251,7 @@ def _get_retrieval_metadata(result: OnMessageResult) -> dict:
 async def _batch_proccessing(file: AskFileResponse) -> None:
     try:
         engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
-        result_file_path = await cl.make_async(batch_process)(file.path, engine)
+        result_file_path = await batch_process(file.path, engine)
 
         # E.g., "abcd.csv" to "abcd_results.csv"
         result_file_name = file.name.removesuffix(".csv") + "_results.csv"

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -251,8 +251,7 @@ def _get_retrieval_metadata(result: OnMessageResult) -> dict:
 async def _batch_proccessing(file: AskFileResponse) -> None:
     try:
         engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
-        # Make the synchronous batch_process function non-blocking
-        result_file_path = await cl.make_async(batch_process)(file.path, engine)
+        result_file_path = await batch_process(file.path, engine)
 
         # E.g., "abcd.csv" to "abcd_results.csv"
         result_file_name = file.name.removesuffix(".csv") + "_results.csv"

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -251,7 +251,7 @@ def _get_retrieval_metadata(result: OnMessageResult) -> dict:
 async def _batch_proccessing(file: AskFileResponse) -> None:
     try:
         engine: chat_engine.ChatEngineInterface = cl.user_session.get("chat_engine")
-        result_file_path = await batch_process(file.path, engine)
+        result_file_path = await cl.make_async(batch_process)(file.path, engine)
 
         # E.g., "abcd.csv" to "abcd_results.csv"
         result_file_name = file.name.removesuffix(".csv") + "_results.csv"


### PR DESCRIPTION
## Ticket
https://navalabs.atlassian.net/browse/DST-709

## Changes
- Fixed type error where `batch_process` was incorrectly defined as async while using synchronous chainlit message operations
- Made `batch_process` synchronous and wrapped it with `cl.make_async` in the chainlit handler
- Maintains proper async/sync boundaries while keeping sequential processing for thread safety

## Context for reviewers
The code had a type mismatch where `batch_process` was async but contained synchronous chainlit operations (`cl.Message.send()`). This caused mypy errors and potential issues with message delivery. The fix:

1. Makes `batch_process` synchronous since it contains synchronous operations
2. Uses `cl.make_async` in the chainlit handler to properly handle async/sync boundaries
3. Keeps the sequential processing to maintain thread safety with LiteLLM

Reference: https://github.com/Chainlit/chainlit/issues/698#issuecomment-1915038945

## Testing
- Tested batch processing locally with CSV file to ensure messages are delivered properly
- Confirmed progress updates work correctly in UI
- Verified file results are properly attached and downloadable