### PR TITLE
fix: Enable multiple user messages per LiteralAI thread

### DIFF
--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -320,14 +320,14 @@ async def query(request: QueryRequest) -> QueryResponse:
     return response
 
 
-def _validate_session_against_literalai(request, session):
+def _validate_session_against_literalai(request: QueryRequest, session: UserSession) -> None:
     thread_id = session.literalai_thread_id
     # Check if request is consisten with LiteralAI thread
     if request.new_session:
         if thread_id:
             raise HTTPException(
                 status_code=409,
-                detail=f"Cannot start a new session with an existing session_id: {request.session_id} associated with thread_id: {thread_id}",
+                detail=f"Cannot start a new session '{request.session_id}' that is already associated with thread_id: {thread_id}",
             )
     else:
         if not thread_id:
@@ -337,7 +337,7 @@ def _validate_session_against_literalai(request, session):
             )
 
 
-def _validate_literalai_message(session, request_msg):
+def _validate_literalai_message(session: UserSession, request_msg: ChatMessage) -> None:
     if not session.literalai_thread_id:
         if not request_msg.thread_id:
             raise HTTPException(

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -66,29 +66,46 @@ class ChatEngineSettings:
 @dataclass
 class UserSession:
     user: UserInfo
+    session_id: str
     chat_engine_settings: ChatEngineSettings
     literalai_user_id: Optional[str] = None
+    literalai_thread_id: Optional[str] = None
     message_history: Optional[Sequence[ChatMessage]] = None
 
 
-def __query_user_session(user_id: str) -> UserSession:
+# FIXME: Replace this with a real DB table
+DB_SESSIONS: dict[str, UserSession] = {}
+
+
+def __query_user_session(user_id: str, session_id: str) -> UserSession:
     """
-    Placeholder for creating/retrieving user's session from the DB, including settings and constraints
+    FIXME: Placeholder for creating/retrieving user's session from the DB, including settings and constraints
     """
+    if session_id in DB_SESSIONS:
+        logger.info("Found user session for: %s", user_id)
+        return DB_SESSIONS[session_id]
+
     session = UserSession(
         user=UserInfo(user_id, ["imagine-la"]),
+        session_id=session_id,
         chat_engine_settings=ChatEngineSettings("imagine-la"),
     )
+    DB_SESSIONS[session_id] = session
     logger.info("Found user session for: %s", user_id)
     return session
 
 
-async def _get_user_session(user_id: str) -> UserSession:
-    session = __query_user_session(user_id)
+async def _get_user_session(user_id: str | None, session_id: str) -> UserSession:
+    user_id = user_id or "Anonymous"
+    session = __query_user_session(user_id, session_id)
     # Ensure user exists in Literal AI
     literalai_user = await literalai().api.get_or_create_user(user_id, session.user.__dict__)
     # Set the LiteralAI user ID for this session so it can be used in literalai().thread()
     session.literalai_user_id = literalai_user.id
+    print(f"User {user_id} has LiteralAI ID: {literalai_user.id}")
+    print(
+        f"Session {session.session_id} is associated with LiteralAI thread_id: {session.literalai_thread_id}"
+    )
     return session
 
 
@@ -108,7 +125,7 @@ def _load_chat_history(db_session: db.Session, session_id: str) -> ChatHistory:
 # Make sure to use async functions for faster responses
 @router.get("/engines")
 async def engines(user_id: str) -> list[str]:
-    session = await _get_user_session(user_id)
+    session = await _get_user_session(user_id, "")
     # Example of using Literal AI to log the request and response
     with literalai().thread(name="API:/engines", participant_id=session.literalai_user_id):
         request_msg = literalai().message(
@@ -151,17 +168,8 @@ async def feedback(
         response_id: the response_id of the chatbot response
         comment: user comment for the feedback
         user_id: the user's id
-
-    Returns:
-        FeedbackResponse
-        user_id: the user's id
-        value: 1 if is_positive was "true" and 0 if is_positive was "false"
-        step_id: ID of the step associated with the score
-        comment: the initial user comment for the feedback
     """
-    user_session_id = request.user_id if request.user_id else request.session_id
-
-    session = await _get_user_session(user_session_id)
+    session = await _get_user_session(request.user_id, request.session_id)
     # API endpoint to send feedback https://docs.literalai.com/guides/logs#add-a-score
     response = await literalai().api.create_score(
         step_id=request.response_id,
@@ -242,14 +250,40 @@ def get_chat_engine(session: UserSession) -> ChatEngineInterface:
 
 @router.post("/query")
 async def query(request: QueryRequest) -> QueryResponse:
-    user_session_id = request.user_id if request.user_id else request.session_id
-    session = await _get_user_session(user_session_id)
-    one_line_question = request.message.strip().splitlines()[0] or "API:/query"
+    logger.info("Query request: %s", request)
+    session = await _get_user_session(request.user_id, request.session_id)
+    _validate_session_against_literalai(request, session)
+
+    one_line_question = None
+    if request.new_session:
+        # Only set the LiteralAI thread name if it's a new session; otherwise the thread name will be updated with the last message
+        one_line_question = request.message.strip().splitlines()[0] or "API:/query"
     with (
-        literalai().thread(name=one_line_question, participant_id=session.literalai_user_id),
+        literalai().thread(
+            name=one_line_question,
+            participant_id=session.literalai_user_id,
+            thread_id=session.literalai_thread_id,
+        ),
         app_config.db_session() as db_session,
         db_session.begin(),  # session is auto-committed or rolled back upon exception
     ):
+        # Load history BEFORE adding the new message to the DB
+        chat_history = _load_chat_history(db_session, request.session_id)
+        if request.new_session and chat_history:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Cannot start a new session with an existing session_id: {request.session_id}",
+            )
+        elif not request.new_session and not chat_history:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Chat history for existing session not found: {request.session_id}",
+            )
+        # Now, add message to DB
+        db_session.add(
+            ChatMessage(session_id=request.session_id, role="user", content=request.message)
+        )
+        # Log the message to LiteralAI
         request_msg = literalai().message(
             content=request.message,
             type="user_message",
@@ -257,24 +291,11 @@ async def query(request: QueryRequest) -> QueryResponse:
             metadata={
                 "request": request.__dict__,
                 "user": session.user.__dict__,
+                "chat_history": chat_history,
             },
         )
-        # Load history BEFORE saving the new message
-        chat_history = _load_chat_history(db_session, request.session_id)
-        if request.new_session and chat_history:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Cannot start a new session with existing session_id: {request.session_id}",
-            )
-        elif not request.new_session and not chat_history:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Chat history for existing session not found: {request.session_id}",
-            )
 
-        db_session.add(
-            ChatMessage(session_id=request.session_id, role="user", content=request.message)
-        )
+        _validate_literalai_message(session, request_msg)
 
         engine = get_chat_engine(session)
         response: QueryResponse = await run_query(engine, request.message, chat_history)
@@ -299,6 +320,40 @@ async def query(request: QueryRequest) -> QueryResponse:
     return response
 
 
+def _validate_session_against_literalai(request, session):
+    thread_id = session.literalai_thread_id
+    # Check if request is consisten with LiteralAI thread
+    if request.new_session:
+        if thread_id:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Cannot start a new session with an existing session_id: {request.session_id} associated with thread_id: {thread_id}",
+            )
+    else:
+        if not thread_id:
+            raise HTTPException(
+                status_code=409,
+                detail=f"LiteralAI thread ID for existing session not found: {request.session_id}",
+            )
+
+
+def _validate_literalai_message(session, request_msg):
+    if not session.literalai_thread_id:
+        if not request_msg.thread_id:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Unexpected: thread_id is not set on LiteralAI message: {request_msg}",
+            )
+        # This is for new sessions
+        session.literalai_thread_id = request_msg.thread_id
+        logger.info("Started new session with thread_id: %s", session.literalai_thread_id)
+    elif session.literalai_thread_id != request_msg.thread_id:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected: LiteralAI thread ID mismatch: {session.literalai_thread_id} != {request_msg.thread_id}",
+        )
+
+
 # Temporarily True until API client handles alert_message field
 INCLUDE_ALERT_IN_RESPONSE = True
 
@@ -306,7 +361,7 @@ INCLUDE_ALERT_IN_RESPONSE = True
 async def run_query(
     engine: ChatEngineInterface, question: str, chat_history: Optional[ChatHistory] = None
 ) -> QueryResponse:
-    logger.info("Received: %s with history: %s", question, chat_history)
+    logger.info("Received: '%s' with history: %s", question, chat_history)
     result = await asyncify(lambda: engine.on_message(question, chat_history))()
     logger.info("Response: %s", result.response)
 

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -81,7 +81,7 @@ def __query_user_session(user_id: str, session_id: str) -> UserSession:
     """
     FIXME: Placeholder for creating/retrieving user's session from the DB, including settings and constraints
     """
-    if session_id in DB_SESSIONS:
+    if session_id and session_id in DB_SESSIONS:
         logger.info("Found user session for: %s", user_id)
         return DB_SESSIONS[session_id]
 
@@ -95,9 +95,9 @@ def __query_user_session(user_id: str, session_id: str) -> UserSession:
     return session
 
 
-async def _get_user_session(user_id: str | None, session_id: str) -> UserSession:
+async def _get_user_session(user_id: str | None, session_id: str | None) -> UserSession:
     user_id = user_id or "Anonymous"
-    session = __query_user_session(user_id, session_id)
+    session = __query_user_session(user_id, session_id or "")
     # Ensure user exists in Literal AI
     literalai_user = await literalai().api.get_or_create_user(user_id, session.user.__dict__)
     # Set the LiteralAI user ID for this session so it can be used in literalai().thread()
@@ -124,7 +124,7 @@ def _load_chat_history(db_session: db.Session, session_id: str) -> ChatHistory:
 # Make sure to use async functions for faster responses
 @router.get("/engines")
 async def engines(user_id: str) -> list[str]:
-    session = await _get_user_session(user_id, "")
+    session = await _get_user_session(user_id, None)
     # Example of using Literal AI to log the request and response
     with literalai().thread(name="API:/engines", participant_id=session.literalai_user_id):
         request_msg = literalai().message(

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 from literalai import Score
+from literalai.my_types import ScoreType
 
 from src import chat_api
 from src.chat_api import (
@@ -32,30 +33,45 @@ class MockContextManager:
         pass
 
 
-def mock_literalai():
-    mock = MagicMock()
-    mock.thread.return_value = MockContextManager()
-    mock.step.return_value = MockContextManager()
-    return mock
+class MockLiteralAI:
+    def __init__(self):
+        self.api = AsyncMock()
+        self.api.get_or_create_user = AsyncMock()
+        self.api.get_or_create_user.return_value = self.api
+        self.api.message = MagicMock()
+        self.api.message.return_value.thread_id = 12345
+        self.api.create_score = AsyncMock()
+
+    def thread(self, *args, **kwargs):
+        return MockContextManager()
+
+    def step(self, *args, **kwargs):
+        return MockContextManager()
+
+    def message(self, *args, **kwargs):
+        mock_msg = MagicMock()
+        mock_msg.thread_id = 12345
+        print(f"-----  Mock message: {mock_msg}")
+        return mock_msg
 
 
 @pytest.fixture
 def client(monkeypatch):
-    mock = mock_literalai()
-    monkeypatch.setattr(mock, "api", AsyncMock())
-    monkeypatch.setattr(chat_api, "literalai", lambda: mock)
+    lai_mock = MockLiteralAI()
+    lai_mock.api = MockLiteralAIApi()
+    monkeypatch.setattr(chat_api, "literalai", lambda: lai_mock)
     return TestClient(router)
 
 
 class MockLiteralAIApi:
     async def get_or_create_user(self, identifier, metadata):
-        self.id = identifier
+        self.id = f"litai_uuid_for_{identifier}"
         return self
 
     async def create_score(
         self,
-        name: str | None,
-        type: str,
+        name: str,
+        type: ScoreType,
         value: float,
         step_id: Optional[str] = None,
         comment: Optional[str] = None,
@@ -72,22 +88,13 @@ class MockLiteralAIApi:
         )
 
 
-@pytest.fixture
-def literalai_client(monkeypatch):
-    mock = mock_literalai()
-    monkeypatch.setattr(mock, "api", MockLiteralAIApi())
-    monkeypatch.setattr(chat_api, "literalai", lambda: mock)
-
-    return TestClient(router)
-
-
 def test_api_engines(client):
     response = client.get("/api/engines?user_id=TestUser")
     assert response.status_code == 200
     assert response.json() == ["imagine-la"]
 
 
-def test_api_query(monkeypatch, client):
+def test_api_query(monkeypatch, client, db_session):
     async def mock_run_query(engine, question, chat_history):
         return QueryResponse(
             response_text=f"Response from LLM: {chat_history}",
@@ -111,7 +118,10 @@ def test_api_query(monkeypatch, client):
         raise AssertionError("Expected HTTPException")
     except HTTPException as e:
         assert e.status_code == 409
-        assert e.detail == "Cannot start a new session with existing session_id: Session0"
+        assert (
+            e.detail
+            == "Cannot start a new session with an existing session_id: Session0 associated with thread_id: 12345"
+        )
 
     # Test chat history
     response = client.post(
@@ -134,7 +144,7 @@ def test_api_query__nonexistent_session_id(monkeypatch, client):
         raise AssertionError("Expected HTTPException")
     except HTTPException as e:
         assert e.status_code == 409
-        assert e.detail == "Chat history for existing session not found: NewSession999"
+        assert e.detail == "LiteralAI thread ID for existing session not found: NewSession999"
 
 
 def test_api_query__bad_request(client):
@@ -236,6 +246,7 @@ def user_info():
 def test_get_chat_engine(user_info):
     session = UserSession(
         user=user_info,
+        session_id="session1",
         chat_engine_settings=ChatEngineSettings("ca-edd-web", retrieval_k=6),
     )
     engine = get_chat_engine(session)
@@ -245,6 +256,7 @@ def test_get_chat_engine(user_info):
 def test_get_chat_engine__unknown(user_info):
     session = UserSession(
         user=user_info,
+        session_id="session1",
         chat_engine_settings=ChatEngineSettings("engine_y"),
     )
     with pytest.raises(HTTPException, match="Unknown engine: engine_y"):
@@ -254,14 +266,15 @@ def test_get_chat_engine__unknown(user_info):
 def test_get_chat_engine_not_allowed(user_info):
     session = UserSession(
         user=user_info,
+        session_id="session1",
         chat_engine_settings=ChatEngineSettings("bridges-eligibility-manual"),
     )
     with pytest.raises(HTTPException, match="Unknown engine: bridges-eligibility-manual"):
         get_chat_engine(session)
 
 
-def test_post_feedback_success(literalai_client):
-    response = literalai_client.post(
+def test_post_feedback_success(client):
+    response = client.post(
         "/api/feedback",
         json={
             "session_id": "Session2",
@@ -274,9 +287,9 @@ def test_post_feedback_success(literalai_client):
     assert response.status_code == 200
 
 
-def test_post_feedback_fail(monkeypatch, literalai_client):
+def test_post_feedback_fail(monkeypatch, client):
     try:
-        literalai_client.post(
+        client.post(
             "/api/feedback",
             json={
                 "session_id": "Session2",


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-815

## Changes

Chat history for a single session is now correctly reflected in LiteralAI.
https://nava.slack.com/archives/C06DP498D1D/p1740507232929499

## Testing

```
curl -X POST 'http://0.0.0.0:8000/api/query' -H 'Content-Type: application/json' -d '{ "session_id": "A123", "new_session": true, "message": "what do you know about?"}'
curl -X POST 'http://0.0.0.0:8000/api/query' -H 'Content-Type: application/json' -d '{ "session_id": "A123", "new_session": false, "message": "list programs"}'
curl -X POST 'http://0.0.0.0:8000/api/query' -H 'Content-Type: application/json' -d '{ "session_id": "A123", "new_session": false, "message": "Thanks"}'
```

Check in LiteralAI
![image](https://github.com/user-attachments/assets/df9e0247-741c-44e8-b151-0aa250d0db3d)
