### PR TITLE
fix: Refine memory handling and timeout params for batch processing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@ Each app should have:
 
 - `ci-[app_name]`: must be created; should run linting and testing
 - `ci-[app_name]-vulnerability-scans`: calls `vulnerability-scans`
-  - Based on [ci-app-vulnerability-scans](https://github.com/navapbc/template-infra/blob/main/.github/workflows/ci-app-vulnerability-scans.yml)
+  - Based on [ci-app-vulnerability-scans.yml.jinja](./ci-{{app_name}}-vulnerability-scans.yml.jinja)
 
 ### App-agnostic workflows
 
@@ -23,7 +23,7 @@ Each app should have:
 Each app should have:
 
 - `cd-[app_name]`: deploys an application
-  - Based on [`cd-app`](https://github.com/navapbc/template-infra/blob/main/.github/workflows/cd-app.yml)
+  - Based on [`cd-app.yml.jinja`](./cd-{{app_name}}.yml.jinja)
 
 The CD workflow uses these reusable workflows:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@ Each app should have:
 
 - `ci-[app_name]`: must be created; should run linting and testing
 - `ci-[app_name]-vulnerability-scans`: calls `vulnerability-scans`
-  - Based on [ci-app-vulnerability-scans.yml.jinja](./ci-{{app_name}}-vulnerability-scans.yml.jinja)
+  - Based on [ci-app-vulnerability-scans.yml.jinja](https://github.com/navapbc/template-infra/blob/main/.github/workflows/ci-%7B%7Bapp_name%7D%7D-vulnerability-scans.yml.jinja)
 
 ### App-agnostic workflows
 
@@ -23,7 +23,7 @@ Each app should have:
 Each app should have:
 
 - `cd-[app_name]`: deploys an application
-  - Based on [`cd-app.yml.jinja`](./cd-{{app_name}}.yml.jinja)
+  - Based on [`cd-app.yml.jinja`](https://github.com/navapbc/template-infra/blob/main/.github/workflows/cd-%7B%7Bapp_name%7D%7D.yml.jinja)
 
 The CD workflow uses these reusable workflows:
 

--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -11,6 +11,12 @@
         },
         {
             "pattern": "https://navalabs.atlassian.net/browse/DST-"
+        },
+        {
+            "pattern": ".*{{.*}}.*.jinja"
+        },
+        {
+            "pattern": "../../app/migrations.sql"
         }
     ],
     "replacementPatterns": [

--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -11,15 +11,6 @@
         },
         {
             "pattern": "https://navalabs.atlassian.net/browse/DST-"
-        },
-        {
-            "pattern": ".*%7B%7B.*%7D%7D.*.jinja"
-        },
-        {
-            "pattern": "../../app/migrations.sql"
-        },
-        {
-            "pattern": "^https://medium.com/"
         }
     ],
     "replacementPatterns": [

--- a/.github/workflows/markdownlint-config.json
+++ b/.github/workflows/markdownlint-config.json
@@ -13,10 +13,13 @@
             "pattern": "https://navalabs.atlassian.net/browse/DST-"
         },
         {
-            "pattern": ".*{{.*}}.*.jinja"
+            "pattern": ".*%7B%7B.*%7D%7D.*.jinja"
         },
         {
             "pattern": "../../app/migrations.sql"
+        },
+        {
+            "pattern": "^https://medium.com/"
         }
     ],
     "replacementPatterns": [
@@ -24,5 +27,5 @@
             "pattern": "^/",
             "replacement": "{{BASEURL}}/"
         }
-  ]
+    ]
 }

--- a/app/gunicorn.conf.py
+++ b/app/gunicorn.conf.py
@@ -15,3 +15,8 @@ from src.app_config import app_config
 bind = app_config.host + ':' + str(app_config.port)
 workers = 1
 threads = 4
+
+# Increase timeout to handle long-running requests
+timeout = 300  # 5 minutes
+graceful_timeout = 300  # 5 minutes
+keepalive = 5

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -42,7 +42,8 @@ async def batch_process(
 
         processed_data = []
 
-        # Process questions with progress updates
+        # Process in smaller batches to manage memory
+        BATCH_SIZE = 10
         for i, q in enumerate(questions, 1):
             logger.info("Processing question %d/%d", i, total_questions)
 
@@ -51,9 +52,13 @@ async def batch_process(
 
             processed_data.append(_process_question(q, engine))
 
-            # Add small delay to prevent overwhelming the system
-            if i % 10 == 0:  # Every 10 questions
+            # Add delay and clear memory after each batch
+            if i % BATCH_SIZE == 0:
                 await asyncio.sleep(0.1)
+                # Force garbage collection to free memory
+                import gc
+
+                gc.collect()
 
         # Update rows with processed data
         for row, data in zip(rows, processed_data, strict=True):

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -1,5 +1,6 @@
 import asyncio
 import csv
+import gc
 import logging
 import tempfile
 from typing import Awaitable, Callable, Optional
@@ -52,12 +53,11 @@ async def batch_process(
 
             processed_data.append(_process_question(q, engine))
 
-            # Add delay and clear memory after each batch
+            # Clear memory after each batch
             if i % BATCH_SIZE == 0:
+                # Add small delay to prevent overwhelming the system
                 await asyncio.sleep(0.1)
                 # Force garbage collection to free memory
-                import gc
-
                 gc.collect()
 
         # Update rows with processed data

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -172,7 +172,7 @@ If a prompt is about an EDD program, but you can't tell which one, detect and cl
 
 
 class ImagineLaEngine(BaseEngine):
-    retrieval_k: int = 50
+    retrieval_k: int = 25
     retrieval_k_min_score: float = -1
 
     # Note: currently not used

--- a/docs/infra/set-up-database.md
+++ b/docs/infra/set-up-database.md
@@ -95,7 +95,7 @@ Before creating migrations that create tables, first create a migration that inc
 ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app
 ```
 
-This will cause all future tables created by the `migrator` user to automatically be accessible by the `app` user. See the [Postgres docs on ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for more info. As an example see the example app's migrations file [migrations.sql](../../app/migrations.sql).
+This will cause all future tables created by the `migrator` user to automatically be accessible by the `app` user. See the [Postgres docs on ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for more info. As an example see the example app's migrations file [migrations.sql](https://github.com/navapbc/template-infra/blob/main/template-only-app/migrations.sql).
 
 Why is this needed? The reason is that the `migrator` role will be used by the migration task to run database migrations (creating tables, altering tables, etc.), while the `app` role will be used by the web service to access the database. Moreover, in Postgres, new tables won't automatically be accessible by roles other than the creator unless specifically granted, even if those other roles have usage access to the schema that the tables are created in. In other words, if the `migrator` user created a new table `foo` in the `app` schema, the `app` user will not automatically be able to access it by default.
 

--- a/docs/infra/set-up-database.md
+++ b/docs/infra/set-up-database.md
@@ -95,7 +95,7 @@ Before creating migrations that create tables, first create a migration that inc
 ALTER DEFAULT PRIVILEGES GRANT ALL ON TABLES TO app
 ```
 
-This will cause all future tables created by the `migrator` user to automatically be accessible by the `app` user. See the [Postgres docs on ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for more info. As an example see the example app's migrations file [migrations.sql](https://github.com/navapbc/template-infra/blob/main/app/migrations.sql).
+This will cause all future tables created by the `migrator` user to automatically be accessible by the `app` user. See the [Postgres docs on ALTER DEFAULT PRIVILEGES](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for more info. As an example see the example app's migrations file [migrations.sql](../../app/migrations.sql).
 
 Why is this needed? The reason is that the `migrator` role will be used by the migration task to run database migrations (creating tables, altering tables, etc.), while the `app` role will be used by the web service to access the database. Moreover, in Postgres, new tables won't automatically be accessible by roles other than the creator unless specifically granted, even if those other roles have usage access to the schema that the tables are created in. In other words, if the `migrator` user created a new table `foo` in the `app` schema, the `app` user will not automatically be able to access it by default.
 

--- a/infra/app/app-config/dev.tf
+++ b/infra/app/app-config/dev.tf
@@ -11,7 +11,7 @@ module "dev_config" {
   has_database                    = true
   has_incident_management_service = local.has_incident_management_service
   service_cpu                     = 2048
-  service_memory                  = 8192
+  service_memory                  = 16384
 
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-709

## Changes

- Increased ECS task memory from 8GB to 16GB in dev environment
- Reduced retrieval_k from 50 to 25 documents in ImagineLaEngine to optimize memory usage
- Added explicit Gunicorn timeout settings (300s) to prevent worker timeouts

## Context for reviewers

We were seeing worker timeout errors in the logs during batch processing. This PR implements two optimizations:
1. Infrastructure: Doubled the available memory for the ECS task
2. Application: Reduced the number of documents retrieved per query and increased worker timeout limits

## Testing

- Deployed ECS changes to dev environment:`./bin/terraform-init infra/app/service dev && make infra-update-app-service APP_NAME=app ENVIRONMENT=dev`
- Verified ECS task is running with new memory settings: `aws ecs describe-task-definition --task-definition app-dev | grep -A 5 "memory"` -> `..."memory": 16384,...`
- Confirmed Gunicorn worker timeout settings are applied
- Tested batch processing functionality to verify improvements