### PR TITLE
fix: new CORS allow_origin_regex pattern

### DIFF
--- a/app/src/app.py
+++ b/app/src/app.py
@@ -11,7 +11,7 @@ app.add_middleware(
     CORSMiddleware,
     # Imagine LA uses port 5173 for development
     allow_origins=["http://localhost:5173"],
-    allow_origin_regex=r"https://dev-social-benefits-navigator--nava-chatbot-.*\.web\.app",
+    allow_origin_regex=r"https://dev-social-benefits-navigator-.*\.web\.app",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Ticket
N/A

## Changes
- Updated CORS `allow_origin_regex` pattern to match new dev environment URL format
  - Before: `r"https://dev-social-benefits-navigator--nava-chatbot-.*\.web\.app"`
  - After: `r"https://dev-social-benefits-navigator-.*\.web\.app"`

## Testing
- Need to verify CORS allows requests from the updated dev URL pattern
