### PR TITLE
chore: Update Imagine LA's URL: benefitnavigator.web.app

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -253,7 +253,7 @@ endif
 
 
 scrape-imagine-la:
-	cd src/ingestion/imagine_la/scrape; uv run --no-project scrape_content_hub.py https://socialbenefitsnavigator25.web.app/contenthub $(CONTENTHUB_PASSWORD)
+	cd src/ingestion/imagine_la/scrape; uv run --no-project scrape_content_hub.py https://benefitnavigator.web.app/contenthub $(CONTENTHUB_PASSWORD)
 
 ingest-imagine-la: check-ingest-arguments
 	$(PY_RUN_CMD) ingest-imagine-la "$(DATASET_ID)" "$(BENEFIT_PROGRAM)" "$(BENEFIT_REGION)" "$(FILEPATH)"

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -299,7 +299,7 @@ set canned_response to a list that gives examples and describes categories for t
 Example prompts: "What do you know about?" "What info do you have?" "What can I ask you?" "What programs do you cover?" "What benefits do you cover?" "What topics do you know?"
 
 If the user's question is about a referral link below, set canned_response to: "I don't have info about that topic in my sources yet. \
-Learn more about [referral link title](referral link). See the [Benefits Information Hub](https://socialbenefitsnavigator25.web.app/contenthub) for the topics I have more information about."
+Learn more about [referral link title](referral link). See the [Benefits Information Hub](https://benefitnavigator.web.app/contenthub) for the topics I have more information about."
 
 Referral links:
 - ID cards: [https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/identification-id-cards/](https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/identification-id-cards/)
@@ -317,7 +317,7 @@ Referral links:
 - Transportation for people with disabilities: [https://accessla.org/](https://accessla.org/)
 - Food banks: [https://www.lafoodbank.org/find-food/pantry-locator/](https://www.lafoodbank.org/find-food/pantry-locator/)
 - Wildfire resources: [https://recovery.lacounty.gov/resources/](https://recovery.lacounty.gov/resources/)
-- Benefit Navigator screening: [https://socialbenefitsnavigator25.web.app/start](https://socialbenefitsnavigator25.web.app/start)
+- Benefit Navigator screening: [https://benefitnavigator.web.app/start](https://benefitnavigator.web.app/start)
 - LA County Hospitals and Clinics: [https://dhs.lacounty.gov/find-a-clinic-or-hospital/](https://dhs.lacounty.gov/find-a-clinic-or-hospital/)
 - LGBTQ resources: [https://dpss.lacounty.gov/en/rights/rights/sogie.html](https://dpss.lacounty.gov/en/rights/rights/sogie.html)
 

--- a/app/src/ingestion/imagine_la/ingest.py
+++ b/app/src/ingestion/imagine_la/ingest.py
@@ -134,7 +134,7 @@ def main() -> None:
         "Imagine LA",
         "mixed",
         "California",
-        "https://socialbenefitsnavigator25.web.app/contenthub/",
+        "https://benefitnavigator.web.app/contenthub/",
         "imagine_la",
     )
     process_and_ingest_sys_args(sys.argv, logger, _ingest_content_hub, default_config)

--- a/app/tests/src/ingestion/imagine-la/test_ingest.py
+++ b/app/tests/src/ingestion/imagine-la/test_ingest.py
@@ -49,7 +49,7 @@ Accordion 22 Body"""
                 "Imagine LA",
                 "mixed",
                 "California",
-                "https://socialbenefitsnavigator25.web.app/contenthub/",
+                "https://benefitnavigator.web.app/contenthub/",
                 "imagine_la_md",
             )
             if file_location == "local":
@@ -64,11 +64,11 @@ Accordion 22 Body"""
         documents = db_session.execute(select(Document).order_by(Document.name)).scalars().all()
         assert len(documents) == 2
         assert documents[0].name == "Document 1"
-        assert documents[0].source == "https://socialbenefitsnavigator25.web.app/contenthub/doc_1"
+        assert documents[0].source == "https://benefitnavigator.web.app/contenthub/doc_1"
         assert documents[0].content == doc_1_content + "\n\n"
 
         assert documents[1].name == "Document 2"
-        assert documents[1].source == "https://socialbenefitsnavigator25.web.app/contenthub/doc_2"
+        assert documents[1].source == "https://benefitnavigator.web.app/contenthub/doc_2"
         assert documents[1].content == doc_2_content + "\n\n"
 
         chunks = db_session.execute(select(Chunk).order_by(Chunk.content)).scalars().all()

--- a/app/tests/src/test_ingest_utils.py
+++ b/app/tests/src/test_ingest_utils.py
@@ -39,7 +39,7 @@ default_config = IngestConfig(
     "Imagine LA",
     "mixed",
     "California",
-    "https://socialbenefitsnavigator25.web.app/contenthub/",
+    "https://benefitnavigator.web.app/contenthub/",
     "imagine_la_md",
 )
 


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-768

## Changes

Update Imagine LA's URL: `benefitnavigator.web.app`

## Testing

(Imagine LA) SBN Content Hub
```
cd app
make scrape-imagine-la CONTENTHUB_PASSWORD=sbn

# check the timestamps
ls -al src/ingestion/imagine_la/scrape/pages

# clear previous markdown cache
rm -rf imagine_la_md/

make ingest-imagine-la DATASET_ID="Imagine LA" BENEFIT_PROGRAM=mixed BENEFIT_REGION=California FILEPATH=src/ingestion/imagine_la/scrape/pages

...
2025-02-10 21:47:01,308 - INFO - Finished ingesting 'Imagine LA' (imagine_la)

```
Zip markdown files for archiving to Google Drive:
```
# check the timestamps
ls -al imagine_la_md

rm -f imagine_la_md.zip
zip imagine_la_md.zip -r imagine_la_md/
```

Query ask instructed in the ticket and check the URL:
![image](https://github.com/user-attachments/assets/d996d297-9fe7-4936-8717-f6ff14194862)
