### PR TITLE
refactor: Make ingest-runner consistent with scrapy-runner

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -271,10 +271,4 @@ scrapy-runner:
 	$(PY_RUN_CMD) scrapy-runner $(args)
 
 ingest-runner:
-ifndef DATASET_ID
-	$(error DATASET_ID is undefined)
-endif
-ifndef FILEPATH
-	$(error FILEPATH is undefined)
-endif
-	$(PY_RUN_CMD) ingest-runner "$(DATASET_ID)" "$(FILEPATH)" $(INGEST_ARGS)
+	$(PY_RUN_CMD) ingest-runner $(args)

--- a/app/src/ingest_runner.py
+++ b/app/src/ingest_runner.py
@@ -9,7 +9,7 @@ from src.util.ingest_utils import DefaultChunkingConfig, IngestConfig, start_ing
 logger = logging.getLogger(__name__)
 
 
-def edd_web_config(dataset_id: str, benefit_program: str, benefit_region: str) -> IngestConfig:
+def edd_web_config(dataset_label: str, benefit_program: str, benefit_region: str, scraper_dataset: str) -> IngestConfig:
     def _fix_input_markdown(markdown: str) -> str:
         # Fix ellipsis text that causes markdown parsing errors
         # '. . .' is parsed as sublists on the same line
@@ -38,17 +38,17 @@ def edd_web_config(dataset_id: str, benefit_program: str, benefit_region: str) -
         item["markdown"] = _fix_input_markdown(markdown)
 
     return IngestConfig(
-        dataset_id,
+        dataset_label,
         benefit_program,
         benefit_region,
         "https://edd.ca.gov/en/",
-        "edd_web_md",
+        scraper_dataset,
         prep_json_item,
     )
 
 
 def la_county_policy_config(
-    dataset_id: str, benefit_program: str, benefit_region: str
+    dataset_label: str, benefit_program: str, benefit_region: str, scraper_dataset: str
 ) -> IngestConfig:
     chunking_config = DefaultChunkingConfig()
     # The document name is the same as item["h2"], so it is redundant to include it in the headings
@@ -63,18 +63,18 @@ def la_county_policy_config(
         item["title"] = f"{program_name}: {item['title']}"
 
     return IngestConfig(
-        dataset_id,
+        dataset_label,
         benefit_program,
         benefit_region,
         "https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/mergedProjects/",
-        "la_policy_md",
+        scraper_dataset,
         prep_json_item,
         chunking_config,
     )
 
 
 def ca_public_charge_config(
-    dataset_id: str, benefit_program: str, benefit_region: str
+    dataset_label: str, benefit_program: str, benefit_region: str, scraper_dataset: str
 ) -> IngestConfig:
     def prep_json_item(item: dict[str, str]) -> None:
         markdown = item.get("main_content", item.get("main_primary", None))
@@ -82,37 +82,37 @@ def ca_public_charge_config(
         item["markdown"] = markdown
 
     return IngestConfig(
-        dataset_id,
+        dataset_label,
         benefit_program,
         benefit_region,
         "https://keepyourbenefits.org/en/ca/",
-        "ca_public_charge_md",
+        scraper_dataset,
         prep_json_item,
     )
 
 
-def get_ingester_config(dataset_id: str) -> IngestConfig:
-    match dataset_id:
-        case "CA EDD":
-            return edd_web_config(dataset_id, "employment", "California")
-        case "DPSS Policy":
-            return la_county_policy_config(dataset_id, "mixed", "California:LA County")
-        case "IRS":
+def get_ingester_config(scraper_dataset: str) -> IngestConfig:
+    match scraper_dataset:
+        case "ca_ftb":
             return IngestConfig(
-                dataset_id, "tax credit", "US", "https://www.irs.gov/", "irs_web_md"
+                "CA FTB", "tax credit", "California", "https://www.ftb.ca.gov/", scraper_dataset
             )
-        case "Keep Your Benefits":
-            return ca_public_charge_config(dataset_id, "mixed", "California")
-        case "CA FTB":
+        case "ca_public_charge":
+            return ca_public_charge_config("Keep Your Benefits", "mixed", "California", scraper_dataset)
+        case "ca_wic":
             return IngestConfig(
-                dataset_id, "tax credit", "California", "https://www.ftb.ca.gov/", "ca_ftb_md"
+                "WIC", "wic", "California", "https://www.phfewic.org/en/", scraper_dataset
             )
-        case "WIC":
+        case "edd":
+            return edd_web_config("CA EDD", "employment", "California", scraper_dataset)
+        case "irs":
             return IngestConfig(
-                dataset_id, "wic", "California", "https://www.phfewic.org/en/", "ca_wic_md"
+                "IRS", "tax credit", "US", "https://www.irs.gov/", scraper_dataset
             )
+        case "la_policy":
+            return la_county_policy_config("DPSS Policy", "mixed", "California:LA County", scraper_dataset)
         case _:
-            raise ValueError(f"Unknown dataset_id: {dataset_id}")
+            raise ValueError(f"Unknown dataset: {scraper_dataset!r}.  Run `make scrapy-runner` to see available datasets")
 
 
 # Print INFO messages since this is often run from the terminal during local development
@@ -121,17 +121,17 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 
 def main() -> None:  # pragma: no cover
     parser = argparse.ArgumentParser()
-    parser.add_argument("dataset_id")
-    parser.add_argument("file_path")
+    parser.add_argument("dataset", help="scraper dataset id from `make scrapy-runner`")
+    parser.add_argument("--json_input", help="path to the JSON file to ingest")
     parser.add_argument("--resume", action="store_true")
     parser.add_argument("--skip_db", action="store_true")
     args = parser.parse_args(sys.argv[1:])
 
-    config = get_ingester_config(sys.argv[1])
+    config = get_ingester_config(args.dataset)
     start_ingestion(
         logger,
         ingest_json,
-        args.file_path,
+        args.json_input or f"src/ingestion/{config.scraper_dataset}_scrapings.json",
         config,
         skip_db=args.skip_db,
         resume=args.resume,

--- a/app/src/ingestion/scrapy_dst/spiders/__init__.py
+++ b/app/src/ingestion/scrapy_dst/spiders/__init__.py
@@ -7,5 +7,5 @@ import os
 import sys
 
 app_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
-print("Adding DST's app folder to sys.path:", app_folder)
+print(f"(Bootstrapping for Scrapy: Adding DST's app folder to sys.path:{app_folder})")
 sys.path.append(app_folder)

--- a/app/src/ingestion/scrapy_runner.py
+++ b/app/src/ingestion/scrapy_runner.py
@@ -61,15 +61,17 @@ def main() -> None:
     if "src" in os.listdir():
         os.chdir("src/ingestion")
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dataset")
+    parser.add_argument("--debug", action="store_true")
+
     if len(sys.argv) == 1:
+        parser.print_help()
+        print("")
         spiders = list_spiders()
         datasets = [spider.removesuffix("_spider") for spider in spiders]
         print(f"Available datasets: {datasets}")
         return
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("dataset")
-    parser.add_argument("--debug", action="store_true")
 
     args = parser.parse_args(sys.argv[1:])
     spider_id = f"{args.dataset}_spider"

--- a/app/tests/src/test_ingest_ca_public_charge.py
+++ b/app/tests/src/test_ingest_ca_public_charge.py
@@ -87,7 +87,7 @@ def test_ingestion(caplog, app_config, db_session, ca_public_charge_local_file):
     db_session.execute(delete(Document))
 
     with TemporaryDirectory(suffix="ca_public_charge_md") as md_base_dir:
-        config = get_ingester_config("Keep Your Benefits")
+        config = get_ingester_config("ca_public_charge")
         with caplog.at_level(logging.WARNING):
             ingest_json(
                 db_session,

--- a/app/tests/src/test_ingest_edd_web.py
+++ b/app/tests/src/test_ingest_edd_web.py
@@ -106,7 +106,7 @@ def test__ingest_edd(
     db_session.execute(delete(Document))
 
     with TemporaryDirectory(suffix="edd_md") as md_base_dir, caplog.at_level(logging.WARNING):
-        config = get_ingester_config("CA EDD")
+        config = get_ingester_config("edd")
         if file_location == "local":
             ingest_json(db_session, edd_web_local_file, config, md_base_dir=md_base_dir)
         else:
@@ -221,7 +221,7 @@ def test__ingest_edd_using_md_tree(caplog, app_config, db_session, edd_web_local
     db_session.execute(delete(Document))
 
     with TemporaryDirectory(suffix="edd_md") as md_base_dir:
-        config = get_ingester_config("CA EDD")
+        config = get_ingester_config("edd")
         with caplog.at_level(logging.WARNING):
             ingest_json(
                 db_session, edd_web_local_file, config, md_base_dir=md_base_dir, resume=True

--- a/app/tests/src/test_ingest_irs_web.py
+++ b/app/tests/src/test_ingest_irs_web.py
@@ -62,7 +62,7 @@ def test_ingestion(caplog, app_config, db_session, irs_web_local_file):
     db_session.execute(delete(Document))
 
     with TemporaryDirectory(suffix="irs_web_md") as md_base_dir:
-        config = get_ingester_config("IRS")
+        config = get_ingester_config("irs")
         with caplog.at_level(logging.WARNING):
             ingest_json(
                 db_session,

--- a/app/tests/src/test_ingest_la_county_policy.py
+++ b/app/tests/src/test_ingest_la_county_policy.py
@@ -87,7 +87,7 @@ def test_ingestion(caplog, app_config, db_session, la_county_policy_local_file):
     db_session.execute(delete(Document))
 
     with TemporaryDirectory(suffix="la_policy_md") as md_base_dir:
-        config = get_ingester_config("DPSS Policy")
+        config = get_ingester_config("la_policy")
         with caplog.at_level(logging.WARNING):
             ingest_json(
                 db_session,

--- a/app/tests/src/test_ingest_utils.py
+++ b/app/tests/src/test_ingest_utils.py
@@ -94,7 +94,7 @@ def test_process_and_ingest_sys_args_calls_ingest(caplog):
         assert call_args[0][1] == "/some/folder"
         ingest_config = call_args[0][2]
         assert isinstance(ingest_config, IngestConfig)
-        assert ingest_config.dataset_id == "bridges-eligibility-manual"
+        assert ingest_config.dataset_label == "bridges-eligibility-manual"
         assert ingest_config.benefit_program == "SNAP"
         assert ingest_config.benefit_region == "Michigan"
         assert call_args[1] == {"skip_db": False}


### PR DESCRIPTION
## Ticket

Follow-on to #189 and #192

## Changes
Refactor code towards [convention over configuration](https://en.wikipedia.org/wiki/Convention_over_configuration)
* In the Makefile, make `ingest-runner` consistent with `scrapy-runner`. Now the dataset argument to both are the same.
* Rename `IngestConfig.dataset_label` since it now acts as a label in the UI, rather than an `dataset_id`

## Testing

```
# List datasets
make scrapy-runner
# Available datasets: ['ca_ftb', 'ca_public_charge', 'ca_wic', 'edd', 'irs', 'la_policy']

make scrapy-runner args=ca_ftb
make ingest-runner args=ca_ftb

make scrapy-runner args=ca_public_charge
make ingest-runner args=ca_public_charge

make scrapy-runner args=ca_wic
make ingest-runner args=ca_wic

...
```