### PR TITLE
feat: Move '(citation-N)' after punctuation

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -373,15 +373,15 @@ For example "List housing programs available to youth" or "What are the requirem
 Provide citation numbers:
 - When referencing the context, do not quote directly. Use the provided citation numbers (e.g., (citation-1)) to indicate when \
 you are drawing from the context. To cite multiple sources at once, you can append citations like so: (citation-1) (citation-2), etc. \
-For example: 'This is a sentence that draws on information from the context.(citation-1)'
+For example: 'This is a sentence that draws on information from the context. (citation-1)'
 
 Example question:
 Can a client get Unemployment and disability at the same time?
 
 Example Answer:
-No, a client cannot receive Unemployment Insurance (UI) and State Disability Insurance (SDI) benefits at the same time. (citation-1). \
+No, a client cannot receive Unemployment Insurance (UI) and State Disability Insurance (SDI) benefits at the same time. (citation-1)
 They must choose the program that best fits their situation. If they don't know which program to apply for, \
-they can apply for both, and their eligibility for each will be reviewed (citation-2) (citation-3)."""
+they can apply for both, and their eligibility for each will be reviewed. (citation-2) (citation-3)"""
 
     def on_message(
         self, question: str, chat_history: Optional[ChatHistory] = None

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -216,6 +216,7 @@ def move_citations_after_punctuation(response: str) -> str:
     def move_citation(match: Match) -> str:
         citations = match.group(1)
         # match.group(2) only has the last citation in match.group(1)
+        # see https://stackoverflow.com/a/43866169/23458508
         punctuation = match.group(3)
         return f"{punctuation} {citations}\n"
 

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -209,15 +209,14 @@ def replace_citation_ids(response: str, remapped_citations: dict[str, Subsection
 
 
 def move_citations_after_punctuation(response: str) -> str:
-    """
-    After the '(citation-N)' should be a newline to avoid associating the citation with the next sentence.
-    """
-
     def move_citation(match: Match) -> str:
         citations = match.group(1)
         # match.group(2) only has the last citation in match.group(1)
         # see https://stackoverflow.com/a/43866169/23458508
         punctuation = match.group(3)
+        # Since citations appear after a punctuation, if there's a subsequent sentence,
+        # then someone might associate `(citation-N)` with that subsequent sentence,
+        # so insert a new line after the citations.
         return f"{punctuation} {citations}\n"
 
     # Include any trailing spaces and a single newline so they can be replaced

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -214,13 +214,10 @@ def move_citations_after_punctuation(response: str) -> str:
         # match.group(2) only has the last citation in match.group(1)
         # see https://stackoverflow.com/a/43866169/23458508
         punctuation = match.group(3)
-        # Since citations appear after a punctuation, if there's a subsequent sentence,
-        # then someone might associate `(citation-N)` with that subsequent sentence,
-        # so insert a new line after the citations.
-        return f"{punctuation} {citations}\n"
+        return f"{punctuation} {citations}"
 
-    # Include any trailing spaces and a single newline so they can be replaced
-    return re.sub(r" *(( *\(citation-\d+\))+) *([\.\?\!]) *\n?", move_citation, response).strip()
+    # Include any left-side spaces so the replacement punctuation immediately follows the last word
+    return re.sub(r" *(( *\(citation-\d+\))+) *([\.\?\!])", move_citation, response).strip()
 
 
 @dataclass

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -208,7 +208,7 @@ def replace_citation_ids(response: str, remapped_citations: dict[str, Subsection
     return re.sub(CITATION_PATTERN, replace_citation, response)
 
 
-def move_citations_after_punctuation(response):
+def move_citations_after_punctuation(response: str) -> str:
     """
     After the '(citation-N)' should be a newline to avoid associating the citation with the next sentence.
     """
@@ -219,7 +219,7 @@ def move_citations_after_punctuation(response):
         # import pdb; pdb.set_trace()
         return f"{punctuation} {citation}\n"
 
-    # Include trailing any spaces and a newline
+    # Include any trailing spaces and a single newline so they can be replaced
     return re.sub(
         r" *(\(citation-\d+\)) *([\.\?\!]) *\n?", move_citation, response, flags=re.MULTILINE
     ).strip()

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -215,7 +215,7 @@ def move_citations_after_punctuation(response: str) -> str:
 
     def move_citation(match: Match) -> str:
         citations = match.group(1)
-        # group(2) is the last citation in group(1)
+        # match.group(2) only has the last citation in match.group(1)
         punctuation = match.group(3)
         return f"{punctuation} {citations}\n"
 

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -214,15 +214,13 @@ def move_citations_after_punctuation(response: str) -> str:
     """
 
     def move_citation(match: Match) -> str:
-        citation = match.group(1)
-        punctuation = match.group(2)
-        # import pdb; pdb.set_trace()
-        return f"{punctuation} {citation}\n"
+        citations = match.group(1)
+        # group(2) is the last citation in group(1)
+        punctuation = match.group(3)
+        return f"{punctuation} {citations}\n"
 
     # Include any trailing spaces and a single newline so they can be replaced
-    return re.sub(
-        r" *(\(citation-\d+\)) *([\.\?\!]) *\n?", move_citation, response, flags=re.MULTILINE
-    ).strip()
+    return re.sub(r" *(( *\(citation-\d+\))+) *([\.\?\!]) *\n?", move_citation, response).strip()
 
 
 @dataclass
@@ -238,7 +236,7 @@ def simplify_citation_numbers(result: ResponseWithSubsections) -> ResponseWithSu
     The returned subsections only contain citations used in the response
     and are ordered consecutively starting from 1.
     """
-    formatted_citations = move_citations_after_punctuation(result.response)
-    remapped_citations = remap_citation_ids(result.subsections, formatted_citations)
-    remapped_response = replace_citation_ids(result.response, remapped_citations)
+    formatted_response = move_citations_after_punctuation(result.response)
+    remapped_citations = remap_citation_ids(result.subsections, formatted_response)
+    remapped_response = replace_citation_ids(formatted_response, remapped_citations)
     return ResponseWithSubsections(remapped_response, tuple(remapped_citations.values()))

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -65,7 +65,11 @@ def format_response(
     # This heading is important to prevent Chainlit from embedding citations_html
     # as the next part of a list in html_response
     html_response.append(
-        to_html(_add_citation_links(raw_response, remapped_citations, config, map_of_accordion_ids))
+        to_html(
+            _add_citation_links(
+                formatted_response, remapped_citations, config, map_of_accordion_ids
+            )
+        )
     )
 
     if citations_html:

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -1,9 +1,12 @@
+from textwrap import dedent
+
 import pytest
 
 from src.citations import (
     CitationFactory,
     basic_chunk_splitter,
     create_prompt_context,
+    move_citations_after_punctuation,
     remap_citation_ids,
     replace_citation_ids,
     split_into_subsections,
@@ -183,3 +186,27 @@ The officer weighs all these factors. They consider positive factors, like a job
     assert subsections[1].text.startswith("The immigration officer will consider")
     assert "* Health" in subsections[1].text
     assert subsections[2].text.startswith("The officer weighs all these factors.")
+
+
+def test_move_citations_after_punctuation():
+    text = dedent(
+        """
+                     Some text (citation-1). Another sentence on same line with no space(citation-2)? Sentence 3 has the correct citation formatting. (citation-3)
+                     - Bullet is on a new line (citation-4)!
+                     Last sentence(citation-99)!
+
+                     New paragraph (citation-100).
+                  """
+    )
+    expected_text = dedent(
+        """
+                            Some text. (citation-1)
+                            Another sentence on same line with no space? (citation-2)
+                            Sentence 3 has the correct citation formatting. (citation-3)
+                            - Bullet is on a new line! (citation-4)
+                            Last sentence! (citation-99)
+
+                            New paragraph. (citation-100)
+                           """
+    ).strip()
+    assert move_citations_after_punctuation(text) == expected_text

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -201,9 +201,7 @@ def test_move_citations_after_punctuation():
     )
     expected_text = dedent(
         """
-                            Some text. (citation-1)
-                            Another sentence on same line with no space? (citation-2)
-                            Sentence 3 has the correct citation formatting. (citation-3)
+                            Some text. (citation-1) Another sentence on same line with no space? (citation-2) Sentence 3 has the correct citation formatting. (citation-3)
                             - Bullet 1 is on a new line! (citation-4) (citation-5)
                             - Bullet 2 is on next line. (citation-14) (citation-15) (citation-16)
                             Last sentence! (citation-6)

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -192,8 +192,9 @@ def test_move_citations_after_punctuation():
     text = dedent(
         """
                      Some text (citation-1). Another sentence on same line with no space(citation-2)? Sentence 3 has the correct citation formatting. (citation-3)
-                     - Bullet is on a new line (citation-4)!
-                     Last sentence(citation-99)!
+                     - Bullet 1 is on a new line (citation-4) (citation-5)!
+                     - Bullet 2 is on next line (citation-14) (citation-15).
+                     Last sentence(citation-6)!
 
                      New paragraph (citation-100).
                   """
@@ -203,8 +204,9 @@ def test_move_citations_after_punctuation():
                             Some text. (citation-1)
                             Another sentence on same line with no space? (citation-2)
                             Sentence 3 has the correct citation formatting. (citation-3)
-                            - Bullet is on a new line! (citation-4)
-                            Last sentence! (citation-99)
+                            - Bullet 1 is on a new line! (citation-4) (citation-5)
+                            - Bullet 2 is on next line. (citation-14) (citation-15)
+                            Last sentence! (citation-6)
 
                             New paragraph. (citation-100)
                            """

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -193,7 +193,7 @@ def test_move_citations_after_punctuation():
         """
                      Some text (citation-1). Another sentence on same line with no space(citation-2)? Sentence 3 has the correct citation formatting. (citation-3)
                      - Bullet 1 is on a new line (citation-4) (citation-5)!
-                     - Bullet 2 is on next line (citation-14) (citation-15).
+                     - Bullet 2 is on next line (citation-14) (citation-15) (citation-16).
                      Last sentence(citation-6)!
 
                      New paragraph (citation-100).
@@ -205,7 +205,7 @@ def test_move_citations_after_punctuation():
                             Another sentence on same line with no space? (citation-2)
                             Sentence 3 has the correct citation formatting. (citation-3)
                             - Bullet 1 is on a new line! (citation-4) (citation-5)
-                            - Bullet 2 is on next line. (citation-14) (citation-15)
+                            - Bullet 2 is on next line. (citation-14) (citation-15) (citation-16)
                             Last sentence! (citation-6)
 
                             New paragraph. (citation-100)

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -1,10 +1,9 @@
 import re
 
 from src.citations import CitationFactory, split_into_subsections
-from src.format import FormattingConfig, _get_breadcrumb_html, format_response, reify_citations
+from src.format import FormattingConfig, _get_breadcrumb_html, format_response
 from src.generate import MessageAttributes
 from src.retrieve import retrieve_with_scores
-from tests.src.db.models.factories import ChunkFactory
 from tests.src.test_retrieve import _create_chunks
 
 
@@ -21,34 +20,6 @@ def _unique_accordion_ids(html):
 
 def to_subsections(chunks_with_scores):
     return split_into_subsections([c.chunk for c in chunks_with_scores], factory=CitationFactory())
-
-
-def test_reify_citations():
-    chunks = ChunkFactory.build_batch(2)
-    chunks[0].content = "This is the first chunk.\n\nWith two subsections"
-    subsections = split_into_subsections(chunks, factory=CitationFactory())
-    config = FormattingConfig()
-
-    assert (
-        reify_citations("This is a citation (citation-0)", [], config, None)
-        == "This is a citation "
-    )
-
-    result = reify_citations(
-        f"This is a citation ({subsections[0].id}) and another ({subsections[1].id}).",
-        subsections,
-        config,
-        None,
-    )
-
-    # Check that citations were added
-    assert "<sup>" in result
-    assert "accordion_item" in result
-    assert "style='cursor:pointer'" in result
-    assert "data-id='a-None'" in result
-    # Check basic text structure remains
-    assert result.startswith("This is a citation")
-    assert "and another" in result
 
 
 def test__get_breadcrumb_html():


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-731

## Changes

* Add `move_citations_after_punctuation()` and unit test
* Updated Chatbot API, Batch Processing, and Chainlit UI to used new method
* Removed unused old method `reify_citations()`

## Testing

See unit test

Paragraphs:
<img width="751" alt="image" src="https://github.com/user-attachments/assets/b492b9c1-5fc8-461f-8cc7-a74b89792fd0" />

Bullets:
<img width="751" alt="image" src="https://github.com/user-attachments/assets/83ab4d72-e25c-4349-87c5-bbbb1a26a321" />
