### PR TITLE
feat: Use query as the LiteralAI thread name

### DIFF
--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -242,8 +242,9 @@ def get_chat_engine(session: UserSession) -> ChatEngineInterface:
 async def query(request: QueryRequest) -> QueryResponse:
     user_session_id = request.user_id if request.user_id else request.session_id
     session = await _get_user_session(user_session_id)
+    one_line_question = request.message.strip().splitlines()[0] or "API:/query"
     with (
-        literalai().thread(name="API:/query", participant_id=session.literalai_user_id),
+        literalai().thread(name=one_line_question, participant_id=session.literalai_user_id),
         app_config.db_session() as db_session,
         db_session.begin(),  # session is auto-committed or rolled back upon exception
     ):


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-756

## Changes

Replace `API:/query` in LiteralAI with the user's question under the `Name` column.

## Testing
POST a question with new lines:
```
curl -X POST 'http://0.0.0.0:8000/api/query' -H 'Content-Type: application/json' -d '{ "session_id": "1234", "new_session": true, "message": "\nunemployment insurance \nbenefit deadlines?"}'
```
Check in LiteralAI for the thread name that uses only the first non-empty line of the `message`:
![image](https://github.com/user-attachments/assets/410af154-24d1-4dd9-ab15-4eeb5d10bf51)
