### PR TITLE
fix: CA Public Charge dataset: fix absolute links

### DIFF
--- a/app/src/ingestion/scrapy_dst/spiders/ca_public_charge_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/ca_public_charge_spider.py
@@ -28,7 +28,6 @@ class CaPublicChargeSpider(CrawlSpider):
                     "find-help",
                 ),
                 allow_domains=allowed_domains,
-                # deny_domains=("https://s3.amazonaws.com","publicsuffix.org"),
                 canonicalize=True,
                 unique=True,
             ),


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-743

## Changes

* Use `response.urljoin()` to resolve `href` links in anchors, instead of prepending `response.url` to relative `href`s
* Clean up code

## Testing

```
./refresh-ingestion.sh ca_public_charge
```

Check URLs in `app/src/ingestion/ca_public_charge_scrapings.json-pretty.json`
Follow instructions in ticket.