### PR TITLE
feat: Add versioned storage system for QA pairs with tests

### DIFF
--- a/app/src/evaluation/data_models.py
+++ b/app/src/evaluation/data_models.py
@@ -103,8 +103,17 @@ class MetricsSummary:
 
 # QA Generation Models
 @dataclass
+class QAPairVersion:
+    """Version information for a QA pair set."""
+
+    version_id: str
+    llm_model: str  # Model used for generation
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
 class QAPair:
-    """A question-answer pair."""
+    """A question-answer pair with versioning."""
 
     question: str
     answer: str
@@ -114,7 +123,7 @@ class QAPair:
     chunk_id: Optional[UUID]
     content_hash: str
     dataset: str
-    llm_model: str  # Model used for generation
+    version: QAPairVersion
     expected_chunk_content: str = ""  # Content of the chunk that contains the answer
     id: Optional[UUID] = None  # Stable ID generated at creation time
     created_at: datetime = field(default_factory=datetime.utcnow)

--- a/app/src/evaluation/qa_generation/runner.py
+++ b/app/src/evaluation/qa_generation/runner.py
@@ -78,6 +78,8 @@ def run_generation(
 
         # Sample documents if requested
         if sample_fraction:
+            if not 0 < sample_fraction <= 1:
+                raise ValueError("Sample fraction must be between 0 and 1")
             documents = get_stratified_sample(
                 documents,
                 sample_fraction=sample_fraction,

--- a/app/src/evaluation/qa_generation/runner.py
+++ b/app/src/evaluation/qa_generation/runner.py
@@ -1,6 +1,5 @@
 import csv
 from dataclasses import asdict, fields
-from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
@@ -8,7 +7,7 @@ from sqlalchemy.orm import joinedload
 
 from src.app_config import app_config
 from src.db.models.document import Document
-from src.evaluation.data_models import QAPair
+from src.evaluation.data_models import QAPair, QAPairVersion
 from src.util.sampling import get_stratified_sample
 
 from .generator import generate_from_documents
@@ -44,8 +43,8 @@ def run_generation(
     dataset_filter: Optional[List[str]] = None,
     sample_fraction: Optional[float] = None,
     random_seed: Optional[int] = None,
-    git_commit: Optional[str] = None,
-) -> Path:
+    version: Optional[QAPairVersion] = None,
+) -> List[QAPair]:
     """Run QA pair generation with given parameters.
 
     Args:
@@ -54,15 +53,11 @@ def run_generation(
         dataset_filter: List of dataset names to include
         sample_fraction: Fraction of documents to sample
         random_seed: Random seed for reproducible sampling
-        git_commit: Git commit hash for tracking generation runs (not used in this simplified version)
+        version: Version information for generated QA pairs
 
     Returns:
-        Path to generated QA pairs CSV
+        List of generated QA pairs
     """
-    # Generate version ID using timestamp for unique identification
-    version_id = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-    qa_pairs_dir = output_dir / "qa_pairs" / version_id
-
     # Load documents from DB
     with app_config.db_session() as session:
         # Start with base query
@@ -96,11 +91,10 @@ def run_generation(
             _ = doc.dataset  # Force load dataset
 
         # Generate QA pairs
-        qa_pairs = list(generate_from_documents(llm_model=llm_model, documents=documents))
-
-        # Save QA pairs
-        qa_pairs_path = save_qa_pairs(qa_pairs_dir, qa_pairs)
+        qa_pairs = list(
+            generate_from_documents(llm_model=llm_model, documents=documents, version=version)
+        )
 
         print(f"Generated {len(qa_pairs)} QA pairs")
 
-        return qa_pairs_path
+        return qa_pairs

--- a/app/src/evaluation/utils/storage.py
+++ b/app/src/evaluation/utils/storage.py
@@ -1,0 +1,209 @@
+"""Shared storage utilities for QA pairs and evaluation results."""
+
+import csv
+import json
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import List, Optional
+
+from ..data_models import QAPair
+
+MAX_RETRIES = 3
+RETRY_DELAY = 0.1
+
+
+class QAPairStorage:
+    """Handles storage and versioning of QA pairs."""
+
+    def __init__(self, base_path: Path):
+        """Initialize storage with base path.
+
+        Args:
+            base_path: Base directory for QA pairs storage
+        """
+        self.base_path = base_path
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    def _update_symlink(self, target_dir: Path, max_retries: int = MAX_RETRIES) -> None:
+        """Update latest symlink with retry logic.
+
+        Args:
+            target_dir: Directory to link to
+            max_retries: Maximum number of retry attempts
+        """
+        latest_link = self.base_path / "latest"
+        temp_link = None
+
+        for attempt in range(max_retries):
+            try:
+                # Create temp symlink with unique name
+                temp_link = self.base_path / f"latest.{datetime.now().timestamp()}"
+                if temp_link.exists():
+                    temp_link.unlink()
+                temp_link.symlink_to(target_dir, target_is_directory=True)
+
+                # Atomic rename of temp symlink to latest
+                if latest_link.exists():
+                    latest_link.unlink()
+                temp_link.rename(latest_link)
+                return
+
+            except (OSError, RuntimeError) as e:
+                if attempt == max_retries - 1:
+                    raise e
+                time.sleep(RETRY_DELAY)
+            finally:
+                # Clean up temp link if it exists and wasn't renamed
+                if temp_link and temp_link.exists():
+                    temp_link.unlink()
+
+    def save_qa_pairs(
+        self,
+        qa_pairs: List[QAPair],
+        version_id: str,
+        git_commit: Optional[str] = None,
+    ) -> Path:
+        """Save QA pairs with version information.
+
+        Args:
+            qa_pairs: List of QA pairs to save
+            version_id: ID for this QA generation run
+            git_commit: Git commit for tracking
+
+        Returns:
+            Path to saved QA pairs CSV
+        """
+        # Create versioned directory
+        version_dir = self.base_path / version_id
+        version_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save metadata
+        metadata = {
+            "version_id": version_id,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "llm_model": qa_pairs[0].version.llm_model if qa_pairs else None,
+            "total_pairs": len(qa_pairs),
+            "datasets": list(set(p.document_source for p in qa_pairs)),
+            "git_commit": git_commit,
+        }
+
+        with open(version_dir / "metadata.json", "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        # Save QA pairs CSV
+        csv_path = version_dir / "qa_pairs.csv"
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.DictWriter(
+                f,
+                fieldnames=[
+                    "id",
+                    "question",
+                    "answer",
+                    "document_name",
+                    "document_source",
+                    "document_id",
+                    "chunk_id",
+                    "content_hash",
+                    "dataset",
+                    "created_at",
+                    "version_id",
+                    "version_timestamp",
+                    "version_llm_model",
+                    "expected_chunk_content",
+                ],
+            )
+            writer.writeheader()
+            for pair in qa_pairs:
+                # Convert dataclass to dict and handle nested version
+                row = pair.__dict__.copy()
+                # Flatten version info into row
+                row["version_id"] = pair.version.version_id
+                row["version_timestamp"] = pair.version.timestamp
+                row["version_llm_model"] = pair.version.llm_model
+                # Remove nested version dict
+                del row["version"]
+                writer.writerow(row)
+
+        # Update latest symlink with robust handling
+        try:
+            self._update_symlink(version_dir)
+        except (OSError, RuntimeError):
+            # If symlink operations fail, just continue
+            # The files are still saved successfully
+            pass
+
+        return csv_path
+
+    def get_latest_version(self) -> str:
+        """Get the version ID of the latest QA pairs.
+
+        Returns:
+            Version ID string
+
+        Raises:
+            ValueError if no QA pairs found
+        """
+        try:
+            # First try to find latest version by timestamp
+            versions = sorted(
+                [d for d in self.base_path.iterdir() if d.is_dir() and d.name != "latest"],
+                key=lambda d: d.name,
+                reverse=True,
+            )
+        except OSError as e:
+            raise ValueError("No QA pairs found - error accessing directory") from e
+
+        if not versions:
+            raise ValueError("No QA pairs found - run generation first")
+
+        latest_version = versions[0]
+
+        # Handle symlink creation/update with retries
+        try:
+            self._update_symlink(latest_version)
+        except (OSError, RuntimeError):
+            # If symlink operations fail completely, just return the version
+            # This maintains core functionality even if symlink fails
+            pass
+
+        return latest_version.name
+
+    def get_version_path(self, version_id: str) -> Path:
+        """Get the path to a specific version of QA pairs.
+
+        Args:
+            version_id: Version ID to locate
+
+        Returns:
+            Path to version directory
+
+        Raises:
+            ValueError if version not found or not a directory
+        """
+        version_dir = self.base_path / version_id
+        if not version_dir.exists() or not version_dir.is_dir():
+            raise ValueError(f"Version {version_id} not found")
+
+        return version_dir
+
+    def get_version_metadata(self, version_id: str) -> dict:
+        """Get metadata for a specific version.
+
+        Args:
+            version_id: Version ID to get metadata for
+
+        Returns:
+            Version metadata dictionary
+
+        Raises:
+            ValueError if version or metadata not found
+        """
+        version_dir = self.get_version_path(version_id)
+        metadata_path = version_dir / "metadata.json"
+
+        if not metadata_path.exists():
+            raise ValueError(f"Metadata not found for version {version_id}")
+
+        with open(metadata_path) as f:
+            return json.load(f)

--- a/app/tests/src/evaluation/cli/test_cli_evaluate.py
+++ b/app/tests/src/evaluation/cli/test_cli_evaluate.py
@@ -1,28 +1,168 @@
 """Tests for the evaluate CLI module."""
 
 import argparse
+import csv
+import json
+import shutil
+import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
+from src.db.models.document import ChunkWithScore
 from src.evaluation.cli import evaluate
+from src.evaluation.data_models import QAPair, QAPairVersion
+from tests.src.db.models.factories import ChunkFactory, DocumentFactory
 
 
 @pytest.fixture
-def mock_run_evaluation():
-    """Mock the run_evaluation function."""
-    with mock.patch("src.evaluation.cli.evaluate.run_evaluation") as mock_run:
-        yield mock_run
+def mock_git_commit():
+    """Mock git commit hash."""
+    with mock.patch("src.evaluation.metrics.batch.get_git_commit", return_value="test123"):
+        yield
 
 
 @pytest.fixture
-def mock_create_retrieval_function():
+def mock_retrieval_func(test_document):
     """Mock the create_retrieval_function."""
-    with mock.patch("src.evaluation.cli.evaluate.create_retrieval_function") as mock_func:
-        mock_retrieval = mock.MagicMock()
-        mock_func.return_value = mock_retrieval
-        yield mock_func, mock_retrieval
+    retrieval_func = create_mock_retrieval_func(test_document)
+    with mock.patch(
+        "src.evaluation.cli.evaluate.create_retrieval_function", return_value=retrieval_func
+    ):
+        yield retrieval_func
+
+
+@pytest.fixture
+def test_document():
+    """Create a test document with chunks."""
+    document = DocumentFactory.build(
+        name="test_doc",
+        content="Test document content",
+        source="test_dataset",
+        dataset="Imagine LA",  # Match the dataset mapping
+    )
+    chunk = ChunkFactory.build(
+        document=document,
+        content="test chunk content",
+    )
+    document.chunks = [chunk]
+    return document
+
+
+@pytest.fixture
+def test_questions_csv(tmp_path, test_document):
+    """Create a temporary CSV file with test questions."""
+    version = QAPairVersion(
+        version_id="20250307_011423",
+        timestamp=datetime.now(UTC).isoformat(),
+        llm_model="test-model",
+    )
+
+    questions = [
+        QAPair(
+            id="1",
+            question="test question 1?",
+            answer="test answer 1",
+            dataset="Imagine LA",  # Match the dataset mapping
+            document_name=test_document.name,
+            document_source="test_dataset",
+            document_id="doc1",
+            chunk_id=str(test_document.chunks[0].id),
+            expected_chunk_content=test_document.chunks[0].content,
+            content_hash="hash1",
+            created_at=datetime.now(UTC).isoformat(),
+            version=version,
+        ),
+        QAPair(
+            id="2",
+            question="test question 2?",
+            answer="test answer 2",
+            dataset="DPSS Policy",  # Match another known dataset
+            document_name="other_doc",
+            document_source="other_dataset",
+            document_id="doc2",
+            chunk_id="chunk2",
+            expected_chunk_content="other content",
+            content_hash="hash2",
+            created_at=datetime.now(UTC).isoformat(),
+            version=version,
+        ),
+    ]
+
+    # Create versioned directory structure
+    version_dir = tmp_path / "qa_pairs" / version.version_id
+    version_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save metadata
+    metadata = {
+        "version_id": version.version_id,
+        "timestamp": version.timestamp,
+        "llm_model": version.llm_model,
+        "total_pairs": len(questions),
+        "datasets": ["test_dataset", "other_dataset"],
+        "git_commit": "test123",
+    }
+
+    with open(version_dir / "metadata.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    # Save QA pairs CSV
+    csv_path = version_dir / "qa_pairs.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "id",
+                "question",
+                "answer",
+                "document_name",
+                "document_source",
+                "document_id",
+                "chunk_id",
+                "content_hash",
+                "dataset",
+                "created_at",
+                "version_id",
+                "version_timestamp",
+                "version_llm_model",
+                "expected_chunk_content",
+            ],
+        )
+        writer.writeheader()
+        for pair in questions:
+            row = pair.__dict__.copy()
+            row["version_id"] = pair.version.version_id
+            row["version_timestamp"] = pair.version.timestamp
+            row["version_llm_model"] = pair.version.llm_model
+            del row["version"]
+            writer.writerow(row)
+
+    # Create latest symlink
+    latest_link = tmp_path / "qa_pairs" / "latest"
+    if latest_link.exists():
+        latest_link.unlink()
+    latest_link.symlink_to(version_dir, target_is_directory=True)
+
+    return str(csv_path)
+
+
+def create_mock_retrieval_func(test_document):
+    """Create a mock retrieval function that returns the test document's chunk."""
+
+    def retrieval_func(query: str, k: int):
+        chunk = test_document.chunks[0]
+        return [ChunkWithScore(chunk=chunk, score=0.85)]
+
+    return retrieval_func
+
+
+@pytest.fixture
+def temp_output_dir():
+    """Create a temporary directory for test outputs."""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield Path(tmpdirname)
 
 
 def test_create_parser():
@@ -43,58 +183,256 @@ def test_create_parser():
     assert args.commit is None
 
 
-def test_main_with_dataset(mock_run_evaluation, mock_create_retrieval_function):
+def test_main_with_dataset(
+    test_document, test_questions_csv, temp_output_dir, mock_git_commit, mock_retrieval_func
+):
     """Test the main function with a dataset specified."""
-    mock_func, mock_retrieval = mock_create_retrieval_function
-
-    with mock.patch("sys.argv", ["evaluate.py", "--dataset", "imagine_la", "--k", "5", "10"]):
-        evaluate.main()
-
-        # Check that run_evaluation was called with the right arguments
-        mock_run_evaluation.assert_called_once()
-        args, kwargs = mock_run_evaluation.call_args
-
-        assert kwargs["dataset_filter"] == ["Imagine LA"]
-        assert kwargs["k_values"] == [5, 10]
-        assert kwargs["sample_fraction"] is None
-        assert kwargs["random_seed"] is None
-        assert kwargs["min_score"] == -1.0
-        assert kwargs["retrieval_func"] == mock_retrieval
-        assert "log_dir" in kwargs
-        assert "commit" in kwargs
-
-
-def test_main_with_sampling(mock_run_evaluation, mock_create_retrieval_function):
-    """Test the main function with sampling specified."""
-    mock_func, mock_retrieval = mock_create_retrieval_function
+    # Copy QA pairs directory structure to output directory
+    qa_pairs_dir = Path(test_questions_csv).parent.parent
+    output_qa_pairs_dir = temp_output_dir / "qa_pairs"
+    shutil.copytree(qa_pairs_dir, output_qa_pairs_dir)
 
     with mock.patch(
         "sys.argv",
-        ["evaluate.py", "--sampling", "0.5", "--random-seed", "42", "--min-score", "0.7"],
+        [
+            "evaluate.py",
+            "--dataset",
+            "imagine_la",  # This will map to "Imagine LA"
+            "--k",
+            "5",  # Only test with one k value
+            "--output-dir",
+            str(temp_output_dir),
+        ],
+    ):
+        # Run main with real retrieval function
+        evaluate.main()
+
+        # Verify evaluation logs were created
+        eval_logs_dir = temp_output_dir / "logs" / "evaluations"
+        assert eval_logs_dir.exists()
+
+        # Find the most recent log files
+        batch_files = list(eval_logs_dir.rglob("batch_*.json"))
+        results_files = list(eval_logs_dir.rglob("results_*.jsonl"))
+        metrics_files = list(eval_logs_dir.rglob("metrics_*.json"))
+
+        assert len(batch_files) > 0
+        assert len(results_files) > 0
+        assert len(metrics_files) > 0
+
+        # Verify batch configuration
+        with open(batch_files[0]) as f:
+            batch_data = json.load(f)
+            assert batch_data["evaluation_config"]["k_value"] == 5
+
+
+def test_main_with_sampling(
+    test_document, test_questions_csv, temp_output_dir, mock_git_commit, mock_retrieval_func
+):
+    """Test the main function with sampling specified."""
+    # Copy QA pairs directory structure to output directory
+    qa_pairs_dir = Path(test_questions_csv).parent.parent
+    output_qa_pairs_dir = temp_output_dir / "qa_pairs"
+    shutil.copytree(qa_pairs_dir, output_qa_pairs_dir)
+
+    with mock.patch(
+        "sys.argv",
+        [
+            "evaluate.py",
+            "--sampling",
+            "0.5",
+            "--random-seed",
+            "42",
+            "--min-score",
+            "0.7",
+            "--output-dir",
+            str(temp_output_dir),
+        ],
+    ):
+        # Run main
+        evaluate.main()
+
+        # Verify evaluation logs were created
+        eval_logs_dir = temp_output_dir / "logs" / "evaluations"
+        assert eval_logs_dir.exists()
+
+        # Find and verify results file
+        results_files = list(eval_logs_dir.rglob("results_*.jsonl"))
+        assert len(results_files) > 0
+
+        # Verify sampled results
+        with open(results_files[0]) as f:
+            results = [line for line in f if line.strip()]
+            assert len(results) >= 1  # Should have at least one result due to sampling
+
+
+def test_error_handling(temp_output_dir, mock_git_commit, mock_retrieval_func):
+    """Test error handling scenarios."""
+    with mock.patch("sys.argv", ["evaluate.py", "--output-dir", str(temp_output_dir)]):
+        # Test no QA pairs directory error
+        with pytest.raises(ValueError, match="No QA pairs found - run generation first"):
+            evaluate.main()
+
+        # Create empty QA pairs directory
+        qa_pairs_dir = temp_output_dir / "qa_pairs"
+        qa_pairs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Test no QA pairs version error
+        with pytest.raises(ValueError, match="No QA pairs found - run generation first"):
+            evaluate.main()
+
+        # Create empty version directory
+        version_dir = qa_pairs_dir / "20250307_011423"
+        version_dir.mkdir(parents=True, exist_ok=True)
+
+        # Test missing metadata error
+        with pytest.raises(ValueError, match="Metadata not found for version"):
+            evaluate.main()
+
+        # Create empty metadata file
+        metadata = {
+            "version_id": "20250307_011423",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "llm_model": "test-model",
+            "total_pairs": 0,
+            "datasets": [],
+            "git_commit": "test123",
+        }
+        with open(version_dir / "metadata.json", "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        # Create empty QA pairs CSV
+        qa_pairs_path = version_dir / "qa_pairs.csv"
+        qa_pairs_path.write_text("id,question,answer,dataset\n")  # Empty CSV with header
+
+        # Test no questions after filtering
+        with pytest.raises(ValueError, match="No questions to evaluate"):
+            evaluate.main()
+
+
+def test_dataset_mapping():
+    """Test dataset name mapping functionality."""
+    # Test known dataset mapping
+    assert evaluate.DATASET_MAPPING["imagine_la"] == "Imagine LA"
+    assert evaluate.DATASET_MAPPING["la_policy"] == "DPSS Policy"
+
+    # Test case sensitivity
+    with mock.patch("sys.argv", ["evaluate.py", "--dataset", "IMAGINE_LA"]):
+        parser = evaluate.create_parser()
+        args = parser.parse_args()
+        db_datasets = [evaluate.DATASET_MAPPING.get(d.lower(), d) for d in args.dataset]
+        assert db_datasets == ["Imagine LA"]
+
+
+def test_argument_parsing():
+    """Test argument parsing with various combinations."""
+    # Test default values
+    parser = evaluate.create_parser()
+    args = parser.parse_args([])
+    assert args.dataset is None
+    assert args.k == [5, 10, 25]
+    assert args.qa_pairs_version is None
+    assert args.min_score == -1.0
+    assert args.sampling is None
+    assert args.random_seed is None
+
+    # Test custom values
+    args = parser.parse_args(
+        [
+            "--dataset",
+            "imagine_la",
+            "la_policy",
+            "--k",
+            "3",
+            "7",
+            "--min-score",
+            "0.5",
+            "--sampling",
+            "0.1",
+            "--random-seed",
+            "42",
+        ]
+    )
+    assert args.dataset == ["imagine_la", "la_policy"]
+    assert args.k == [3, 7]
+    assert args.min_score == 0.5
+    assert args.sampling == 0.1
+    assert args.random_seed == 42
+
+
+def validate_positive_int(value):
+    """Validate that value is a positive integer."""
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"{value} is not a positive integer")
+    return ivalue
+
+
+def validate_sampling_fraction(value):
+    """Validate that value is a valid sampling fraction (0 < x <= 1)."""
+    fvalue = float(value)
+    if not 0 < fvalue <= 1:
+        raise argparse.ArgumentTypeError(
+            f"{value} is not a valid sampling fraction (must be between 0 and 1)"
+        )
+    return fvalue
+
+
+def test_invalid_arguments():
+    """Test handling of invalid arguments."""
+    parser = evaluate.create_parser()
+
+    # Add type validation to parser
+    parser.add_argument("--test-k", type=validate_positive_int)
+    parser.add_argument("--test-sampling", type=validate_sampling_fraction)
+
+    # Test invalid k value
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--test-k", "-1"])
+
+    # Test invalid sampling value
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--test-sampling", "2.0"])
+
+
+@pytest.mark.integration
+def test_main_integration(
+    test_document, test_questions_csv, temp_output_dir, mock_git_commit, mock_retrieval_func
+):
+    """Integration test with minimal test data."""
+    # Copy QA pairs directory structure to output directory
+    qa_pairs_dir = Path(test_questions_csv).parent.parent
+    output_qa_pairs_dir = temp_output_dir / "qa_pairs"
+    shutil.copytree(qa_pairs_dir, output_qa_pairs_dir)
+
+    with mock.patch(
+        "sys.argv",
+        [
+            "evaluate.py",
+            "--dataset",
+            "imagine_la",  # This will map to "Imagine LA"
+            "--k",
+            "1",
+            "--output-dir",
+            str(temp_output_dir),
+        ],
     ):
         evaluate.main()
 
-        # Check that run_evaluation was called with the right arguments
-        mock_run_evaluation.assert_called_once()
-        args, kwargs = mock_run_evaluation.call_args
+        # Verify evaluation logs were created
+        eval_logs_dir = temp_output_dir / "logs" / "evaluations"
+        assert eval_logs_dir.exists()
 
-        assert kwargs["dataset_filter"] is None
-        assert kwargs["k_values"] == [5, 10, 25]  # Default values
-        assert kwargs["sample_fraction"] == 0.5
-        assert kwargs["random_seed"] == 42
-        assert kwargs["min_score"] == 0.7
-        assert kwargs["retrieval_func"] == mock_retrieval
+        # Find and verify log files
+        batch_files = list(eval_logs_dir.rglob("batch_*.json"))
+        results_files = list(eval_logs_dir.rglob("results_*.jsonl"))
+        metrics_files = list(eval_logs_dir.rglob("metrics_*.json"))
 
+        assert len(batch_files) > 0
+        assert len(results_files) > 0
+        assert len(metrics_files) > 0
 
-def test_main_error_handling(mock_run_evaluation):
-    """Test error handling in the main function."""
-    test_error = RuntimeError("Test error")
-    mock_run_evaluation.side_effect = test_error
-
-    with mock.patch("sys.argv", ["evaluate.py"]):
-        with mock.patch("builtins.print") as mock_print:
-            with pytest.raises(RuntimeError, match="Test error"):
-                evaluate.main()
-
-            # Check that the error message was printed
-            mock_print.assert_called_with("Error running evaluation: Test error")
+        # Verify results contain only Imagine LA questions
+        with open(results_files[0]) as f:
+            results = [json.loads(line) for line in f if line.strip()]
+            assert all(r["dataset"] == "Imagine LA" for r in results)

--- a/app/tests/src/evaluation/utils/test_storage.py
+++ b/app/tests/src/evaluation/utils/test_storage.py
@@ -1,0 +1,132 @@
+"""Tests for QA pairs storage utilities."""
+
+import json
+import uuid
+from datetime import datetime
+
+import pytest
+
+from src.evaluation.data_models import QAPair, QAPairVersion
+from src.evaluation.utils.storage import QAPairStorage
+
+
+@pytest.fixture
+def storage_dir(tmp_path):
+    """Create a temporary directory for storage tests."""
+    return tmp_path / "qa_pairs"
+
+
+@pytest.fixture
+def storage(storage_dir):
+    """Create a QAPairStorage instance for testing."""
+    return QAPairStorage(storage_dir)
+
+
+@pytest.fixture
+def sample_qa_pairs():
+    """Create sample QA pairs for testing."""
+    version = QAPairVersion(
+        version_id="test_v1",
+        llm_model="test-model",
+        timestamp=datetime.utcnow(),
+    )
+
+    return [
+        QAPair(
+            id=uuid.uuid4(),
+            question="Test question 1?",
+            answer="Test answer 1",
+            document_name="doc1.txt",
+            document_source="test_dataset",
+            document_id=uuid.uuid4(),
+            chunk_id=uuid.uuid4(),
+            content_hash="hash1",
+            dataset="test_dataset",
+            version=version,
+        ),
+        QAPair(
+            id=uuid.uuid4(),
+            question="Test question 2?",
+            answer="Test answer 2",
+            document_name="doc2.txt",
+            document_source="test_dataset",
+            document_id=uuid.uuid4(),
+            chunk_id=uuid.uuid4(),
+            content_hash="hash2",
+            dataset="test_dataset",
+            version=version,
+        ),
+    ]
+
+
+def test_save_qa_pairs(storage, sample_qa_pairs):
+    """Test saving QA pairs with version information."""
+    version_id = "test_v1"
+    git_commit = "abc123"
+
+    csv_path = storage.save_qa_pairs(sample_qa_pairs, version_id, git_commit)
+
+    # Check that files were created
+    assert csv_path.exists()
+    assert (csv_path.parent / "metadata.json").exists()
+
+    # Check metadata content
+    with open(csv_path.parent / "metadata.json") as f:
+        metadata = json.load(f)
+        assert metadata["version_id"] == version_id
+        assert metadata["git_commit"] == git_commit
+        assert metadata["llm_model"] == "test-model"
+        assert metadata["total_pairs"] == 2
+        assert metadata["datasets"] == ["test_dataset"]
+
+
+def test_get_latest_version_empty(storage):
+    """Test getting latest version with no QA pairs."""
+    with pytest.raises(ValueError, match="No QA pairs found"):
+        storage.get_latest_version()
+
+
+def test_get_latest_version(storage, sample_qa_pairs):
+    """Test getting latest version with multiple versions."""
+    # Save two versions
+    storage.save_qa_pairs(sample_qa_pairs, "v1", "commit1")
+    storage.save_qa_pairs(sample_qa_pairs, "v2", "commit2")
+
+    latest = storage.get_latest_version()
+    assert latest == "v2"
+
+    # Check that latest symlink points to v2
+    latest_link = storage.base_path / "latest"
+    assert latest_link.exists()
+    assert latest_link.resolve().name == "v2"
+
+
+def test_get_version_path(storage, sample_qa_pairs):
+    """Test getting path for specific version."""
+    version_id = "test_v1"
+    storage.save_qa_pairs(sample_qa_pairs, version_id, "commit1")
+
+    path = storage.get_version_path(version_id)
+    assert path.exists()
+    assert path.is_dir()
+    assert path.name == version_id
+
+    # Test non-existent version
+    with pytest.raises(ValueError, match="Version bad_version not found"):
+        storage.get_version_path("bad_version")
+
+
+def test_get_version_metadata(storage, sample_qa_pairs):
+    """Test getting metadata for specific version."""
+    version_id = "test_v1"
+    git_commit = "commit1"
+    storage.save_qa_pairs(sample_qa_pairs, version_id, git_commit)
+
+    metadata = storage.get_version_metadata(version_id)
+    assert metadata["version_id"] == version_id
+    assert metadata["git_commit"] == git_commit
+    assert metadata["llm_model"] == "test-model"
+
+    # Test non-existent version
+    with pytest.raises(ValueError, match="Version bad_version not found"):
+        storage.get_version_metadata("bad_version")


### PR DESCRIPTION
## Ticket

NA

## Changes

- Added versioned storage system for QA pairs
  - Timestamp-based versioning with metadata (e.g., `20250307_011423/`)
  - Stores QA pairs in versioned directories with metadata.json
  - Maintains "latest" symlink for easy access
  - Version-specific metadata (LLM model, git commit, etc.)
- Updated tests to work with new storage
  - cli tests to handle versioned QA pairs
  - integration tests for the QA generation with versioning

## Context for reviewers

Introduced feature versioned storage system for QA pairs to improve traceability + reproducibility

## Testing

Passing with `make test`
`make generate-qa dataset="la_policy" sampling=0.005 && make evaluate k="5"`