### PR TITLE
refactor: Update postgres ssl logging to info level

### DIFF
--- a/app/src/adapters/db/clients/postgres_client.py
+++ b/app/src/adapters/db/clients/postgres_client.py
@@ -124,8 +124,6 @@ def generate_iam_auth_token(aws_region: str, host: str, port: int, user: str) ->
 
 
 def verify_ssl(connection_info: Any) -> None:
-    """Verify that the database connection is encrypted and log a warning if not."""
-    if connection_info.pgconn.ssl_in_use:
-        logger.info("database connection is using SSL")
-    else:
-        logger.warning("database connection is not using SSL")
+    """Verify that the database connection is encrypted and log the SSL status."""
+    ssl_status = "using SSL" if connection_info.pgconn.ssl_in_use else "not using SSL"
+    logger.info(f"database connection is {ssl_status}")

--- a/app/tests/src/adapters/db/clients/test_postgres_client.py
+++ b/app/tests/src/adapters/db/clients/test_postgres_client.py
@@ -34,7 +34,7 @@ def test_verify_ssl_not_in_use(caplog):
     verify_ssl(conn_info)
 
     assert caplog.messages == ["database connection is not using SSL"]
-    assert caplog.records[0].levelname == "WARNING"
+    assert caplog.records[0].levelname == "INFO"
 
 
 def test_get_connection_parameters(monkeypatch: pytest.MonkeyPatch):

--- a/app/tests/src/adapters/db/test_db.py
+++ b/app/tests/src/adapters/db/test_db.py
@@ -1,5 +1,6 @@
 import pytest
 from sqlalchemy import text
+import logging
 
 import src.adapters.db as db
 
@@ -11,6 +12,7 @@ def test_db_connection(db_client):
 
 
 def test_check_db_connection(caplog, monkeypatch: pytest.MonkeyPatch):
+    caplog.set_level(logging.INFO)
     monkeypatch.setenv("DB_CHECK_CONNECTION_ON_INIT", "True")
     db.PostgresDBClient()
     assert "database connection is not using SSL" in caplog.messages


### PR DESCRIPTION
## Ticket

N/A - Small logging level change

## Changes

- Changed PostgreSQL SSL connection logging from WARNING to INFO level to match our logging standards
- Updated corresponding test assertions
- Logs connection status instead of prints at every db read (see screenshot of previous version)

![Screenshot 2025-02-11 at 3 48 36 PM](https://github.com/user-attachments/assets/3945d0b0-c6de-40e9-8c8f-d85909571aca)

## Context for reviewers

This is a small change to make our logging levels consistent across the codebase. We log SSL connection status at INFO level in other places, so this brings the PostgreSQL client in line with that standard.

## Testing

- Ran `make test`
- SSL status. now gets logged at INFO level
- All tests pass with updated assertions