### PR TITLE
feat: Add benefit_program to ImagineLA_MessageAttributes

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -75,6 +75,9 @@ class ChatEngineInterface(ABC):
     chunks_shown_max_num: int = 5
     chunks_shown_min_score: float = 0.65
 
+    # Whether to show message-assessment attributes resulting from system_prompt_1 in the UI
+    show_msg_attributes: bool = False
+
     system_prompt_1: str = ANALYZE_MESSAGE_PROMPT
     system_prompt_2: str = PROMPT
 
@@ -125,6 +128,7 @@ class BaseEngine(ChatEngineInterface):
         "llm",
         "retrieval_k",
         "retrieval_k_min_score",
+        "show_msg_attributes",
         "chunks_shown_max_num",
         "chunks_shown_min_score",
         "system_prompt_1",
@@ -216,6 +220,7 @@ If a prompt is about an EDD program, but you can't tell which one, detect and cl
 
 
 class ImagineLA_MessageAttributes(MessageAttributes):
+    benefit_program: str
     canned_response: str
     alert_message: str
 
@@ -228,10 +233,13 @@ class ImagineLaEngine(BaseEngine):
     chunks_shown_min_score: float = -1
     chunks_shown_max_num: int = 8
 
+    show_msg_attributes: bool = False
+
     user_settings = [
         "llm",
         "retrieval_k",
         "retrieval_k_min_score",
+        "show_msg_attributes",
         "system_prompt_1",
         "system_prompt_2",
     ]
@@ -274,6 +282,8 @@ Moving Assistance (MA), 4 Month Rental Assistance, General Relief (GR) Rental As
 
 If the user asks what programs or what information is available, \
 set canned_response to text that gives examples and describes categories for the in-scope benefit programs.
+
+Set benefit_program to the name of the in-scope benefit program that the user's question is about.
 
 If the user's question is not about one of the in-scope benefit programs, set canned_response to \
 "Sorry, I don't have info about that topic. \

--- a/app/tests/src/test_batch_process.py
+++ b/app/tests/src/test_batch_process.py
@@ -64,6 +64,7 @@ def test_process_question(monkeypatch, engine):
         attributes=ImagineLA_MessageAttributes(
             needs_context=True,
             translated_message="",
+            benefit_program="CalFresh",
             canned_response="",
             alert_message="Some alert message.",
         ),
@@ -80,6 +81,7 @@ def test_process_question(monkeypatch, engine):
         "citation_1_text": subsection_text,
         "attrib__needs_context": True,
         "attrib__translated_message": "",
+        "attrib__benefit_program": "CalFresh",
         "attrib__alert_message": "Some alert message.",
         "attrib__canned_response": "",
     }

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -182,6 +182,7 @@ async def test_run_query__2_citations(subsections):
                 ImagineLA_MessageAttributes(
                     needs_context=True,
                     translated_message="",
+                    benefit_program="CalFresh",
                     canned_response="",
                     alert_message="Some alert message.",
                 ),

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -42,6 +42,7 @@ def test_on_message_Imagine_LA_canned_response(monkeypatch):
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=True,
             translated_message="",
+            benefit_program="",
             canned_response="This is a canned response",
             alert_message="",
         ),
@@ -50,6 +51,7 @@ def test_on_message_Imagine_LA_canned_response(monkeypatch):
     engine = chat_engine.create_engine("imagine-la")
     result = engine.on_message("What is AI?")
     assert result.response == "This is a canned response"
+    assert not result.attributes.benefit_program
     assert not result.attributes.alert_message
 
 
@@ -60,6 +62,7 @@ def test_on_message_Imagine_LA_alert_message(monkeypatch):
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=True,
             translated_message="",
+            benefit_program="CalFresh",
             canned_response="",
             alert_message="Some alert message",
         ),
@@ -70,6 +73,7 @@ def test_on_message_Imagine_LA_alert_message(monkeypatch):
     engine = chat_engine.create_engine("imagine-la")
     result = engine.on_message("What is AI?")
     assert result.response == "This is a generated response"
+    assert result.attributes.benefit_program == "CalFresh"
     assert result.attributes.alert_message.startswith("**Policy update**: ")
     assert result.attributes.alert_message.endswith("\n\nThe rest of this answer may be outdated.")
 
@@ -81,6 +85,7 @@ def test_on_message_Imagine_LA_needs_context_False(monkeypatch):
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=False,
             translated_message="",
+            benefit_program="CalFresh",
             canned_response="",
             alert_message="Some alert message",
         ),
@@ -92,5 +97,6 @@ def test_on_message_Imagine_LA_needs_context_False(monkeypatch):
     assert result.response == "This is a generated response"
     assert not result.chunks_with_scores
     assert not result.subsections
+    assert result.attributes.benefit_program == "CalFresh"
     assert result.attributes.alert_message.startswith("**Policy update**: ")
     assert result.attributes.alert_message.endswith("\n\nThe rest of this answer may be outdated.")


### PR DESCRIPTION
## Ticket

Supports investigation and solutioning for https://navalabs.atlassian.net/browse/DST-733

## Changes

To facilitate testing [these hypotheses](https://navalabs.atlassian.net/browse/DST-733?focusedCommentId=10477) and improving the system prompt:
1. add `benefit_program` as an attribute that the LLM should populate
2. explicitly show the message attributes in the UI so they can be quickly assessed (instead of having to wait for Literal AI to be updated and searching for the corresponding message).

## Testing

Enable "Show message-assessment attributes" in the chatbot settings, submit a query, expect to see message attributes after the response:
![image](https://github.com/user-attachments/assets/b77e244b-5294-4813-9134-25f94dd7551e)
