### PR TITLE
feat: API: Add source_dataset field to the Citation API response

### DIFF
--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -195,6 +195,7 @@ class Citation(BaseModel):
     citation_id: str
     source_id: str
     source_name: str
+    source_dataset: str
     page_number: Optional[int] | None
     uri: Optional[str] | None
     headings: Sequence[str]
@@ -208,6 +209,7 @@ class Citation(BaseModel):
             citation_id=f"citation-{subsection.id}",
             source_id=str(chunk.document.id),
             source_name=chunk.document.name,
+            source_dataset=chunk.document.dataset,
             page_number=chunk.page_number,
             uri=highlighted_text_src,
             headings=subsection.text_headings,


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C07U7LJ8GRX/p1739480852230819)

## Changes

Add `source_dataset` field to the Citation API response so that API clients can display the dataset name for citations.

## Testing

None