### PR TITLE
fix: Support multiple datasets and k values using nargs in evaluation CLI

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -251,7 +251,6 @@ ifndef FILEPATH
 	$(error FILEPATH is undefined)
 endif
 
-
 scrape-imagine-la:
 	cd src/ingestion/imagine_la/scrape; uv run --no-project scrape_content_hub.py https://benefitnavigator.web.app/contenthub $(CONTENTHUB_PASSWORD)
 
@@ -275,8 +274,8 @@ ingest-runner: ## Ingest scrapings into DB: `make ingest-runner args="dataset"`
 
 run-evaluation: ## Run precision-recall evaluation with configurable parameters
 	$(PY_RUN_CMD) python -m src.metrics.cli \
-		$(if $(dataset),--dataset=$(dataset),) \
-		$(if $(k),--k=$(k),) \
+		$(if $(dataset),--dataset $(dataset),) \
+		$(if $(k),--k $(k),) \
 		$(if $(questions_file),--questions-file=$(questions_file),) \
 		$(if $(sampling),--sampling=$(sampling),) \
 		$(if $(min_score),--min-score=$(min_score),) \

--- a/app/src/metrics/README.md
+++ b/app/src/metrics/README.md
@@ -33,12 +33,24 @@ The questions CSV file should have the following columns:
 The `src.metrics.cli` module provides a CLI for running evaluations:
 
 ```bash
-make run-evaluation dataset=imagine_la k=5,10,25
+# Evaluate all datasets with default k values
+make run-evaluation
+
+# Evaluate a single dataset
+make run-evaluation dataset="imagine_la"
+
+# Evaluate multiple datasets with specific k values
+make run-evaluation dataset="imagine_la la_policy" k="5 10 25"
+
+# Evaluate all datasets with sampling
+make run-evaluation sampling=0.1
 ```
 
 Arguments:
-- `dataset`: Filter questions from the CSV by matching this value against the 'dataset' column (e.g., "imagine_la", "la_policy", or "all" to use all datasets)
-- `k`: Comma-separated list of k values (default: 5,10,25)
+- `dataset`: Optional. One or more datasets to evaluate (e.g., "imagine_la la_policy"). If not specified, evaluates all available datasets. Currently supports:
+  - `imagine_la`: Imagine LA dataset
+  - `la_policy`: LA County Policy dataset
+- `k`: One or more k values to evaluate (default: "5 10 25")
 - `questions_file`: Path to questions CSV file (default: src/metrics/data/question_answer_pairs.csv)
 - `min_score`: Minimum similarity score for retrieval (default: -1.0)
 - `sampling`: Fraction of questions to sample (e.g., 0.1) for each specified dataset (default: 1.0)

--- a/app/src/metrics/cli.py
+++ b/app/src/metrics/cli.py
@@ -4,16 +4,11 @@
 import argparse
 import json
 import os
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence
 
 from src.retrieve import retrieve_with_scores
 
 from .evaluation.runner import run_evaluation
-
-
-def parse_k_values(k_str: str) -> List[int]:
-    """Parse comma-separated k values."""
-    return [int(k) for k in k_str.split(",")]
 
 
 def create_retrieval_function(min_score: float) -> Callable[[str, int], Sequence[Any]]:

--- a/app/src/metrics/cli.py
+++ b/app/src/metrics/cli.py
@@ -38,7 +38,7 @@ def main() -> None:
     parser.add_argument(
         "--dataset",
         type=str,
-        help="Dataset to evaluate (imagine_la, la_policy, or all)",
+        help="Comma-separated list of datasets to evaluate (e.g., imagine_la,la_policy or all)",
         required=True,
     )
     parser.add_argument("--k", type=str, default="5,10,25", help="Comma-separated list of k values")
@@ -66,7 +66,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Set up dataset filter
-    dataset_filter = None if args.dataset == "all" else [args.dataset]
+    dataset_filter = None if args.dataset == "all" else args.dataset.split(",")
 
     # Evaluation results stored in src/metrics/logs/YYYY-MM-DD/
     # See README.md for details on log storage and structure

--- a/app/src/metrics/cli.py
+++ b/app/src/metrics/cli.py
@@ -38,12 +38,20 @@ def main() -> None:
     parser.add_argument(
         "--dataset",
         type=str,
+        nargs="+",
         # TODO: We currently only support 'imagine_la' and 'la_policy' datasets.
         # This will be expanded to include other datasets (ca_wic, edd, etc.) as we add more evaluation data.
-        help="Comma-separated list of datasets to evaluate (e.g., imagine_la,la_policy or all)",
-        required=True,
+        help="One or more datasets to evaluate (e.g., imagine_la la_policy). If not specified, evaluates all datasets.",
+        required=False,
+        default=None,
     )
-    parser.add_argument("--k", type=str, default="5,10,25", help="Comma-separated list of k values")
+    parser.add_argument(
+        "--k",
+        type=int,
+        nargs="+",
+        default=[5, 10, 25],
+        help="One or more k values to evaluate (e.g., 5 10 25)",
+    )
     parser.add_argument(
         "--questions-file",
         type=str,
@@ -67,8 +75,8 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Set up dataset filter
-    dataset_filter = None if args.dataset == "all" else args.dataset.split(",")
+    # Set up dataset filter - None means all datasets
+    dataset_filter = args.dataset
 
     # Evaluation results stored in src/metrics/logs/YYYY-MM-DD/
     # See README.md for details on log storage and structure
@@ -83,7 +91,7 @@ def main() -> None:
     try:
         run_evaluation(
             questions_file=args.questions_file,
-            k_values=parse_k_values(args.k),
+            k_values=args.k,
             retrieval_func=retrieval_func,
             dataset_filter=dataset_filter,
             sample_fraction=args.sampling,

--- a/app/src/metrics/cli.py
+++ b/app/src/metrics/cli.py
@@ -38,6 +38,8 @@ def main() -> None:
     parser.add_argument(
         "--dataset",
         type=str,
+        # TODO: We currently only support 'imagine_la' and 'la_policy' datasets.
+        # This will be expanded to include other datasets (ca_wic, edd, etc.) as we add more evaluation data.
         help="Comma-separated list of datasets to evaluate (e.g., imagine_la,la_policy or all)",
         required=True,
     )

--- a/app/tests/src/metrics/test_cli.py
+++ b/app/tests/src/metrics/test_cli.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.metrics.cli import create_retrieval_function, format_metric_value, main, parse_k_values
+from src.metrics.cli import create_retrieval_function, format_metric_value, main
 
 
 def test_format_metric_value():
@@ -26,19 +26,6 @@ def test_format_metric_value():
 
     # Test dict values
     assert format_metric_value({"key": "value"}) == "{'key': 'value'}"
-
-
-def test_parse_k_values():
-    """Test parsing of k values from string."""
-    # Test single value
-    assert parse_k_values("5") == [5]
-
-    # Test multiple values
-    assert parse_k_values("5,10,25") == [5, 10, 25]
-
-    # Test invalid input
-    with pytest.raises(ValueError):
-        parse_k_values("5,abc,25")
 
 
 def test_create_retrieval_function():
@@ -73,8 +60,8 @@ def test_main_dataset_filter(args, expected_dataset_filter):
     with patch("argparse.ArgumentParser.parse_args") as mock_args:
         # Setup mock arguments
         mock_args.return_value = MagicMock(
-            dataset=args[1:] if len(args) > 1 else None,  # If no --dataset arg, return None
-            k=[5, 10],  # Now k is a list of integers
+            dataset=args[1:] if len(args) > 1 else None,
+            k=[5, 10],
             questions_file="test_file.csv",
             sampling=None,
             min_score=-1.0,
@@ -106,7 +93,7 @@ def test_main_k_values(k_values):
         # Setup mock arguments
         mock_args.return_value = MagicMock(
             dataset=["all"],
-            k=k_values,  # Now k is a list of integers
+            k=k_values,
             questions_file="test_file.csv",
             sampling=None,
             min_score=-1.0,
@@ -147,7 +134,7 @@ def test_main_results_display():
 
     with patch("argparse.ArgumentParser.parse_args") as mock_args:
         mock_args.return_value = MagicMock(
-            dataset=["all"],
+            dataset=None,
             k=[5],
             questions_file="test_file.csv",
             sampling=None,


### PR DESCRIPTION
## Ticket

N/A

## Changes

- Fixed `--dataset` argument in `app/src/metrics/cli.py` to handle multiple datasets and k values using `nargs="+"` in the make command for `run-evaluation`:
  - Also changed dataset filter parsing to split comma-separated values into a list
  - This (still) allows running evals on multiple datasets and/or k simultaneously (e.g., `...dataset="imagine_la la_policy", k="5 10"...`)

## Context for reviewers

When trying to evaluate multiple datasets, the command would fail because it was treating the comma-separated list as a single dataset name.

Fix modifies dataset arguments parsing, similar to how we handle k-values. We can pass multiple datasets using a comma-separated list.

Note: We currently only support 'imagine_la' and 'la_policy' datasets. This will be expanded to include other datasets (ca_wic, edd, etc.) as we add more evaluation data.
