### PR TITLE
fix: Limit origins to localhost:5173 and remove pattern from regex

### DIFF
--- a/app/src/app.py
+++ b/app/src/app.py
@@ -9,8 +9,8 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost"],
-    allow_origin_regex=r"http://localhost:\d+|https://dev-social-benefits-navigator--nava-chatbot-.*\.web\.app",
+    allow_origins=["http://localhost:5173"],
+    allow_origin_regex=r"https://dev-social-benefits-navigator--nava-chatbot-.*\.web\.app",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/app/src/app.py
+++ b/app/src/app.py
@@ -9,6 +9,7 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
+    # Imagine LA uses port 5173 for development
     allow_origins=["http://localhost:5173"],
     allow_origin_regex=r"https://dev-social-benefits-navigator--nava-chatbot-.*\.web\.app",
     allow_credentials=True,


### PR DESCRIPTION
Reference fix: https://github.com/navapbc/labs-decision-support-tool/pull/182/files#r1919131709

Tests showing locahost:3000 is blocked but localhost:5173 is valid:

```bash
labs-decision-support-tool/app on  DST-722-limit-cors-policy [?] ➜ curl -v -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Content-Type" -X OPTIONS http://localhost:8000/api/query
* Host localhost:8000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8000...
* Connected to localhost (::1) port 8000
> OPTIONS /api/query HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.7.1
> Accept: */*
> Origin: http://localhost:3000
> Access-Control-Request-Method: POST
> Access-Control-Request-Headers: Content-Type
> 
* Request completely sent off
< HTTP/1.1 400 Bad Request
< date: Thu, 16 Jan 2025 20:30:05 GMT
< server: uvicorn
< vary: Origin
< access-control-allow-methods: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT
< access-control-max-age: 600
< access-control-allow-credentials: true
< access-control-allow-headers: Content-Type
< content-length: 22
< content-type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
Disallowed CORS origin%                                                                                                 

labs-decision-support-tool/app on  DST-722-limit-cors-policy [?] ➜ curl -v -H "Origin: http://example.com" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Content-Type" -X OPTIONS http://localhost:8000/api/query
* Host localhost:8000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8000...
* Connected to localhost (::1) port 8000
> OPTIONS /api/query HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.7.1
> Accept: */*
> Origin: http://example.com
> Access-Control-Request-Method: POST
> Access-Control-Request-Headers: Content-Type
> 
* Request completely sent off
< HTTP/1.1 400 Bad Request
< date: Thu, 16 Jan 2025 20:30:25 GMT
< server: uvicorn
< vary: Origin
< access-control-allow-methods: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT
< access-control-max-age: 600
< access-control-allow-credentials: true
< access-control-allow-headers: Content-Type
< content-length: 22
< content-type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
Disallowed CORS origin%                                                                                                 

labs-decision-support-tool/app on  DST-722-limit-cors-policy [?] ➜ curl -v -H "Origin: http://localhost:5173" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: Content-Type" -X OPTIONS http://localhost:8000/api/query
* Host localhost:8000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8000...
* Connected to localhost (::1) port 8000
> OPTIONS /api/query HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/8.7.1
> Accept: */*
> Origin: http://localhost:5173
> Access-Control-Request-Method: POST
> Access-Control-Request-Headers: Content-Type
> 
* Request completely sent off
< HTTP/1.1 200 OK
< date: Thu, 16 Jan 2025 20:31:58 GMT
< server: uvicorn
< vary: Origin
< access-control-allow-methods: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT
< access-control-max-age: 600
< access-control-allow-credentials: true
< access-control-allow-origin: http://localhost:5173
< access-control-allow-headers: Content-Type
< content-length: 2
< content-type: text/plain; charset=utf-8
< 
* Connection #0 to host localhost left intact
OK%                          
```