### PR TITLE
feat: Ingest from multiple JSON scraping files

### DIFF
--- a/app/src/ingest_runner.py
+++ b/app/src/ingest_runner.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -95,7 +96,7 @@ def ca_public_charge_config(
     )
 
 
-def get_ingester_config(scraper_dataset: str) -> IngestConfig:
+def get_ingester_config(scraper_dataset: str) -> IngestConfig:  # pragma: no cover
     match scraper_dataset:
         case "ca_ftb":
             return IngestConfig(
@@ -154,11 +155,12 @@ def conditionally_consolidate_json_files(json_files: list[str], outfile_prefix: 
         return json_files[0]
 
     output_file = f"{outfile_prefix}_combined_scrapings.json"
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     merge_json_files(json_files, output_file)
     return output_file
 
 
-def main() -> None:  # pragma: no cover
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("dataset", help="scraper dataset id from `make scrapy-runner`")
     parser.add_argument("--json_input", help="path to the JSON file to ingest", action="append")
@@ -168,7 +170,8 @@ def main() -> None:  # pragma: no cover
 
     config = get_ingester_config(args.dataset)
 
-    json_input = conditionally_consolidate_json_files(args.json_input, config.scraper_dataset)
+    output_file_prefix = os.path.join(config.md_base_dir, config.scraper_dataset)
+    json_input = conditionally_consolidate_json_files(args.json_input, output_file_prefix)
 
     start_ingestion(
         logger,

--- a/app/src/ingester.py
+++ b/app/src/ingester.py
@@ -101,6 +101,7 @@ def load_json_items(
 ) -> Sequence[dict[str, str]]:
     with smart_open(json_filepath, "r", encoding="utf-8") as json_file:
         json_items = json.load(json_file)
+    logger.info("Loaded %d items from %r", len(json_items), json_filepath)
 
     def verbose_document_exists(item: dict[str, str]) -> bool:
         if skip_db:

--- a/app/tests/src/test_ingest_runner.py
+++ b/app/tests/src/test_ingest_runner.py
@@ -1,0 +1,118 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from src import ingest_runner
+from src.ingest_runner import main
+from src.util.ingest_utils import IngestConfig
+
+FILE_1_JSON_OBJS = [
+    {
+        "url": "https://www.ssa.gov/pubs/EN-05-10095.pdf#page=5",
+        "title": "Working While Disabled p5",
+        "md_file": "ssa_extra_md/EN-05-10095/page05.md",
+    },
+    {
+        "url": "https://www.ssa.gov/pubs/EN-05-10095.pdf#page=7",
+        "title": "Working While Disabled p7",
+        "md_file": "ssa_extra_md/EN-05-10095/page07.md",
+    },
+    {
+        "url": "https://www.ssa.gov/pubs/EN-05-10095.pdf#page=9",
+        "title": "Working While Disabled p9",
+        "md_file": "ssa_extra_md/EN-05-10095/page09.md",
+    },
+]
+
+FILE_2_JSON_OBJS = [
+    {
+        "url": "https://edd.ca.gov/en/disability/options_to_file_for_di_benefits/",
+        "title": "Options to File for Disability Insurance Benefits",
+        "markdown": "Disability Insurance (DI) provides short-term, partial wage replacement ...",
+        "extra_fields": "## Nonindustrial Disability Insurance\n\nGet answers to FAQs about Nonindustrial Disability Insurance.",
+    },
+    {
+        "url": "https://edd.ca.gov/en/jobs_and_training/northern_region/",
+        "title": "The Northern Job Fairs and Workshops",
+        "main_primary": "## Scheduled Events\n\n",
+    },
+]
+
+
+@pytest.fixture
+def json_file_1(tmp_path):
+    file_path = tmp_path / "json_file_1.json"
+    file_path.write_text(json.dumps(FILE_1_JSON_OBJS), encoding="utf-8")
+    return str(file_path)
+
+
+@pytest.fixture
+def json_file_2(tmp_path):
+    file_path = tmp_path / "json_file_2.json"
+    file_path.write_text(json.dumps(FILE_2_JSON_OBJS), encoding="utf-8")
+    return str(file_path)
+
+
+def patch_ingest_runner(monkeypatch):
+    monkeypatch.setattr(
+        ingest_runner,
+        "get_ingester_config",
+        lambda x: IngestConfig(
+            "Test ingest runner", "", "", "https://test.org/", "test_ingest_runner"
+        ),
+    )
+
+    mock_start_ingestion = Mock()
+    monkeypatch.setattr(ingest_runner, "start_ingestion", mock_start_ingestion)
+    return mock_start_ingestion
+
+
+def test_main__combine_jsons(monkeypatch, json_file_1, json_file_2):
+    mock_start_ingestion = patch_ingest_runner(monkeypatch)
+
+    sys.argv = [
+        "ingest_runner",
+        "test_ingest_runner",
+        f"--json_input={json_file_1}",
+        f"--json_input={json_file_2}",
+        "--skip_db",
+    ]
+    main()
+
+    combined_file = mock_start_ingestion.call_args.args[2]
+    json_items = json.loads(Path(combined_file).read_text(encoding="utf-8"))
+    assert len(json_items) == 5
+    for item in FILE_1_JSON_OBJS + FILE_2_JSON_OBJS:
+        assert item in json_items
+
+
+def test_main__1_json_file(monkeypatch, json_file_1):
+    mock_start_ingestion = patch_ingest_runner(monkeypatch)
+
+    sys.argv = [
+        "ingest_runner",
+        "test_ingest_runner",
+        f"--json_input={json_file_1}",
+        "--skip_db",
+    ]
+    main()
+
+    assert mock_start_ingestion.call_args.args[2] == json_file_1
+
+
+def test_main__default_json_file(monkeypatch):
+    mock_start_ingestion = patch_ingest_runner(monkeypatch)
+
+    sys.argv = [
+        "ingest_runner",
+        "test_ingest_runner",
+        "--skip_db",
+    ]
+    main()
+
+    assert (
+        mock_start_ingestion.call_args.args[2] == "src/ingestion/test_ingest_runner_scrapings.json"
+    )

--- a/app/tests/src/test_ingester.py
+++ b/app/tests/src/test_ingester.py
@@ -82,7 +82,7 @@ If you are enrolled in the Annual Leave Program (ALP), your employer will contin
 
 
 @pytest.fixture
-def edd_web_local_file(tmp_path, sample_cards):
+def local_file(tmp_path, sample_cards):
     file_path = tmp_path / "edd_scrapings.json"
     file_path.write_text(sample_cards)
     return str(file_path)
@@ -94,7 +94,7 @@ def edd_web_s3_file(mock_s3_bucket_resource, sample_cards):
     return "s3://test_bucket/edd_scrapings.json"
 
 
-def test__ingest_edd_using_md_tree(caplog, app_config, db_session, edd_web_local_file):
+def test__ingester__edd(caplog, app_config, db_session, local_file):
     # Force a short max_seq_length to test chunking
     app_config_for_test.sentence_transformer.max_seq_length = 47
 
@@ -103,17 +103,13 @@ def test__ingest_edd_using_md_tree(caplog, app_config, db_session, edd_web_local
     with TemporaryDirectory(suffix="edd_md") as md_base_dir:
         config = get_ingester_config("edd")
         with caplog.at_level(logging.WARNING):
-            ingest_json(
-                db_session, edd_web_local_file, config, md_base_dir=md_base_dir, resume=True
-            )
+            ingest_json(db_session, local_file, config, md_base_dir=md_base_dir, resume=True)
 
         check_database_contents(db_session, caplog)
 
         # Re-ingesting the same data should not add any new documents
         with caplog.at_level(logging.INFO):
-            ingest_json(
-                db_session, edd_web_local_file, config, md_base_dir=md_base_dir, resume=True
-            )
+            ingest_json(db_session, local_file, config, md_base_dir=md_base_dir, resume=True)
 
     skipped_logs = {
         msg for msg in caplog.messages if msg.startswith("Skipping -- document already exists")


### PR DESCRIPTION
## Ticket

Improvement for https://navalabs.atlassian.net/browse/DST-751

## Changes

Allow ingesting from multiple JSON scraping files. This enables adding manually scraped JSON entries to automatically scrapped JSON.

## Testing

```sh
> make ingest-runner args="ssa --json_input=ssa_scrapings.json --json_input=src/ingestion/irs_scrapings.json --skip_db"

2025-02-10 15:57:36,706 - INFO - Loaded 10 items from 'ssa_scrapings.json'
2025-02-10 15:57:36,708 - INFO - Loaded 31 items from 'src/ingestion/irs_scrapings.json'
2025-02-10 15:57:36,708 - INFO - Merged 2 files into 41 items in 'ssa_combined_scrapings.json'
2025-02-10 15:57:36,710 - INFO - Ingesting from 'ssa_combined_scrapings.json': {'dataset': 'SSA', 'program': 'social security', 'region': 'US'}
...
```

See that `ssa_md/ssa_combined_scrapings.json` is indeed a concatenation of all input JSON files.