### PR TITLE
feat: Facilitate 'all' datasets in refresh-ingestion.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ app/src/evaluation/metrics/data/
 
 # Local development files
 app/Makefile.local
+
+# Local refresh-ingestion-created scripts
+/refresh-*.sh
+

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -50,6 +50,7 @@ documents/
 /logs/
 /*.zip
 ssa_scrapings.json
+/OLD_INGESTION*
 
 # Files for `make app-shell`
 /.app-shell.bashrc_local

--- a/app/refresh-ingestion.sh
+++ b/app/refresh-ingestion.sh
@@ -246,11 +246,6 @@ check_preconditions(){
         echo "Move or delete the file/folder(s) before running this script."
         exit 50
     fi
-
-    if ! aws sts get-caller-identity; then
-        echo "ERROR: AWS CLI is not configured. Run 'aws configure' to set up."
-        exit 51
-    fi
 }
 
 if ! [ -e "refresh-ingestion.sh" ]; then
@@ -265,7 +260,7 @@ if [ -z "$1" ]; then
     echo "If <DATASET_ID> is 'all', it will run re-scrape all the datasets and create scripts for both dev and prod."
     echo "  SKIP_LOCAL_EMBEDDING=true by default when <DATASET_ID>='all'."
     echo "Set DEPLOY_ENV to 'dev' (default) or 'prod' to create refresh-$DEPLOY_ENV.sh script for the appropriate environment."
-    echo "Set SKIP_LOCAL_INGEST=true to skip local ingestion but still creating files for upload and ingestion for the deployed app."
+    echo "Set SKIP_LOCAL_INGEST=true to skip local ingestion but still create files for upload and ingestion for the deployed app."
     echo "Set TODAY=YYYY-MM-DD to use a different date than the current day."
     exit 1
 fi
@@ -329,7 +324,7 @@ case "$1" in
         echo ""
         echo "REMINDERS:"
         echo "- Upload the zip files to the 'Chatbot Knowledge Markdown' Google Drive folder."
-        echo "- Review and run the refresh scripts for both dev and prod."
+        echo "- Review and run the refresh scripts (in the top-level folder): refresh-dev-${TODAY} and refresh-prod-${TODAY}."
         echo "- Restore local TF to dev environment: ./bin/terraform-init infra/app/service dev"
         ;;
     *)

--- a/app/src/util/ingest_utils.py
+++ b/app/src/util/ingest_utils.py
@@ -19,7 +19,7 @@ from src.ingestion.markdown_chunking import ChunkingConfig
 logger = logging.getLogger(__name__)
 
 
-def _drop_existing_dataset(db_session: db.Session, dataset: str) -> bool:
+def drop_existing_dataset(db_session: db.Session, dataset: str) -> bool:
     dataset_exists = db_session.execute(select(Document).where(Document.dataset == dataset)).first()
     if dataset_exists:
         db_session.execute(delete(Document).where(Document.dataset == dataset))
@@ -129,7 +129,7 @@ def start_ingestion(
             ingestion_call(db_session, file_path, config, skip_db=skip_db, resume=resume)
         else:
             if not skip_db:
-                dropped = _drop_existing_dataset(db_session, config.dataset_label)
+                dropped = drop_existing_dataset(db_session, config.dataset_label)
                 if dropped:
                     logger.warning("Dropped existing dataset %s", config.dataset_label)
                 db_session.commit()

--- a/app/tests/src/test_ingest_utils.py
+++ b/app/tests/src/test_ingest_utils.py
@@ -11,8 +11,8 @@ from sqlalchemy import delete, select
 from src.db.models.document import Document
 from src.util.ingest_utils import (
     IngestConfig,
-    _drop_existing_dataset,
     add_embeddings,
+    drop_existing_dataset,
     process_and_ingest_sys_args,
     save_json,
     tokenize,
@@ -27,11 +27,11 @@ def test__drop_existing_dataset(db_session, enable_factory_create):
     docs = DocumentFactory(dataset="1"), DocumentFactory(dataset="2")
 
     # This shouldn't do anything
-    assert _drop_existing_dataset(db_session, "nonexistent dataset") is False
+    assert drop_existing_dataset(db_session, "nonexistent dataset") is False
     assert len(db_session.execute(select(Document)).all()) == 2
 
     # After this, the only document left should be the second one
-    assert _drop_existing_dataset(db_session, docs[0].dataset) is True
+    assert drop_existing_dataset(db_session, docs[0].dataset) is True
     assert db_session.execute(select(Document)).one()[0].dataset == docs[1].dataset
 
 


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-809


## Changes

- Added `all` argument to `refresh-ingestion.sh` to facilitate ingestion for all datasets for both dev and prod
- Added `--drop-only` ingest option to only drop the dataset so that ingestion can use `--resume` in subsequent runs
- Save AWS-related commands to separate script files to be executed separately since they affect the deployments and some commands can fail due to AWS resources.

## Testing

```
./refresh-ingestion.sh all
```
then follow the instructions
```
- Review and run the refresh scripts (in the top-level folder): ...
- Restore local TF to dev environment: ./bin/terraform-init infra/app/service dev
```
