### PR TITLE
docs: Updating README.md with steps using ingest-runner and refresh-ingestion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,75 +8,124 @@ To set up your local development environment, follow the instructions in [Gettin
 
 ## Data Ingestion
 
-Chat engines (defined in [app/src/chat_engine.py](https://github.com/navapbc/labs-decision-support-tool/blob/main/app/src/chat_engine.py)) are downstream consumers of data sources. To add a new engine, a class must be created with the following attributes: `engine_id`, `name`, `datasets` (which must match the name of the ingestion dataset’s script, see below), and a formatter which formats the chat engine’s response.
-The `engine_id` determines the endpoint of the chatbot, while the `dataset` points to the data source to be consumed by the engine.
+Chat engines (defined in [app/src/chat_engine.py](https://github.com/navapbc/labs-decision-support-tool/blob/main/app/src/chat_engine.py)) are downstream consumers of data sources. To add a new engine, a class must be created with the following attributes: `engine_id`, `name`, `datasets` (which must match the name of the ingestion dataset's script, see below), and a `formatting_config` which determines how the chat engine's response is formatted.
+The `engine_id` determines the endpoint of the chatbot, while the `datasets` list points to the data sources to be consumed by the engine.
 
 ## Loading documents
 
-The application supports loading Guru cards from .json files or PDFs of [Michigan's Bridges Eligibility Manual (BEM)](https://mdhhs-pres-prod.michigan.gov/olmweb/ex/BP/Public/BEM/000.pdf).
+The application supports loading data from various sources including web scraping, JSON files, and PDFs. We have automated scripts for scraping and ingesting data from several sources.
+
+### Refreshing all data sources
+
+To refresh all data sources at once, use the refresh-ingestion.sh script from within `/app`:
+
+```bash
+./refresh-ingestion.sh all
+```
+
+This will scrape and ingest data from all supported sources except for 'ssa' (which requires manual scraping). Note that for the imagine_la dataset, you'll need to set the CONTENTHUB_PASSWORD environment variable:
+
+```bash
+export CONTENTHUB_PASSWORD="your_password_here"
+./refresh-ingestion.sh all
+```
+
+### Refreshing specific data sources
+
+To refresh a specific data source, specify the dataset ID:
+
+```bash
+./refresh-ingestion.sh ca_ftb
+```
+
+For the imagine_la dataset:
+
+```bash
+CONTENTHUB_PASSWORD="your_password_here" ./refresh-ingestion.sh imagine_la
+```
+
+Available datasets include: imagine_la, ca_ftb, ca_public_charge, ca_wic, covered_ca, irs, edd, la_policy, and ssa.
 
 ### Loading documents locally
 
-To load a JSON file containing Guru cards in your local environment, from within `/app`:
+For manual ingestion, you can use the make commands directly:
 
 ```bash
-make ingest-guru-cards DATASET_ID=dataset_identifier BENEFIT_PROGRAM=SNAP BENEFIT_REGION=Michigan FILEPATH=path/to/some_cards.json
+make ingest-imagine-la DATASET_ID="Benefits Information Hub" BENEFIT_PROGRAM=mixed BENEFIT_REGION=California FILEPATH=src/ingestion/imagine_la/scrape/pages
 ```
-
-Note that the DATASET_ID `dataset_identifier` will be used in the chatbot web UI to prefix each citation, so use a user-friendly identifier like "CA EDD".
-
-To load the BEM pdfs in your local environment, from within `/app`:
 
 ```bash
-make ingest-bem-pdfs DATASET_ID=bridges-eligibility-manual BENEFIT_PROGRAM=multiprogram BENEFIT_REGION=Michigan FILEPATH=path/to/bem_pdfs
+make ingest-runner args="edd --json_input=src/ingestion/edd_scrapings.json"
 ```
 
-- The same `DATASET_ID` identifier can be used for multiple documents (`FILEPATH`) to represent that the documents belong in the same dataset.
+Note that the DATASET_ID will be used in the chatbot web UI to prefix each citation, so use a user-friendly identifier like "CA EDD".
+
+- The same `DATASET_ID` identifier can be used for multiple documents to represent that they belong in the same dataset.
 - Example `BENEFIT_PROGRAM` values include `housing`, `utilities`, `food`, `medical`, `employment`, `SNAP`, `Medicaid`, etc.
 - `BENEFIT_REGION` can correspond to a town, city, state, country, or any geographic area.
 
 The Docker container mounts the `/app` folder, so FILEPATH should be relative to `/app`. `/app/documents` is ignored by git, so is a good place for files you want to load but not commit.
 
+### Web scraping
+
+The refresh-ingestion.sh script handles both scraping and ingestion. For manual scraping:
+
+```bash
+make scrapy-runner args="dataset_id --debug"
+```
+
+For the imagine_la dataset:
+
+```bash
+make scrape-imagine-la CONTENTHUB_PASSWORD=your_password_here
+```
+
+For la_policy, which requires dynamic content scraping:
+
+```bash
+make scrape-la-county-policy
+make scrapy-runner args="la_policy --debug"
+```
+
 ### Loading documents in a deployed environment
 
-The deployed application includes an S3 bucket, following the format `s3://decision-support-tool-app-<env>`, e.g., `s3://decision-support-tool-app-dev`.
+The refresh-ingestion.sh script generates deployment scripts for both dev and prod environments. After running the script, you'll find refresh-dev-YYYY-MM-DD.sh and refresh-prod-YYYY-MM-DD.sh in the top-level directory.
+
+For manual deployment, the deployed application includes an S3 bucket, following the format `s3://decision-support-tool-app-<env>`, e.g., `s3://decision-support-tool-app-dev`.
 
 After authenticating with AWS, from the root of this repo run:
 
 ```bash
-aws s3 cp path/to/some_cards.json s3://decision-support-tool-app-dev/
-./bin/run-command app <ENVIRONMENT> '["ingest-guru-cards", "dataset_identifier", "SNAP", "Michigan", "s3://decision-support-tool-app-dev/some_cards.json"]'
+aws s3 cp path/to/scrapings.json s3://decision-support-tool-app-dev/
+./bin/run-command app <ENVIRONMENT> '["ingest-runner", "dataset_id", "--json_input", "s3://decision-support-tool-app-dev/scrapings.json"]'
 ```
 
 Replace `<ENVIRONMENT>` with your environment, e.g., `dev`.
-Note the arguments `"dataset_identifier", "SNAP", "Michigan", "s3://decision-support-tool-app-dev/some_cards.json"` are in the same order as described above for `ingest-guru-cards`, i.e., `DATASET_ID BENEFIT_PROGRAM BENEFIT_REGION FILEPATH`.
 
 #### Resuming ingestion for large datasets
 
-To continue ingestion from where it last stopped (typically due to resource limitation failures), start ingestion with the `INGEST_ARGS="--resume"` argument like `make ingest-edd-web DATASET_ID="CA EDD" BENEFIT_PROGRAM=employment BENEFIT_REGION=California FILEPATH=src/ingestion/edd_scrapings.json INGEST_ARGS="--resume"`.
+For large datasets like edd and la_policy, use the `--resume` flag to continue ingestion from where it last stopped:
 
-This will commit the DB transaction for each Document, rather than committing after all Document records are added.
-Upon re-running ingestion using the same command. Expect to see `Skipping -- item already exists:` log messages for Documents that already exist in the DB.
-
-### Web scraping
-
-Scrape web pages and save to a JSON file, for example: 
-```sh
-poetry run scrape-edd-web
+```bash
+./bin/run-command app <ENVIRONMENT> '["ingest-runner", "edd", "--json_input", "s3://decision-support-tool-app-dev/edd/edd_scrapings.json", "--resume"]'
 ```
 
-To load into the vector database, see sections above but use `make ingest-edd-web DATASET_ID="CA EDD" BENEFIT_PROGRAM=employment BENEFIT_REGION=California FILEPATH=src/ingestion/edd_scrapings.json`.
-
+This will commit the DB transaction for each Document, rather than committing after all Document records are added.
 
 ### To Skip Access to the DB
 
-For dry-runs or exporting of markdown files, avoid reading and writing to the DB during ingestion by adding the `--skip_db` argument like so:
-```
-make ingest-edd-web DATASET_ID="CA EDD test" BENEFIT_PROGRAM=employment BENEFIT_REGION=California FILEPATH=src/ingestion/edd_scrapings.json INGEST_ARGS="--skip_db"
+For dry-runs or exporting of markdown files, avoid reading and writing to the DB during ingestion by adding the `--skip_db` argument:
+
+```bash
+make ingest-runner args="dataset_id --json_input=path/to/scrapings.json --skip_db"
 ```
 
-See PR #171 for other examples.
+Or set the environment variable before running refresh-ingestion.sh:
 
+```bash
+export SKIP_LOCAL_EMBEDDING=true
+./refresh-ingestion.sh dataset_id
+```
 
 ## Batch processing
 


### PR DESCRIPTION
## Ticket

NA

## Changes

* Updated README.md
  * Refreshing data sources with `refresh-ingestion.sh` script
  * Instructions to handle `imagine_la` -specific soureces with password reqs
  * Detail manual ingestion and web scraping, resuming ingestions for large sets, and skipping db access
  * Add section about loading documents in dev and prod environments 

## Context for reviewers

README updates give more recent instructions on scraping and ingestion process

## Testing

Ran commands following the instructions in updated README