### PR TITLE
fix: Temporarily allow empty user id

### DIFF
--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Optional, Sequence
 
 from asyncer import asyncify
-from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 from literalai import AsyncLiteralClient, Message
 from pydantic import BaseModel
 from sqlalchemy import select

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -26,9 +26,6 @@ from src.generate import ChatHistory
 from src.healthcheck import HealthCheck, health
 from src.util.string_utils import format_highlighted_uri
 
-# from typing import Annotated, Optional, Sequence
-
-
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["Chat API"])
 

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -140,6 +140,7 @@ def test_api_query(monkeypatch, client, db_session):
         == "Response from LLM: [{'role': 'user', 'content': 'Hello'}, {'role': 'assistant', 'content': 'Response from LLM: []'}]"
     )
 
+
 """
 def test_api_query__empty_user_id(monkeypatch, client, db_session):
     try:
@@ -159,6 +160,7 @@ def test_api_query__empty_user_id(monkeypatch, client, db_session):
         assert error["msg"] == "String should have at least 1 character"
         assert error["loc"] == ("body", "user_id")
 """
+
 
 def test_api_query__nonexistent_session_id(monkeypatch, client, db_session):
     try:

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -140,7 +140,7 @@ def test_api_query(monkeypatch, client, db_session):
         == "Response from LLM: [{'role': 'user', 'content': 'Hello'}, {'role': 'assistant', 'content': 'Response from LLM: []'}]"
     )
 
-
+"""
 def test_api_query__empty_user_id(monkeypatch, client, db_session):
     try:
         client.post(
@@ -158,7 +158,7 @@ def test_api_query__empty_user_id(monkeypatch, client, db_session):
         assert error["type"] == "string_too_short"
         assert error["msg"] == "String should have at least 1 character"
         assert error["loc"] == ("body", "user_id")
-
+"""
 
 def test_api_query__nonexistent_session_id(monkeypatch, client, db_session):
     try:


### PR DESCRIPTION
## Ticket

n/a


## Changes
 - Temporarily allow empty user id strings in requests


## Context for reviewers
 - Unblock development team testing by temporarily allowing an empty user string while the issue is addressed on the frontend


## Testing
<img width="317" alt="Screenshot 2025-02-27 at 1 22 19 PM" src="https://github.com/user-attachments/assets/f9a1a65c-2b85-4ae8-a91f-34dffea200d7" />
<img width="642" alt="Screenshot 2025-02-27 at 1 22 25 PM" src="https://github.com/user-attachments/assets/829f9261-5ee6-443f-b84f-d477546afb92" />
