### PR TITLE
fix: Imagine LA ingest: switch region to "California" and pass DATASET_ID to echo_cmds

### DIFF
--- a/app/refresh-ingestion.sh
+++ b/app/refresh-ingestion.sh
@@ -155,7 +155,7 @@ echo_stats(){
     echo "Markdown file count: $(find "${DATASET_ID}-${TODAY}_md" -type f -iname '*.md' | wc -l)"
     echo "-----------------------------------"
     echo "REMINDERS:"
-    echo_cmds
+    echo_cmds "$DATASET_ID"
 }
 
 echo_cmds(){
@@ -171,7 +171,7 @@ echo_cmds(){
         echo "aws s3 cp app/logs/${DATASET_ID}-${TODAY}_stats.json ${S3_HTML_DIR}/stats/${TODAY}_stats.json"
         echo ""
         echo "# 3. Run ingestion on deployed app:"
-        echo "./bin/run-command app ${DEPLOY_ENV} '[\"ingest-imagine-la\", \"Benefits Information Hub\", \"mixed\", \"California:LA County\", \"$S3_HTML_DIR\"]'"
+        echo "./bin/run-command app ${DEPLOY_ENV} '[\"ingest-imagine-la\", \"Benefits Information Hub\", \"mixed\", \"California\", \"$S3_HTML_DIR\"]'"
     elif [ "$DATASET_ID" == "ssa" ]; then
         echo "The 'ssa' datasource was manually scraped, so it doesn't need to be refreshed."
     else


### PR DESCRIPTION
## Ticket
NA

## Changes
- Changed region parameter from "California:LA County" to "California" to match ingest_imagine_la() expected params
- Updated `echo_cmds` function to accept `DATASET_ID` parameter
- Standardized region parameter to "California" for imagine_la dataset

## Context for reviewers
- `echo_cmds` function wasn't properly handling imagine_la dataset paths. Added `DATASET_ID` parameter to generate correct S3 paths and ingestion commands.
- region parameter "California:LA County" in ingest_imagine_la() expects just "California"

## Testing
- Ran ingestion script locally: `./refresh-ingestion.sh imagine_la`
- Ran S3 upload and ingestion on dev environment completed successfully
- Confirmed HTML files processed into chunks in database

```
> CONTENTHUB_PASSWORD=sbn ./refresh-ingestion.sh imagine_la
> aws s3 sync src/ingestion/imagine_la/scrape/pages/ s3://decision-support-tool-app-dev/imagine_la-2025-02-28/ && aws s3 cp logs/imagine_la-2025-02-28_stats.json s3://decision-support-tool-app-dev/imagine_la-2025-02-28/stats/2025-02-28_stats.json
>./bin/run-command app dev '["ingest-imagine-la", "Benefits Information Hub", "mixed", "California", "s3://decision-support-tool-app-dev/imagine_la-2025-02-28"]'
```

```
> aws logs get-log-events --log-group-name service/app-dev --log-stream-name app-dev/app-dev/db396fc547474798b47a7c1036bfc2ce --limit 100 | jq -r '.events[].message'

2025-03-01 00:17:08,917 - INFO - Adding embeddings for 'https://benefitnavigator.web.app/contenthub/wic'
2025-03-01 00:17:11,171 - INFO - Adding embeddings for 'https://benefitnavigator.web.app/contenthub/youngchildtaxcredit'
2025-03-01 00:17:12,053 - INFO - Finished ingesting 'Benefits Information Hub' (imagine_la)
```