### PR TITLE
feat: Add MessageAttributes to Literal AI message metadata

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -251,6 +251,7 @@ def _get_retrieval_metadata(result: OnMessageResult) -> dict:
             for citations in result.subsections
         ],
         "raw_response": result.response,
+        "attributes": result.attributes.model_dump(),
     }
 
 


### PR DESCRIPTION
## Ticket

Associated with investigating https://navalabs.atlassian.net/browse/DST-733


## Changes

Add MessageAttributes to Literal AI message metadata so that we can investigate why RAG isn't being performed for certain questions.

## Testing

The response in LiteralAI should now show attributes:
![image](https://github.com/user-attachments/assets/42a98f0f-d46d-4c88-b76f-87ed100a9c27)
