### PR TITLE
fix: Remove unused ImagineLA chat engine settings from UI

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -179,6 +179,13 @@ class ImagineLaEngine(BaseEngine):
     chunks_shown_min_score: float = -1
     chunks_shown_max_num: int = 8
 
+    user_settings = [
+        "llm",
+        "retrieval_k",
+        "retrieval_k_min_score",
+        "system_prompt",
+    ]
+
     engine_id: str = "imagine-la"
     name: str = "Imagine LA Chat Engine"
     datasets = ["CA EDD", "Imagine LA", "DPSS Policy", "IRS", "Keep Your Benefits", "CA FTB", "WIC"]


### PR DESCRIPTION

## Ticket

[Slack](https://nava.slack.com/archives/C06ETE82UHM/p1737672114646719?thread_ts=1737671120.579439&cid=C06ETE82UHM)

## Changes

Remove unused ImagineLA chat engine settings from UI

## Testing

In chatbot web UI, open the chatbot's settings to ensure those 2 settings don't appear.