### PR TITLE
chore: Rename Imagine LA to Benefits Information Hub

### DIFF
--- a/app/refresh-ingestion.sh
+++ b/app/refresh-ingestion.sh
@@ -21,7 +21,7 @@ ingest_imagine_la() {
     [ -d "${DATASET_ID}_md" ] && mv -iv "$DATASET_ID"{,-orig}_md
 
     # Save markdown files and ingest into DB
-    make ingest-imagine-la DATASET_ID="Imagine LA" BENEFIT_PROGRAM=mixed BENEFIT_REGION=California \
+    make ingest-imagine-la DATASET_ID="Benefits Information Hub" BENEFIT_PROGRAM=mixed BENEFIT_REGION=California \
         FILEPATH=src/ingestion/imagine_la/scrape/pages 2>&1 | tee logs/${DATASET_ID}-2ingest.log
     if [ $? -ne 0 ] || grep -E 'make:.*Error' "logs/${DATASET_ID}-2ingest.log"; then
         echo "ERROR: ingest-runner failed. Check logs/${DATASET_ID}-2ingest.log"

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -245,10 +245,10 @@ class ImagineLaEngine(BaseEngine):
     ]
 
     engine_id: str = "imagine-la"
-    name: str = "Imagine LA Chat Engine"
+    name: str = "SBN Chat Engine"
     datasets = [
         "CA EDD",
-        "Imagine LA",
+        "Benefits Information Hub",
         "DPSS Policy",
         "IRS",
         "Keep Your Benefits",

--- a/app/src/ingestion/imagine_la/ingest.py
+++ b/app/src/ingestion/imagine_la/ingest.py
@@ -137,7 +137,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
     default_config = IngestConfig(
-        "Imagine LA",
+        "Benefits Information Hub",
         "mixed",
         "California",
         "https://benefitnavigator.web.app/contenthub/",

--- a/app/src/metrics/evaluation/batch.py
+++ b/app/src/metrics/evaluation/batch.py
@@ -127,7 +127,7 @@ def filter_questions(
 
     # Map CLI dataset names to actual dataset names in CSV
     dataset_mapping = {
-        "imagine_la": "Imagine LA",
+        "imagine_la": "Benefits Information Hub",
         "la_policy": "LA County Policy",
     }
 

--- a/app/tests/src/ingestion/imagine-la/test_ingest.py
+++ b/app/tests/src/ingestion/imagine-la/test_ingest.py
@@ -46,7 +46,7 @@ Accordion 22 Body"""
     with TemporaryDirectory(suffix="imagine_la_md") as md_base_dir:
         with caplog.at_level(logging.INFO):
             config = IngestConfig(
-                "Imagine LA",
+                "Benefits Information Hub",
                 "mixed",
                 "California",
                 "https://benefitnavigator.web.app/contenthub/",

--- a/app/tests/src/metrics/evaluation/test_batch.py
+++ b/app/tests/src/metrics/evaluation/test_batch.py
@@ -137,7 +137,7 @@ def test_stratified_sample():
 def test_filter_questions():
     """Test question filtering by dataset."""
     questions = [
-        {"dataset": "Imagine LA", "question": "q1"},
+        {"dataset": "Benefits Information Hub", "question": "q1"},
         {"dataset": "LA County Policy", "question": "q2"},
         {"dataset": "Other Dataset", "question": "q3"},
     ]

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -25,7 +25,7 @@ def test_create_engine_Imagine_LA():
     assert engine.name == ImagineLaEngine.name
     assert engine.datasets == [
         "CA EDD",
-        "Imagine LA",
+        "Benefits Information Hub",
         "DPSS Policy",
         "IRS",
         "Keep Your Benefits",

--- a/app/tests/src/test_ingest_utils.py
+++ b/app/tests/src/test_ingest_utils.py
@@ -36,7 +36,7 @@ def test__drop_existing_dataset(db_session, enable_factory_create):
 
 
 default_config = IngestConfig(
-    "Imagine LA",
+    "Benefits Information Hub",
     "mixed",
     "California",
     "https://benefitnavigator.web.app/contenthub/",


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-769

## Changes

Rename "Imagine LA" to "Benefits Information Hub"

Reingested for deployed app:
```
./bin/run-command app dev '["ingest-imagine-la", "Benefits Information Hub", "mixed", "California:LA County", "s3://decision-support-tool-app-dev/imagine_la-2025-02-10/"]'
```

## Testing

```
make ingest-imagine-la DATASET_ID="Benefits Information Hub" BENEFIT_PROGRAM=mixed BENEFIT_REGION=California FILEPATH=src/ingestion/imagine_la/scrape/pages
```

<img width="751" alt="image" src="https://github.com/user-attachments/assets/4aa032cd-d8e6-4059-958d-c85fdd3efb41" />

