### PR TITLE
feat: Add IRS family tax credit webpages as a new dataset

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -273,3 +273,10 @@ scrape-la-county-policy:
 
 ingest-la-county-policy: check-ingest-arguments
 	$(PY_RUN_CMD) ingest-la-policy "$(DATASET_ID)" "$(BENEFIT_PROGRAM)" "$(BENEFIT_REGION)" "$(FILEPATH)" $(INGEST_ARGS)
+
+
+scrape-irs-web:
+	$(PY_RUN_CMD) scrape-irs-web
+
+ingest-irs-web: check-ingest-arguments
+	$(PY_RUN_CMD) ingest-irs-web "$(DATASET_ID)" "$(BENEFIT_PROGRAM)" "$(BENEFIT_REGION)" "$(FILEPATH)" $(INGEST_ARGS)

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -73,6 +73,8 @@ scrape-edd-web = "src.ingestion.scrape_edd_web:main"
 ingest-imagine-la = "src.ingestion.imagine_la.ingest:main"
 scrape-la-policy = "src.ingestion.scrape_la_policy:main"
 ingest-la-policy = "src.ingest_la_county_policy:main"
+scrape-irs-web = "src.ingestion.scrape_irs_web:main"
+ingest-irs-web = "src.ingest_irs_web:main"
 
 [tool.black]
 line-length = 100

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -181,7 +181,7 @@ class ImagineLaEngine(BaseEngine):
 
     engine_id: str = "imagine-la"
     name: str = "Imagine LA Chat Engine"
-    datasets = ["CA EDD", "Imagine LA", "DPSS Policy"]
+    datasets = ["CA EDD", "Imagine LA", "DPSS Policy", "IRS"]
 
     system_prompt = f"""You are an assistant to navigators who support clients-such as claimants, beneficiaries, families, and individuals-during the screening, application, and receipt of public benefits in California.
 If you can't find information about the user's prompt in your context, don't answer it. If the user asks a question about a program not available in California, don't answer beyond pointing the user to the relevant trusted website for more information.

--- a/app/src/ingest_edd_web.py
+++ b/app/src/ingest_edd_web.py
@@ -93,11 +93,10 @@ def _ingest_edd_web(
     skip_db: bool = False,
     resume: bool = False,
 ) -> None:
-    def prep_json_item(item: dict[str, str]) -> dict[str, str]:
+    def prep_json_item(item: dict[str, str]) -> None:
         markdown = item.get("main_content", item.get("main_primary", None))
         assert markdown, f"Item {item['url']} has no main_content or main_primary"
         item["markdown"] = _fix_input_markdown(markdown)
-        return item
 
     common_base_url = "https://edd.ca.gov/en/"
     ingest_json(
@@ -143,13 +142,13 @@ def ingest_json(
     common_base_url: str,
     skip_db: bool = False,
     resume: bool = False,
-    prep_json_item: Callable[[dict[str, str]], dict[str, str]] = lambda x: x,
+    prep_json_item: Callable[[dict[str, str]], None] = lambda x: x,
     chunking_config: Optional[ChunkingConfig] = None,
 ) -> None:
     json_items = load_json_items(db_session, json_filepath, doc_attribs, skip_db, resume)
 
     for item in json_items:
-        item = prep_json_item(item)
+        prep_json_item(item)
 
     if not chunking_config:
         chunking_config = DefaultChunkingConfig()

--- a/app/src/ingest_edd_web.py
+++ b/app/src/ingest_edd_web.py
@@ -142,7 +142,7 @@ def ingest_json(
     common_base_url: str,
     skip_db: bool = False,
     resume: bool = False,
-    prep_json_item: Callable[[dict[str, str]], None] = lambda x: x,
+    prep_json_item: Callable[[dict[str, str]], None] = lambda x: None,
     chunking_config: Optional[ChunkingConfig] = None,
 ) -> None:
     json_items = load_json_items(db_session, json_filepath, doc_attribs, skip_db, resume)

--- a/app/src/ingest_irs_web.py
+++ b/app/src/ingest_irs_web.py
@@ -1,0 +1,37 @@
+import logging
+import sys
+
+from src.adapters import db
+from src.ingest_edd_web import ingest_json
+from src.util.ingest_utils import process_and_ingest_sys_args
+
+logger = logging.getLogger(__name__)
+
+
+def _ingest_irs_web(
+    db_session: db.Session,
+    json_filepath: str,
+    doc_attribs: dict[str, str],
+    md_base_dir: str = "irs_web_md",
+    skip_db: bool = False,
+    resume: bool = False,
+) -> None:
+    common_base_url = "https://www.irs.gov/"
+
+    def prep_json_item(item: dict[str, str]) -> None:
+        pass
+
+    ingest_json(
+        db_session,
+        json_filepath,
+        doc_attribs,
+        md_base_dir,
+        common_base_url,
+        skip_db,
+        resume,
+        prep_json_item,
+    )
+
+
+def main() -> None:
+    process_and_ingest_sys_args(sys.argv, logger, _ingest_irs_web)

--- a/app/src/ingest_irs_web.py
+++ b/app/src/ingest_irs_web.py
@@ -18,9 +18,6 @@ def _ingest_irs_web(
 ) -> None:
     common_base_url = "https://www.irs.gov/"
 
-    def prep_json_item(item: dict[str, str]) -> None:
-        pass
-
     ingest_json(
         db_session,
         json_filepath,
@@ -29,9 +26,8 @@ def _ingest_irs_web(
         common_base_url,
         skip_db,
         resume,
-        prep_json_item,
     )
 
 
-def main() -> None:
+def main() -> None:  # pragma: no cover
     process_and_ingest_sys_args(sys.argv, logger, _ingest_irs_web)

--- a/app/src/ingest_la_county_policy.py
+++ b/app/src/ingest_la_county_policy.py
@@ -18,14 +18,13 @@ def _ingest_la_county_policy(
 ) -> None:
     common_base_url = "https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/mergedProjects/"
 
-    def prep_json_item(item: dict[str, str]) -> dict[str, str]:
+    def prep_json_item(item: dict[str, str]) -> None:
         # More often than not, the h2 heading is better suited as the title
         item["title"] = item["h2"]
 
         # Include the program name in the document title
         program_name = item["h1"]
         item["title"] = f"{program_name}: {item['title']}"
-        return item
 
     chunking_config = DefaultChunkingConfig()
     # The document name is the same as item["h2"], so it is redundant to include it in the headings

--- a/app/src/ingestion/scrape_irs_web.py
+++ b/app/src/ingestion/scrape_irs_web.py
@@ -1,0 +1,27 @@
+# /// script
+# dependencies = [
+#   "scrapy",
+#   "markdownify",
+#   "nltk",
+#   "langchain_text_splitters",
+#   "html2text",
+# ]
+# ///
+# (This comment enables `uv run` to automatically create a virtual environment)
+
+SPIDER_NAME = "irs_web_spider"
+OUTPUT_JSON = "irs_web_scrapings.json"
+
+
+def main() -> None:
+    import os
+
+    from .scrapy_runner import run
+
+    run(SPIDER_NAME, OUTPUT_JSON, debug=bool(os.environ.get("DEBUG_SCRAPINGS", False)))
+
+
+if __name__ == "__main__":
+    from scrapy_runner import run
+
+    run(SPIDER_NAME, OUTPUT_JSON, debug=True)

--- a/app/src/ingestion/scrape_irs_web.py
+++ b/app/src/ingestion/scrape_irs_web.py
@@ -1,14 +1,3 @@
-# /// script
-# dependencies = [
-#   "scrapy",
-#   "markdownify",
-#   "nltk",
-#   "langchain_text_splitters",
-#   "html2text",
-# ]
-# ///
-# (This comment enables `uv run` to automatically create a virtual environment)
-
 SPIDER_NAME = "irs_web_spider"
 OUTPUT_JSON = "irs_web_scrapings.json"
 

--- a/app/src/ingestion/scrapy_dst/cache.py
+++ b/app/src/ingestion/scrapy_dst/cache.py
@@ -18,6 +18,6 @@ class FolderBasedFSCacheStorage(FilesystemCacheStorage):
     def _get_request_path(self, spider: Spider, request: Request) -> str:
         global crawl_log
         crawl_log.write(f"{request.url}\n")
-        key = request.url.replace(spider.common_url_prefix, "pages").replace(":", "_")
+        key = request.url.replace(spider.common_url_prefix, "pages/").replace(":", "_")
         folders = key.split("/")
         return os.path.join(self.cachedir, spider.name, *folders)

--- a/app/src/ingestion/scrapy_dst/settings.py
+++ b/app/src/ingestion/scrapy_dst/settings.py
@@ -20,7 +20,7 @@ LOG_LEVEL = "INFO"
 DEPTH_STATS_VERBOSE = True
 
 # the maximum number of errors to receive before closing the spider
-# CLOSESPIDER_ERRORCOUNT = 1
+CLOSESPIDER_ERRORCOUNT = 1
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True

--- a/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
@@ -1,48 +1,12 @@
 import re
-from typing import Any, Callable, Iterable, Optional, Sequence
+from typing import Optional
 
 import html2text
-from markdownify import markdownify
 from scrapy.http import HtmlResponse
 from scrapy.linkextractors import LinkExtractor
-from scrapy.selector import Selector, SelectorList
 from scrapy.spiders.crawl import CrawlSpider, Rule
 
-from src.util import string_utils  # noqa: E402
-
 AccordionSections = dict[str, list[str]]
-
-"""
-Use web browser to identify patterns across webpages (e.g., heading structure, common CSS classes) to do the scraping
-Test scraping in the Scrapy shell: cd src/ingestion/; scrapy shell https://www.irs.gov/credits-deductions/family-dependents-and-students-credits
-    # Grab the title for document.name
-    title = response.css("h1.pup-page-node-type-article-page__title::text").get().strip()
-    # Get element with non-boilerplate content
-    pup = response.css("div.pup-main-container").get()
-    # Remove elements to declutter desired content
-    response.css("div.sidebar-left").drop()
-    # Re-query after dropping
-    pup = response.css("div.pup-main-container").get()
-    # Convert to markdown
-    import html2text
-    h2t = html2text.HTML2Text()
-    h2t.body_width = 0
-    h2t.wrap_links = False
-    # Check that it has all the desired content
-    print(h2t.handle(pup))
-Incorporate code into Scrapy spider
-Run the spider:
-    Set `CLOSESPIDER_ERRORCOUNT = 1` in app/src/ingestion/scrapy_dst/settings.py so that it stops on the first error
-    Keep an eye on the cache in src/ingestion/.scrapy/httpcache/
-    DEBUG_SCRAPINGS=true poetry run scrape-irs-web
-Update spider with assertions and logger warnings to identify webpages that don't meet expectations
-    Use `allow`, `deny`, and `restrict_css` to limit the crawl scope of the spider
-Iterate
-
-Examine irs_web_scrapings.json-pretty.json
-Ingest: make ingest-irs-web DATASET_ID="IRS" BENEFIT_PROGRAM="tax credit" BENEFIT_REGION="US" FILEPATH=src/ingestion/irs_web_scrapings.json INGEST_ARGS="--skip_db"
-Examine markdown files under irs_web_md/
-"""
 
 
 class IrsSpider(CrawlSpider):

--- a/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
@@ -22,7 +22,16 @@ class IrsSpider(CrawlSpider):
         Rule(
             LinkExtractor(
                 allow="www.irs.gov/credits-deductions/",
-                deny=("www.irs.gov/credits-deductions/businesses"),
+                deny=(
+                    "www.irs.gov/credits-deductions/businesses",
+                    # These are about pandemic era changes to the child tax credit that aren't active anymore
+                    # Exclude since they could be misleading if they get cited
+                    r"2021-child-tax-credit-and-advance-child-tax-credit-payments.*",
+                    r"tax-year-2021-filing-season-2022-child-tax-credit-frequently-asked-questions.*",
+                    "advance-child-tax-credit-payments-in-2021/",
+                    # Irrelavant pages
+                    "clean-vehicle-and-energy-credits",
+                ),
                 allow_domains=allowed_domains,
                 deny_domains=(),
                 restrict_css=("div.pup-main-container"),

--- a/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
@@ -1,0 +1,131 @@
+import re
+
+from markdownify import markdownify
+from scrapy.http import HtmlResponse
+from scrapy.linkextractors import LinkExtractor
+from scrapy.selector import Selector, SelectorList
+from scrapy.spiders.crawl import CrawlSpider, Rule
+
+from src.util import string_utils  # noqa: E402
+
+AccordionSections = dict[str, list[str]]
+
+
+class IrsSpider(CrawlSpider):
+    # This name is used on the commandline: scrapy crawl edd_spider
+    name = "irs_spider"
+    allowed_domains = ["irs.gov"]
+    start_urls = ["https://www.irs.gov/credits-deductions/family-dependents-and-students-credits"]
+
+    # This is used to substitute the base URL in the cache storage
+    common_url_prefix = "https://www.irs.gov/"
+
+    rules = (
+        Rule(
+            LinkExtractor(
+                allow=r"credits-deductions/",
+                deny=(
+                ),
+                allow_domains=allowed_domains,
+                deny_domains=(
+                ),
+                restrict_css=(),
+                canonicalize=True,
+                unique=True,
+            ),
+            callback="parse_page",
+            follow=True,
+        ),
+    )
+
+    def parse_page(self, response: HtmlResponse) -> dict[str, str | AccordionSections]:
+        extractions = {"url": response.url}
+
+        title = response.css("div.full-width-title h1::text").get()
+        if len(response.css("h1::text").getall()) == 1:
+            title = response.css("h1::text").get()
+            extractions["title"] = title.strip()
+        else:
+            titles = ";".join(response.css("h1::text").getall())
+            extractions["title"] = titles
+
+        base_url = response.url
+        if two_thirds := response.css("div.two-thirds"):
+            # Remove buttons from the main content, i.e., "Show All"
+            two_thirds.css("button").drop()
+            extractions |= self.parse_entire_two_thirds(base_url, two_thirds)
+
+            if not extractions.get("main_content"):
+                self.logger.warning(
+                    "Insufficient div.two-thirds content, fallback to parsing entire main-content for %s",
+                    response.url,
+                )
+                # The main-content div often has boilerplate navigation content that we usually ignore.
+                # For these 'en/about_edd/news_releases_and_announcements' pages, the navigation content doesn't exist
+                extractions |= self.parse_main_content(base_url, response.css("div#main-content"))
+
+            if accordions := two_thirds.css("div.panel-group.accordion"):
+                if len(accordions) > 1:
+                    self.logger.info("Multiple accordions found at %s", response.url)
+
+                # If these parse methods become more complicated, move them to items.py
+                # and use ItemLoaders https://docs.scrapy.org/en/latest/topics/loaders.html
+                extractions |= self.parse_nonaccordion(base_url, two_thirds)
+                extractions |= self.parse_accordions(base_url, two_thirds)
+
+        elif main_primary := response.css("main.main-primary"):
+            main_primary.css("button").drop()
+            extractions |= self.parse_main_primary(base_url, main_primary)
+        else:
+            pass
+
+        return extractions
+
+    def to_markdown(self, base_url: str, html: str) -> str:
+        markdown = markdownify(
+            html,
+            heading_style="ATX",
+            escape_asterisks=False,
+            escape_underscores=False,
+            escape_misc=False,
+            sup_symbol="<sup>",
+            sub_symbol="<sub>",
+        )
+        # Clean up markdown text: consolidate newlines; replace non-breaking spaces
+        markdown = re.sub(r"\n\n+", "\n\n", markdown).replace("\u00A0", " ")
+
+        # Replace non-absolute URLs with absolute URLs
+        markdown = string_utils.resolve_urls(base_url, markdown)
+        return markdown.strip()
+
+    def parse_main_primary(self, base_url: str, main_primary: SelectorList) -> dict[str, str]:
+        markdown = self.to_markdown(base_url, main_primary.get())
+        return {"main_primary": markdown}
+
+    def parse_main_content(self, base_url: str, main_content: SelectorList) -> dict[str, str]:
+        markdown = self.to_markdown(base_url, main_content.get())
+        return {"main_content": markdown}
+
+    def parse_entire_two_thirds(self, base_url: str, two_thirds: SelectorList) -> dict[str, str]:
+        markdown = self.to_markdown(base_url, two_thirds.get())
+        cleaned_markdown = re.sub(r"\[(.*?)\]\(#collapse-(.*?)\)", r"\1", markdown)
+        # FIXME: parse tab panes correctly -- https://irs.ca.gov/en/unemployment/
+        cleaned_markdown = re.sub(r"\[(.*?)\]\(#pane-(.*?)\)", r"\1", cleaned_markdown)
+        return {"main_content": cleaned_markdown}
+
+    def parse_nonaccordion(self, base_url: str, main_content: SelectorList) -> dict[str, str]:
+        # Create a copy for modification without affecting the original
+        nonaccordion = Selector(text=main_content.get())
+        nonaccordion.css("div.panel-group.accordion").drop()
+        return {"nonaccordion": self.to_markdown(base_url, nonaccordion.get())}
+
+    def parse_accordions(
+        self, base_url: str, main_content: SelectorList
+    ) -> dict[str, AccordionSections]:
+        sections: AccordionSections = {}
+        for p in main_content.css("div.panel.panel-default"):
+            heading = p.css("div.panel-heading :is(h2, h3, h4, h5, h6) a::text").get().strip()
+            paragraphs = p.css("div.panel-body")
+            sections[heading] = [self.to_markdown(base_url, para.get()) for para in paragraphs]
+
+        return {"accordions": sections}

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -23,4 +23,4 @@ def test_create_engine_Imagine_LA():
     engine = chat_engine.create_engine(engine_id)
     assert engine is not None
     assert engine.name == ImagineLaEngine.name
-    assert engine.datasets == ["CA EDD", "Imagine LA", "DPSS Policy"]
+    assert engine.datasets == ["CA EDD", "Imagine LA", "DPSS Policy", "IRS"]

--- a/app/tests/src/test_ingest_irs_web.py
+++ b/app/tests/src/test_ingest_irs_web.py
@@ -1,0 +1,97 @@
+import json
+import logging
+from tempfile import TemporaryDirectory
+
+import pytest
+from sqlalchemy import delete, select
+
+from src.app_config import app_config as app_config_for_test
+from src.db.models.document import Document
+from src.ingest_irs_web import _ingest_irs_web
+
+
+@pytest.fixture
+def sample_markdown():
+    return json.dumps(
+        [
+        ]
+    )
+
+
+@pytest.fixture
+def irs_web_local_file(tmp_path, sample_markdown):
+    file_path = tmp_path / "web_scrapings.json"
+    file_path.write_text(sample_markdown)
+    return str(file_path)
+
+
+doc_attribs = {
+    "dataset": "IRS",
+    "program": "tax credit",
+    "region": "US",
+}
+
+
+def test_ingestion(caplog, app_config, db_session, irs_web_local_file):
+    # Force a short max_seq_length to test chunking
+    app_config_for_test.sentence_transformer.max_seq_length = 47
+
+    db_session.execute(delete(Document))
+
+    with TemporaryDirectory(suffix="irs_web_md") as md_base_dir:
+        with caplog.at_level(logging.WARNING):
+            _ingest_irs_web(
+                db_session,
+                irs_web_local_file,
+                doc_attribs,
+                md_base_dir=md_base_dir,
+                resume=True,
+            )
+
+        # check_database_contents(db_session, caplog)
+
+        # Re-ingesting the same data should not add any new documents
+        with caplog.at_level(logging.INFO):
+            _ingest_irs_web(
+                db_session,
+                irs_web_local_file,
+                doc_attribs,
+                md_base_dir=md_base_dir,
+                resume=True,
+            )
+
+
+def check_database_contents(db_session, caplog):
+    documents = db_session.execute(select(Document).order_by(Document.name)).scalars().all()
+    assert len(documents) == 3
+
+    assert documents[0].name == "CALFRESH: 63-300 Application Process"
+    assert (
+        documents[0].source
+        == "https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/mergedProjects/CalFresh/CalFresh/63-300_Application_Process/63-300_Application_Process.htm"
+    )
+
+    assert documents[1].name == "CalWORKs: 44-115 Income-In-Kind"
+    assert (
+        documents[1].source
+        == "https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/mergedProjects/CalWORKs/CalWORKs/44-115_Inkind_Income/44-115_Inkind_Income.htm"
+    )
+
+    assert documents[2].name == "CalWORKs: 44-133 Treatment of Income"
+    assert (
+        documents[2].source
+        == "https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/mergedProjects/CalWORKs/CalWORKs/44-133_Treatment_of_Income/44-133_Treatment_of_Income.htm"
+    )
+
+    doc0 = documents[0]
+    assert len(doc0.chunks) == 2
+    assert doc0.chunks[0].content.startswith("## 63-300 Application Process\n\n### Purpose\n\n")
+    assert doc0.chunks[0].headings == ["CALFRESH"]
+    assert doc0.chunks[1].content.startswith("# CALFRESH")
+    assert doc0.chunks[1].headings == []
+
+    # Document[1] is short
+    doc1 = documents[1]
+    assert len(doc1.chunks) == 1
+    assert doc1.chunks[0].content.startswith("# CalWORKs\n\n## 44-115 Income-In-Kind\n\n")
+    assert doc1.chunks[0].headings == []


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-672

## Changes

* Add IRS web scraper for https://www.irs.gov/credits-deductions/family-dependents-and-students-credits
* Add ingestion scripts to `Makefile` and `poetry`
* Add IRS dataset to chat engine

## Testing

```
make scrape-irs-web

make ingest-irs-web DATASET_ID="IRS" BENEFIT_PROGRAM="tax credit" BENEFIT_REGION="US" FILEPATH=src/ingestion/irs_web_scrapings.json INGEST_ARGS=""
```

<img width="772" alt="image" src="https://github.com/user-attachments/assets/2d38826d-0f96-441b-a4e4-e9de7b490154" />
