### PR TITLE
fix: Allow CORS from prod environment

### DIFF
--- a/app/src/app.py
+++ b/app/src/app.py
@@ -11,7 +11,7 @@ app.add_middleware(
     CORSMiddleware,
     # Imagine LA uses port 5173 for development
     allow_origins=["http://localhost:5173"],
-    allow_origin_regex=r"https://dev-social-benefits-navigator-.*\.web\.app",
+    allow_origin_regex=r"https://(dev-social-benefits-navigator[a-zA-Z0-9-]+|benefitnavigator)\.web\.app",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Ticket

n/a

## Changes
 - Update CORS regex for dev instances as well as the prod URL


## Context for reviewers
n/a


## Testing
From an Imagine LA dev environment, confirming the new regex still allows requests:
<img width="728" alt="Screenshot 2025-03-04 at 1 47 48 PM" src="https://github.com/user-attachments/assets/c5df6060-8b5d-436e-9f93-7effa6c48224" />

From an Imagine LA prod environment BEFORE this change:
<img width="749" alt="Screenshot 2025-03-04 at 1 47 29 PM" src="https://github.com/user-attachments/assets/a0a9ef6b-397b-4367-a5a5-cda40f9dd6e9" />

From an Imagine LA prod environment AFTER the change:
<img width="729" alt="Screenshot 2025-03-04 at 1 47 33 PM" src="https://github.com/user-attachments/assets/d5da0f16-e188-460c-af36-f9a0cde57b5a" />
