### PR TITLE
feat: Subscribe monitoring email to CloudWatch alarms

### DIFF
--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -175,7 +175,7 @@ module "service" {
 module "monitoring" {
   source = "../../modules/monitoring"
   #Email subscription list:
-  #email_alerts_subscription_list = ["email1@email.com", "email2@email.com"]
+  email_alerts_subscription_list = ["nava-labs-alerts@navapbc.com"]
 
   # Module takes service and ALB names to link all alerts with corresponding targets
   service_name                                = local.service_config.service_name


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-671


## Changes
 - Subscribe group email address to existing CloudWatch alarms


## Context for reviewers
 - The latency threshold is probably too strict (200ms) for the API routes that call an LLM, but we can start here and tune upward as needed.
 - After making this change I applied it with:
 ```
make infra-update-app-service APP_NAME=app ENVIRONMENT=dev
make infra-update-app-service APP_NAME=app ENVIRONMENT=prod
```

In retrospect I should have waited for PR approval!

You can see the alarms here:
https://github.com/navapbc/labs-decision-support-tool/blob/main/infra/modules/monitoring/main.tf#L12

## Testing
N/A -- existing platform functionality