### PR TITLE
dev experience: Add app-shell target to Makefile

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -106,6 +106,9 @@ stop:
 
 check: format-check lint test
 
+app-shell:
+	docker compose run -ti -e PY_RUN_APPROACH=local --name $(APP_NAME)-shell --rm $(APP_NAME) /bin/bash
+
 ##################################################
 # DB & migrations
 ##################################################


### PR DESCRIPTION
## Changes

Add `app-shell` to Makefile that creates a transient container to quickly run commands against the code base without the overhead of creating a new container with each `make ...` command.

## Testing

Create a `main-app-shell` container: `make app-shell`

and leave it open to run any `make ...` commands:
```
make lint
make test
...
exit  # Or Ctrl-D
```