### PR TITLE
fix: Remove repeated text around alert_msg

### DIFF
--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -314,8 +314,6 @@ async def run_query(
     citations = [Citation.from_subsection(subsection) for subsection in final_result.subsections]
 
     alert_msg = getattr(result.attributes, "alert_message", None)
-    if alert_msg:
-        alert_msg = f"**Policy update**: {alert_msg}\n\nThe rest of this answer may be outdated."
 
     if INCLUDE_ALERT_IN_RESPONSE and alert_msg:
         response_msg = f"{alert_msg}\n\n{final_result.response}"

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -184,7 +184,7 @@ async def test_run_query__2_citations(subsections):
                     translated_message="",
                     benefit_program="CalFresh",
                     canned_response="",
-                    alert_message="Some alert message.",
+                    alert_message="**Policy update**: Some alert message.\n\nThe rest of this answer may be outdated.",
                 ),
                 chunks_with_scores=[],
                 subsections=subsections,


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-816

## Changes

Don't wrap the `alert_msg` around the `**Policy update**` and `The rest of this answer may be outdated.` text twice.
`engine.on_message` already does this.


## Testing

Unit test already exists but since it mocks `engine.on_message`, this bug wasn't apparent.
I fixed the mock to return the pre-wrapped text.

