### PR TITLE
refactor: Generalize scrapy-runner

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -268,10 +268,7 @@ scrape-la-county-policy:
 
 
 scrapy-runner:
-ifndef SPIDER
-	$(error SPIDER (prefix for the spider name) is undefined)
-endif
-	$(PY_RUN_CMD) scrapy-runner "$(SPIDER)"
+	$(PY_RUN_CMD) scrapy-runner $(args)
 
 ingest-runner:
 ifndef DATASET_ID

--- a/app/Makefile
+++ b/app/Makefile
@@ -107,7 +107,7 @@ stop:
 check: format-check lint test
 
 app-shell:
-	docker compose run -ti -e PY_RUN_APPROACH=local --name $(APP_NAME)-shell --rm $(APP_NAME) /bin/bash
+	docker compose run -ti -e PY_RUN_APPROACH=local --name $(APP_NAME)-shell --rm $(APP_NAME) /bin/bash --rcfile .apprc
 
 ##################################################
 # DB & migrations
@@ -252,13 +252,6 @@ ifndef FILEPATH
 endif
 
 
-scrape-ca-public-charge:
-	$(PY_RUN_CMD) scrapy-runner ca_public_charge
-
-scrape-edd-web:
-	$(PY_RUN_CMD) scrapy-runner edd
-
-
 scrape-imagine-la:
 	cd src/ingestion/imagine_la/scrape; uv run --no-project scrape_content_hub.py https://socialbenefitsnavigator25.web.app/contenthub $(CONTENTHUB_PASSWORD)
 
@@ -273,11 +266,12 @@ scrape-la-county-policy:
 	# Now that we have the expanded nav bar, scrape all the links in the nav bar
 	$(PY_RUN_CMD) scrapy-runner la_policy 2>&1 | tee out.log
 
-scrape-irs-web:
-	$(PY_RUN_CMD) scrapy-runner irs
 
-scrape-ca-ftb:
-	$(PY_RUN_CMD) scrapy-runner ca_ftb
+scrapy-runner:
+ifndef SPIDER
+	$(error SPIDER (prefix for the spider name) is undefined)
+endif
+	$(PY_RUN_CMD) scrapy-runner "$(SPIDER)"
 
 ingest-runner:
 ifndef DATASET_ID

--- a/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/irs_spider.py
@@ -9,7 +9,7 @@ from scrapy.spiders.crawl import CrawlSpider, Rule
 
 class IrsSpider(CrawlSpider):
     # This name is used on the commandline: scrapy crawl edd_spider
-    name = "irs_web_spider"
+    name = "irs_spider"
     allowed_domains = ["irs.gov"]
     start_urls = ["https://www.irs.gov/credits-deductions/family-dependents-and-students-credits"]
 

--- a/app/src/ingestion/scrapy_runner.py
+++ b/app/src/ingestion/scrapy_runner.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pprint import pprint
 
+from scrapy import spiderloader
 from scrapy.crawler import CrawlerProcess
 from scrapy.utils.project import get_project_settings
 
@@ -49,17 +50,23 @@ def postprocess_json(input_filename: str) -> None:
             logger.info("Formatted JSON saved to %s-pretty.json", input_filename)
 
 
-def run(spider_name: str, output_json_filename: str, debug: bool = False) -> None:
+def list_spiders() -> list[str]:
+    settings = get_project_settings()
+    spider_loader = spiderloader.SpiderLoader.from_settings(settings)
+    return spider_loader.list()
+
+
+def main() -> None:
     # Scrapy expects the scrapy.cfg file to be in the current working directory
     if "src" in os.listdir():
         os.chdir("src/ingestion")
 
-    run_spider(spider_name, output_json_filename)
-    if debug:
-        postprocess_json(output_json_filename)
+    if len(sys.argv) == 1:
+        spiders = list_spiders()
+        datasets = [spider.removesuffix("_spider") for spider in spiders]
+        print(f"Available datasets: {datasets}")
+        return
 
-
-def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("dataset")
     parser.add_argument("--debug", action="store_true")
@@ -67,4 +74,7 @@ def main() -> None:
     args = parser.parse_args(sys.argv[1:])
     spider_id = f"{args.dataset}_spider"
     json_output = f"{spider_id.removesuffix("spider")}scrapings.json"
-    run(spider_id, json_output, debug=args.debug)
+
+    run_spider(spider_id, json_output)
+    if args.debug:
+        postprocess_json(json_output)

--- a/app/src/ingestion/scrapy_runner.py
+++ b/app/src/ingestion/scrapy_runner.py
@@ -59,24 +59,12 @@ def run(spider_name: str, output_json_filename: str, debug: bool = False) -> Non
         postprocess_json(output_json_filename)
 
 
-DATASETS = {
-    "edd": {},
-    "la_policy": {},
-    "irs": {
-        "spider": "irs_web_spider",
-    },
-    "ca_public_charge": {},
-    "ca_ftb": {},
-}
-
-
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("dataset")
     parser.add_argument("--debug", action="store_true")
 
     args = parser.parse_args(sys.argv[1:])
-    ds = DATASETS[args.dataset]
-    spider_id = ds.get("spider", f"{args.dataset}_spider")
-    json_output = ds.get("output", f"{spider_id.removesuffix("spider")}scrapings.json")
+    spider_id = f"{args.dataset}_spider"
+    json_output = f"{spider_id.removesuffix("spider")}scrapings.json"
     run(spider_id, json_output, debug=args.debug)


### PR DESCRIPTION
## Ticket

Follow-on to #186

## Changes

* Remove specific `scrape-*` Makefile targets for each Srapy dataset
* Add general `scrapy-runner` Makefile target
* Generalize `scrapy_runner.py`

Impact:
* Reduces the number files we need to remember to update when adding a new dataset for ingestion

## Testing

```
# List datasets
make scrapy-runner

# Run specific scrapy spider
make scrapy-runner args="ca_ftb --debug"
```