### PR TITLE
chore: Bump DB max capacity

### DIFF
--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -50,7 +50,7 @@ resource "aws_rds_cluster" "db" {
 
   serverlessv2_scaling_configuration {
     max_capacity = 2.0
-    min_capacity = 1.0
+    min_capacity = 0.5
   }
 
   db_subnet_group_name   = var.database_subnet_group_name

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -49,8 +49,8 @@ resource "aws_rds_cluster" "db" {
   deletion_protection = true
 
   serverlessv2_scaling_configuration {
-    max_capacity = 1.0
-    min_capacity = 0.5
+    max_capacity = 2.0
+    min_capacity = 1.0
   }
 
   db_subnet_group_name   = var.database_subnet_group_name

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -49,7 +49,7 @@ resource "aws_rds_cluster" "db" {
   deletion_protection = true
 
   serverlessv2_scaling_configuration {
-    max_capacity = 2.0
+    max_capacity = 4.0
     min_capacity = 0.5
   }
 


### PR DESCRIPTION
## Ticket

n/a


## Changes
 - Prod DB resource usage is about ~50% at the current pilot -- bump the ceiling from 1.0 to 4.0 so there's room to scale in case needed.


## Context for reviewers
Will run `make infra-update-app-database APP_NAME=app ENVIRONMENT=prod` once this is approved and merged


## Testing
n/a