### PR TITLE
feat: Ingest manual scraping of SSA pdf

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -255,6 +255,7 @@ class ImagineLaEngine(BaseEngine):
         "CA FTB",
         "WIC",
         "Covered California",
+        "SSA",
     ]
 
     system_prompt_1 = """Analyze the user's message to respond with a JSON dictionary populated with the following fields and default values:

--- a/app/src/ingest_runner.py
+++ b/app/src/ingest_runner.py
@@ -121,6 +121,10 @@ def get_ingester_config(scraper_dataset: str) -> IngestConfig:
             return IngestConfig("IRS", "tax credit", "US", "https://www.irs.gov/", scraper_dataset)
         case "la_policy":
             return la_policy_config("DPSS Policy", "mixed", "California:LA County", scraper_dataset)
+        case "ssa":
+            return IngestConfig(
+                "SSA", "social security", "US", "https://www.ssa.gov/", scraper_dataset
+            )
         case _:
             raise ValueError(
                 f"Unknown dataset: {scraper_dataset!r}.  Run `make scrapy-runner` to see available datasets"

--- a/app/src/ingester.py
+++ b/app/src/ingester.py
@@ -189,11 +189,20 @@ def _chunk_into_splits_from_json(
         urls_processed.add(url)
 
         assert "title" in item, f"Item {url} has no title"
-        assert "markdown" in item, f"Item {url} has no markdown content"
-        document = Document(name=item["title"], content=item["markdown"], source=url, **doc_attribs)
 
         file_path = create_file_path(md_base_dir, common_base_url, url)
-        load_or_save_doc_markdown(file_path, document)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        if "md_file" in item:
+            # Load the markdown content from the file
+            logger.info("  Loading markdown from file: %r", item["md_file"])
+            content = Path(item["md_file"]).read_text(encoding="utf-8")
+        else:
+            assert "markdown" in item, f"Item {url} has no markdown content"
+            # Load the markdown from a file if it exists (in case of manual modifications)
+            # or save item["markdown"] content to a file
+            content = load_or_save_doc_markdown(file_path, item["markdown"])
+
+        document = Document(name=item["title"], content=content, source=url, **doc_attribs)
 
         chunks_file_path = f"{file_path}.splits.json"
         if os.path.exists(chunks_file_path):

--- a/app/src/ingester.py
+++ b/app/src/ingester.py
@@ -6,6 +6,8 @@ from typing import Optional, Sequence
 
 from smart_open import open as smart_open
 
+# from smart_open import parse_uri
+
 from src.adapters import db
 from src.app_config import app_config
 from src.db.models.document import Chunk, Document
@@ -97,6 +99,7 @@ def ingest_json(
     chunking_config = config.chunking_config or DefaultChunkingConfig()
     # First, chunk all json_items into splits (fast) to debug any issues quickly
     all_splits = _chunk_into_splits_from_json(
+        json_filepath,
         md_base_dir or config.md_base_dir,
         json_items,
         config.doc_attribs,
@@ -169,6 +172,7 @@ def save_to_db(
 
 
 def _chunk_into_splits_from_json(
+    json_filepath: str,
     md_base_dir: str,
     json_items: Sequence[dict[str, str]],
     doc_attribs: dict[str, str],
@@ -194,8 +198,13 @@ def _chunk_into_splits_from_json(
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
         if "md_file" in item:
             # Load the markdown content from the file
-            logger.info("  Loading markdown from file: %r", item["md_file"])
-            content = Path(item["md_file"]).read_text(encoding="utf-8")
+            json_base_dir = os.path.dirname(json_filepath)
+            # if parse_uri(json_filepath).scheme == "file":
+            #     json_base_dir=str(Path(json_base_dir).resolve())
+            extra_md_file_path = os.path.join(json_base_dir, item["md_file"])
+            logger.info("  Loading markdown from file: %r", extra_md_file_path)
+            with smart_open(extra_md_file_path, "r", encoding="utf-8") as md_file:
+                content = md_file.read()
         else:
             assert "markdown" in item, f"Item {url} has no markdown content"
             # Load the markdown from a file if it exists (in case of manual modifications)

--- a/app/src/ingester.py
+++ b/app/src/ingester.py
@@ -6,8 +6,6 @@ from typing import Optional, Sequence
 
 from smart_open import open as smart_open
 
-# from smart_open import parse_uri
-
 from src.adapters import db
 from src.app_config import app_config
 from src.db.models.document import Chunk, Document
@@ -199,8 +197,6 @@ def _chunk_into_splits_from_json(
         if "md_file" in item:
             # Load the markdown content from the file
             json_base_dir = os.path.dirname(json_filepath)
-            # if parse_uri(json_filepath).scheme == "file":
-            #     json_base_dir=str(Path(json_base_dir).resolve())
             extra_md_file_path = os.path.join(json_base_dir, item["md_file"])
             logger.info("  Loading markdown from file: %r", extra_md_file_path)
             with smart_open(extra_md_file_path, "r", encoding="utf-8") as md_file:

--- a/app/src/ingestion/imagine_la/ingest.py
+++ b/app/src/ingestion/imagine_la/ingest.py
@@ -65,11 +65,10 @@ def _parse_html(
     content = f"# {document.name}\n\n"
     for heading, body in accordion_data.items():
         content += f"## {heading}\n\n{md(body)}\n\n"
-    document.content = content
 
     assert document.source
     file_path = create_file_path(md_base_dir, common_base_url, document.source)
-    load_or_save_doc_markdown(file_path, document)
+    document.content = load_or_save_doc_markdown(file_path, content)
 
     # Convert markdown to chunks
     tree = create_markdown_tree(content, doc_name=document.name, doc_source=document.source)

--- a/app/src/util/ingest_utils.py
+++ b/app/src/util/ingest_utils.py
@@ -196,18 +196,18 @@ def create_file_path(base_dir: str, common_base_url: str, source_url: str) -> st
     return file_path
 
 
-def load_or_save_doc_markdown(file_path: str, document: Document) -> str:
+def load_or_save_doc_markdown(file_path: str, content: str) -> str:
     md_file_path = f"{file_path}.md"
     if os.path.exists(md_file_path):
         # Load the markdown content from the file in case it's been manually edited
         logger.info("  Loading markdown from file: %r", md_file_path)
-        document.content = Path(md_file_path).read_text(encoding="utf-8")
+        content = Path(md_file_path).read_text(encoding="utf-8")
     else:
         logger.info("  Saving markdown to %r", md_file_path)
-        assert document.content
+        assert content
         os.makedirs(os.path.dirname(md_file_path), exist_ok=True)
-        Path(md_file_path).write_text(document.content, encoding="utf-8")
-    return file_path
+        Path(md_file_path).write_text(content, encoding="utf-8")
+    return content
 
 
 def save_json(file_path: str, chunks: list[Chunk]) -> None:

--- a/app/src/util/ingest_utils.py
+++ b/app/src/util/ingest_utils.py
@@ -200,7 +200,7 @@ def load_or_save_doc_markdown(file_path: str, content: str) -> str:
     md_file_path = f"{file_path}.md"
     if os.path.exists(md_file_path):
         # Load the markdown content from the file in case it's been manually edited
-        logger.info("  Loading markdown from file: %r", md_file_path)
+        logger.info("  Loading markdown from file instead: %r", md_file_path)
         content = Path(md_file_path).read_text(encoding="utf-8")
     else:
         logger.info("  Saving markdown to %r", md_file_path)

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -32,6 +32,7 @@ def test_create_engine_Imagine_LA():
         "CA FTB",
         "WIC",
         "Covered California",
+        "SSA",
     ]
 
 


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-751

## Changes

* Add ingester for SSA
* Add SSA dataset to chat engine

## Testing

Download `ssa_scrapings.json` and `ssa_extra_md/` folder from https://us-east-1.console.aws.amazon.com/s3/buckets/decision-support-tool-app-dev?region=us-east-1&bucketType=general&prefix=ssa/
```
make ingest-runner args="ssa --json_input=ssa_scrapings.json"
```

Query chatbot:
![image](https://github.com/user-attachments/assets/86f71a6b-8cf4-4bcd-8d39-261e758fd6fa)


Reminder to ingest into deployed app
```
> aws s3 cp ssa_scrapings.json s3://decision-support-tool-app-dev/ssa/ssa_scrapings.json
upload: ./ssa_scrapings.json to s3://decision-support-tool-app-dev/ssa/ssa_scrapings.json

> aws s3 sync ssa_extra_md s3://decision-support-tool-app-dev/ssa/ssa_extra_md
upload: ssa_extra_md/EN-05-10095/page05.md to s3://decision-support-tool-app-dev/ssa/ssa_extra_md/EN-05-10095/page05.md
upload: ssa_extra_md/EN-05-10095/page07.md to s3://decision-support-tool-app-dev/ssa/ssa_extra_md/EN-05-10095/page07.md
...

> ./bin/run-command app dev '["ingest-runner", "ssa", "--json_input", "s3://decision-support-tool-app-dev/ssa/ssa_scrapings.json"]'
```