### PR TITLE
feat: Export QA pairs from LiteralAI logs

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -299,3 +299,6 @@ generate-qa: ## Generate QA pairs from documents
 		$(if $(sampling),--sampling=$(sampling),) \
 		$(if $(random_seed),--random-seed=$(random_seed),) \
 		--commit=$(shell git rev-parse HEAD)
+
+literalai-exporter:
+	$(PY_RUN_CMD) literalai-exporter $(args)

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -70,6 +70,7 @@ db-migrate-down = "src.db.migrations.run:down"
 db-migrate-down-all = "src.db.migrations.run:downall"
 
 pg-dump = "src.db.pg_dump_util:main"
+literalai-exporter = "src.evaluation.literalai_exporter:main"
 
 scrape-edd-web = "src.ingestion.scrape_edd_web:main"
 ingest-imagine-la = "src.ingestion.imagine_la.ingest:main"

--- a/app/src/evaluation/literalai_exporter.py
+++ b/app/src/evaluation/literalai_exporter.py
@@ -1,8 +1,11 @@
+import argparse
 import csv
 import functools
+import logging
 import json
-import os
 import pickle
+import sys
+
 from typing import NamedTuple, Optional
 from datetime import datetime
 from literalai import LiteralClient, Thread, Step
@@ -10,190 +13,124 @@ from literalai.filter import Filter, OrderBy
 
 from src.app_config import app_config
 
+logger = logging.getLogger(__name__)
+# Configure logging since this file is run directly
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
 
 @functools.cache
 def literalai() -> LiteralClient:
-    """
-    This needs to be a function so that it's not immediately instantiated upon
-    import of this module and so that it can mocked in tests.
-    """
     if app_config.literal_api_key_for_api:
         return LiteralClient(api_key=app_config.literal_api_key_for_api)
     return LiteralClient()
 
 
-def query_threads_since(client: LiteralClient, date: datetime):
-    since_date = date.isoformat()  # strftime("%Y-%m-%d")
-    # list[Filter[Literal['id', 'createdAt', 'name', 'stepType', 'stepName',
-    #   'stepOutput', 'metadata', 'tokenCount', 'tags', 'participantId',
-    #   'participantIdentifiers', 'scoreValue', 'duration']]]
-    filters: list[Filter] = [Filter(field="createdAt", operator="gte", value=since_date)]
+# @functools.cache
+# @property
+def get_project_id() -> str:
+    client = literalai()
+    proj_id = client.api.get_my_project_id()
+    logger.info("Project ID: %r", proj_id)
+    return proj_id
 
-    # OrderBy[Literal['createdAt', 'tokenCount']]
+
+def query_threads_since(start_date: datetime, end_date: datetime) -> list[Thread]:
+    start_date = start_date.isoformat()
+    filters: list[Filter] = [
+        Filter(field="createdAt", operator="gte", value=start_date),
+        Filter(field="createdAt", operator="lt", value=end_date),
+    ]
+    logger.info("Query filter: %r", filters)
     order_by: OrderBy = OrderBy(column="createdAt", direction="ASC")
 
+    client = literalai()
     threads = []
-    has_next_page = True
     after = None
-    while has_next_page:
+    while True:
         response = client.api.get_threads(filters=filters, order_by=order_by, after=after)
-        # print(response.to_dict())
-        # Save response to file
-        has_next_page = response.pageInfo.hasNextPage
         after = response.pageInfo.endCursor
-
-        print(f"totalCount: {response.totalCount}, has_next_page: {has_next_page}, after: {after}")
         threads += response.data
+        logger.info("Got %r of %r total threads", len(threads), response.totalCount)
+        if not response.pageInfo.hasNextPage:
+            assert (
+                len(threads) == response.totalCount
+            ), f"Expected {response.totalCount} threads, but got only {len(threads)}"
+            return threads
 
-    with open("response.json", "w", encoding="utf-8") as f:
-        thread_dicts = [thread.to_dict() for thread in threads]
-        f.write(json.dumps(thread_dicts, indent=2))
-    # Serialize the object to a file
-    with open("response.pickle", "wb") as file:
-        pickle.dump(threads, file)
-
-
-class LaiCitation(NamedTuple):
-    citation_id: str
-    uri: str
-    source_dataset: str
-    source_name: str
-
-    @classmethod
-    def from_json(cls, obj: dict):
-        return LaiCitation(
-            citation_id=obj["citation_id"],
-            uri=obj["uri"],
-            source_dataset=obj["source_dataset"],
-            source_name=obj["source_name"],
-        )
-
-
-class LaiStep(NamedTuple):
-    id: str
-    # threadId: str
-    parentId: str
-    startTime: str
-    endTime: str
-
-    type: str
-    # name: str
-    output: str
-
-    benefit_program: Optional[str]
-    needs_context: Optional[bool]
-    # raw_response: str
-
-    has_chat_history: bool
-    citations: Optional[dict[str, LaiCitation]]
-
-    @classmethod
-    def from_json(cls, obj: dict):
-        attribs = obj["metadata"].get("attributes", None)
-        citations = obj["metadata"].get("citations", None)
-        chat_history = obj["metadata"].get("chat_history", None)
-        return LaiStep(
-            id=obj["id"],
-            parentId=obj["parentId"],
-            startTime=obj["startTime"],
-            endTime=obj["endTime"],
-            type=obj["type"],
-            # name=obj["name"],
-            output=obj["output"]["content"],
-            benefit_program=attribs["benefit_program"] if attribs else None,
-            needs_context=attribs["needs_context"] if attribs else None,
-            # raw_response=obj["metadata"].get("raw_response"),
-            has_chat_history=bool(chat_history),
-            citations=(
-                {c["citation_id"]: LaiCitation.from_json(c) for c in citations}
-                if citations
-                else None
-            ),
-        )
-
-
-class LaiThread(NamedTuple):
-    id: str
-    createdAt: str
-    participant: str
-    steps: dict[str, LaiStep]
-
-    @classmethod
-    def from_json(cls, obj: dict):
-        steps = {step_obj["id"]: LaiStep.from_json(step_obj) for step_obj in obj["steps"]}
-        return LaiThread(
-            id=obj["id"],
-            createdAt=obj["createdAt"],
-            participant=obj["participant"]["identifier"],
-            steps=steps,
-        )
+    raise RuntimeError("Didn't get last page of responses")
 
 
 class QARow(NamedTuple):
+    # uniquely identifies the thread in Literal AI; can have several associated questions
     thread_id: str
+    # uniquely identifies the question in Literal AI
     question_id: str
-    question_timestamp: str
+    # question's timestamp
+    timestamp: str
+    # ids submitted in request
     user_id: str
     agency_id: str
     session_id: str
+    # user's question
     question: str
+    # LLM's generated answer
     answer: str
+    # benefit_program
     program: Optional[str]
+    # links to citations in the order they are referenced in the answer
     citation_links: Optional[str]
-    citations: Optional[dict[str, str]]
+    # dataset and document name/title for each citation
+    citation_sources: Optional[str]
+    # another clue to signal that the QA pair follows another QA pair in the same thread
     has_chat_history: bool
 
     @property
     def lai_link(self):
-        return f"https://cloud.getliteral.ai/projects/{project_id}/logs/threads/{self.thread_id}?currentStepId={self.question_id}"
-
-    # @classmethod
-    # def from_lai_steps(cls, thread: LaiThread, question_step: LaiStep, answer_step: LaiStep):
-    #     assert question_step.type == "user_message", "Question step must be a user_message"
-    #     assert answer_step.type == "assistant_message", "Answer step must be an assistant_message"
-    #     return QARow(
-    #         thread_id=thread.id,
-    #         question_id=question_step.id,
-    #         question=question_step.output,
-    #         answer=answer_step.output,
-    #         program=answer_step.benefit_program,
-    #         has_chat_history=answer_step.has_chat_history,
-    #     )
+        return (
+            f"https://cloud.getliteral.ai/projects/{project_id}/logs/"
+            "threads/{self.thread_id}?currentStepId={self.question_id}"
+        )
 
     @classmethod
-    def from_lai_steps2(cls, thread: Thread, question_step: Step, answer_step: Step):
+    def from_lai_thread(cls, thread: Thread, question_step: Step, answer_step: Step):
         assert question_step, "Question step must not be None"
+        # question_step.id is used to create the link to Literal AI
         assert question_step.id, "Question step id must not be None"
+        # start_time can also be used to distinguish question-answer pairs
         assert question_step.start_time, "Question step start_time must not be None"
 
         assert question_step.type == "user_message", "Question step must be a user_message"
         assert answer_step.type == "assistant_message", "Answer step must be an assistant_message"
 
+        # output["content"] is the text shown in the chatbot UI
         assert question_step.output
         assert question_step.output["content"]
         assert answer_step.output
         assert answer_step.output["content"]
 
+        # Handle custom metadata
         assert question_step.metadata
         assert answer_step.metadata
         attribs = answer_step.metadata.get("attributes", None)
-        chat_history = answer_step.metadata.get("chat_history", None)
         citations = answer_step.metadata.get("citations", None)
 
         return QARow(
             thread_id=thread.id,
             question_id=question_step.id,
-            question_timestamp=question_step.start_time,
+            timestamp=question_step.start_time,
             user_id=question_step.metadata["request"]["user_id"],
             agency_id=question_step.metadata["request"]["agency_id"],
             session_id=question_step.metadata["request"]["session_id"],
             question=question_step.output["content"],
             answer=answer_step.output["content"],
-            # TODO: add to API
             program=attribs["benefit_program"] if attribs else None,
             citation_links=("\n".join(c["uri"] for c in citations) if citations else None),
-            citations=({c["citation_id"]: c["uri"] for c in citations} if citations else None),
-            has_chat_history=bool(chat_history),
+            citation_sources=(
+                "\n".join(f"{c['source_dataset']}: {['source_name']}" for c in citations)
+                if citations
+                else None
+            ),
+            has_chat_history=bool(answer_step.metadata.get("chat_history", None)),
         )
 
 
@@ -204,13 +141,16 @@ def to_csv(threads: list[Thread]):
         steps = {step.id: step for step in th.steps}
         pairs = [
             # assert th.steps[step.parentId], f"Parent step {step.parentId} not found"
-            QARow.from_lai_steps2(thread=th, question_step=steps[step.parent_id], answer_step=step)
+            QARow.from_lai_thread(
+                thread=th, question_step=steps.pop(step.parent_id), answer_step=steps.pop(step.id)
+            )
             for step in th.steps
             if step.parent_id
         ]
-        for pair in pairs:
-            qa_pairs.append(pair)
-            print(json.dumps(pair, indent=2))
+        for remaining in steps:
+            logger.info("Step %r has no parent", remaining)
+            # print(json.dumps(pair, indent=2))
+        qa_pairs += pairs
 
     # import pdb; pdb.set_trace()
     fields = QARow._fields  # ["thread_id", "question", "answer", "lai_link"]
@@ -221,52 +161,43 @@ def to_csv(threads: list[Thread]):
             writer.writerow({k: getattr(pair, k, "") for k in fields})
 
 
-# def json_to_csv(json_obj: dict):
-#     # import pdb; pdb.set_trace()
-#     threads = [LaiThread.from_json(thread_obj) for thread_obj in json_obj["data"]]
-#     qa_pairs = []
-#     for th in threads:
-#         # print(json.dumps(th, indent=2))
-#         # print(list(json_obj.keys()))
-
-#         pairs = [
-#             QARow.from_lai_steps(
-#                 thread=th, question_step=th.steps[step.parentId], answer_step=step
-#             )
-#             for step in th.steps.values()
-#             if step.parentId
-#         ]
-#         for pair in pairs:
-#             qa_pairs.append(pair)
-#             print(json.dumps(pair, indent=2))
-
-#     fields = ["thread_id", "question", "answer"]
-#     with open("lai_pairs.csv", "w", encoding="utf-8") as f:
-#         writer = csv.DictWriter(f, fieldnames=fields)
-#         writer.writeheader()
-#         for pair in qa_pairs:
-#             writer.writerow({k: getattr(pair, k, "") for k in fields})
+def _save_threads(threads: list[Thread]):
+    with open("response.json", "w", encoding="utf-8") as f:
+        thread_dicts = [thread.to_dict() for thread in threads]
+        f.write(json.dumps(thread_dicts, indent=2))
+    with open("response.pickle", "wb") as file:
+        pickle.dump(threads, file)
 
 
-def query():
-    client = literalai()
-    date = datetime.fromisoformat("2025-03-05T00:00:00.000Z")
-    query_threads_since(client, date)
-
-
-def load_response() -> list[Thread]:
-    # with open("response.json", "r") as f:
-    #     return json.load(f)
+def _load_response() -> list[Thread]:
+    print("Loading from pickle")
     with open("response.pickle", "rb") as file:
         return pickle.load(file)
 
 
-if False:
-    query()
-    client = literalai()
-    project_id = client.api.get_my_project_id()
-    print(project_id)
+QUERY = False
+if QUERY:
+    project_id = get_project_id()
 else:
     project_id = "Decision-Support-Tool---Imagine-LA-FEcqNEkhUJ71"
     # project_id="PROD-Decision-Support-Tool---Imagine-LA-Zu5f2WjplboI"
-to_csv(load_response())
+
+
+def main() -> None:  # pragma: no cover
+    parser = argparse.ArgumentParser()
+    parser.add_argument("start", help="(inclusive) beginning datetime of threads to export")
+    parser.add_argument("end", help="(exclusive) end datetime of threads to export")
+    args = parser.parse_args(sys.argv[1:])
+    logger.info("Running with args %r", args)
+
+    if QUERY:
+        start_date = datetime.fromisoformat(args.start)  # ("2025-03-05T00:00:00.000Z")
+        end_date = datetime.fromisoformat(args.end)
+        threads = query_threads_since(start_date, end_date)
+        _save_threads(threads)
+
+    to_csv(_load_response())
+
+
+if __name__ == "__main__":
+    main()

--- a/app/src/evaluation/literalai_exporter.py
+++ b/app/src/evaluation/literalai_exporter.py
@@ -1,0 +1,272 @@
+import csv
+import functools
+import json
+import os
+import pickle
+from typing import NamedTuple, Optional
+from datetime import datetime
+from literalai import LiteralClient, Thread, Step
+from literalai.filter import Filter, OrderBy
+
+from src.app_config import app_config
+
+
+@functools.cache
+def literalai() -> LiteralClient:
+    """
+    This needs to be a function so that it's not immediately instantiated upon
+    import of this module and so that it can mocked in tests.
+    """
+    if app_config.literal_api_key_for_api:
+        return LiteralClient(api_key=app_config.literal_api_key_for_api)
+    return LiteralClient()
+
+
+def query_threads_since(client: LiteralClient, date: datetime):
+    since_date = date.isoformat()  # strftime("%Y-%m-%d")
+    # list[Filter[Literal['id', 'createdAt', 'name', 'stepType', 'stepName',
+    #   'stepOutput', 'metadata', 'tokenCount', 'tags', 'participantId',
+    #   'participantIdentifiers', 'scoreValue', 'duration']]]
+    filters: list[Filter] = [Filter(field="createdAt", operator="gte", value=since_date)]
+
+    # OrderBy[Literal['createdAt', 'tokenCount']]
+    order_by: OrderBy = OrderBy(column="createdAt", direction="ASC")
+
+    threads = []
+    has_next_page = True
+    after = None
+    while has_next_page:
+        response = client.api.get_threads(filters=filters, order_by=order_by, after=after)
+        # print(response.to_dict())
+        # Save response to file
+        has_next_page = response.pageInfo.hasNextPage
+        after = response.pageInfo.endCursor
+
+        print(f"totalCount: {response.totalCount}, has_next_page: {has_next_page}, after: {after}")
+        threads += response.data
+
+    with open("response.json", "w", encoding="utf-8") as f:
+        thread_dicts = [thread.to_dict() for thread in threads]
+        f.write(json.dumps(thread_dicts, indent=2))
+    # Serialize the object to a file
+    with open("response.pickle", "wb") as file:
+        pickle.dump(threads, file)
+
+
+class LaiCitation(NamedTuple):
+    citation_id: str
+    uri: str
+    source_dataset: str
+    source_name: str
+
+    @classmethod
+    def from_json(cls, obj: dict):
+        return LaiCitation(
+            citation_id=obj["citation_id"],
+            uri=obj["uri"],
+            source_dataset=obj["source_dataset"],
+            source_name=obj["source_name"],
+        )
+
+
+class LaiStep(NamedTuple):
+    id: str
+    # threadId: str
+    parentId: str
+    startTime: str
+    endTime: str
+
+    type: str
+    # name: str
+    output: str
+
+    benefit_program: Optional[str]
+    needs_context: Optional[bool]
+    # raw_response: str
+
+    has_chat_history: bool
+    citations: Optional[dict[str, LaiCitation]]
+
+    @classmethod
+    def from_json(cls, obj: dict):
+        attribs = obj["metadata"].get("attributes", None)
+        citations = obj["metadata"].get("citations", None)
+        chat_history = obj["metadata"].get("chat_history", None)
+        return LaiStep(
+            id=obj["id"],
+            parentId=obj["parentId"],
+            startTime=obj["startTime"],
+            endTime=obj["endTime"],
+            type=obj["type"],
+            # name=obj["name"],
+            output=obj["output"]["content"],
+            benefit_program=attribs["benefit_program"] if attribs else None,
+            needs_context=attribs["needs_context"] if attribs else None,
+            # raw_response=obj["metadata"].get("raw_response"),
+            has_chat_history=bool(chat_history),
+            citations=(
+                {c["citation_id"]: LaiCitation.from_json(c) for c in citations}
+                if citations
+                else None
+            ),
+        )
+
+
+class LaiThread(NamedTuple):
+    id: str
+    createdAt: str
+    participant: str
+    steps: dict[str, LaiStep]
+
+    @classmethod
+    def from_json(cls, obj: dict):
+        steps = {step_obj["id"]: LaiStep.from_json(step_obj) for step_obj in obj["steps"]}
+        return LaiThread(
+            id=obj["id"],
+            createdAt=obj["createdAt"],
+            participant=obj["participant"]["identifier"],
+            steps=steps,
+        )
+
+
+class QARow(NamedTuple):
+    thread_id: str
+    question_id: str
+    question_timestamp: str
+    user_id: str
+    agency_id: str
+    session_id: str
+    question: str
+    answer: str
+    program: Optional[str]
+    citation_links: Optional[str]
+    citations: Optional[dict[str, str]]
+    has_chat_history: bool
+
+    @property
+    def lai_link(self):
+        return f"https://cloud.getliteral.ai/projects/{project_id}/logs/threads/{self.thread_id}?currentStepId={self.question_id}"
+
+    # @classmethod
+    # def from_lai_steps(cls, thread: LaiThread, question_step: LaiStep, answer_step: LaiStep):
+    #     assert question_step.type == "user_message", "Question step must be a user_message"
+    #     assert answer_step.type == "assistant_message", "Answer step must be an assistant_message"
+    #     return QARow(
+    #         thread_id=thread.id,
+    #         question_id=question_step.id,
+    #         question=question_step.output,
+    #         answer=answer_step.output,
+    #         program=answer_step.benefit_program,
+    #         has_chat_history=answer_step.has_chat_history,
+    #     )
+
+    @classmethod
+    def from_lai_steps2(cls, thread: Thread, question_step: Step, answer_step: Step):
+        assert question_step, "Question step must not be None"
+        assert question_step.id, "Question step id must not be None"
+        assert question_step.start_time, "Question step start_time must not be None"
+
+        assert question_step.type == "user_message", "Question step must be a user_message"
+        assert answer_step.type == "assistant_message", "Answer step must be an assistant_message"
+
+        assert question_step.output
+        assert question_step.output["content"]
+        assert answer_step.output
+        assert answer_step.output["content"]
+
+        assert question_step.metadata
+        assert answer_step.metadata
+        attribs = answer_step.metadata.get("attributes", None)
+        chat_history = answer_step.metadata.get("chat_history", None)
+        citations = answer_step.metadata.get("citations", None)
+
+        return QARow(
+            thread_id=thread.id,
+            question_id=question_step.id,
+            question_timestamp=question_step.start_time,
+            user_id=question_step.metadata["request"]["user_id"],
+            agency_id=question_step.metadata["request"]["agency_id"],
+            session_id=question_step.metadata["request"]["session_id"],
+            question=question_step.output["content"],
+            answer=answer_step.output["content"],
+            # TODO: add to API
+            program=attribs["benefit_program"] if attribs else None,
+            citation_links=("\n".join(c["uri"] for c in citations) if citations else None),
+            citations=({c["citation_id"]: c["uri"] for c in citations} if citations else None),
+            has_chat_history=bool(chat_history),
+        )
+
+
+def to_csv(threads: list[Thread]):
+    qa_pairs = []
+    for th in threads:
+        assert th.steps
+        steps = {step.id: step for step in th.steps}
+        pairs = [
+            # assert th.steps[step.parentId], f"Parent step {step.parentId} not found"
+            QARow.from_lai_steps2(thread=th, question_step=steps[step.parent_id], answer_step=step)
+            for step in th.steps
+            if step.parent_id
+        ]
+        for pair in pairs:
+            qa_pairs.append(pair)
+            print(json.dumps(pair, indent=2))
+
+    # import pdb; pdb.set_trace()
+    fields = QARow._fields  # ["thread_id", "question", "answer", "lai_link"]
+    with open("lai_pairs.csv", "w", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for pair in qa_pairs:
+            writer.writerow({k: getattr(pair, k, "") for k in fields})
+
+
+# def json_to_csv(json_obj: dict):
+#     # import pdb; pdb.set_trace()
+#     threads = [LaiThread.from_json(thread_obj) for thread_obj in json_obj["data"]]
+#     qa_pairs = []
+#     for th in threads:
+#         # print(json.dumps(th, indent=2))
+#         # print(list(json_obj.keys()))
+
+#         pairs = [
+#             QARow.from_lai_steps(
+#                 thread=th, question_step=th.steps[step.parentId], answer_step=step
+#             )
+#             for step in th.steps.values()
+#             if step.parentId
+#         ]
+#         for pair in pairs:
+#             qa_pairs.append(pair)
+#             print(json.dumps(pair, indent=2))
+
+#     fields = ["thread_id", "question", "answer"]
+#     with open("lai_pairs.csv", "w", encoding="utf-8") as f:
+#         writer = csv.DictWriter(f, fieldnames=fields)
+#         writer.writeheader()
+#         for pair in qa_pairs:
+#             writer.writerow({k: getattr(pair, k, "") for k in fields})
+
+
+def query():
+    client = literalai()
+    date = datetime.fromisoformat("2025-03-05T00:00:00.000Z")
+    query_threads_since(client, date)
+
+
+def load_response() -> list[Thread]:
+    # with open("response.json", "r") as f:
+    #     return json.load(f)
+    with open("response.pickle", "rb") as file:
+        return pickle.load(file)
+
+
+if False:
+    query()
+    client = literalai()
+    project_id = client.api.get_my_project_id()
+    print(project_id)
+else:
+    project_id = "Decision-Support-Tool---Imagine-LA-FEcqNEkhUJ71"
+    # project_id="PROD-Decision-Support-Tool---Imagine-LA-Zu5f2WjplboI"
+to_csv(load_response())

--- a/app/tests/src/evaluation/test_literalai_exporter.py
+++ b/app/tests/src/evaluation/test_literalai_exporter.py
@@ -1,0 +1,122 @@
+import logging
+from datetime import datetime
+from io import StringIO
+from unittest.mock import MagicMock
+
+import pytest
+from literalai import Step, Thread
+from literalai.my_types import PageInfo
+
+from src.evaluation import literalai_exporter
+from src.evaluation.literalai_exporter import (
+    convert_to_qa_rows,
+    get_project_id,
+    query_threads,
+    save_csv,
+)
+
+THREADS = [Thread(f"th_{i}") for i in range(18)]
+
+
+class MockLiteralAIApi:
+    def __init__(self):
+        self.get_threads_counter = 0
+        self.responses = [THREADS[:5], THREADS[5:10], THREADS[10:]]
+
+    def get_my_project_id(self):
+        return "Test_Project_1234ABC"
+
+    def get_threads(self, filters=None, **kwargs):
+        threads = self.responses[self.get_threads_counter]
+        self.get_threads_counter += 1
+
+        response = MagicMock()
+        response.data = threads
+        response.totalCount = len(THREADS)
+        response.pageInfo = PageInfo(
+            hasNextPage=threads != self.responses[-1],
+            startCursor=threads[0].id,
+            endCursor=threads[-1].id,
+        )
+        return response
+
+
+@pytest.fixture
+def literalai_client(monkeypatch):
+    mock_lai_client = MagicMock()
+    mock_lai_client.api = MockLiteralAIApi()
+    monkeypatch.setattr(literalai_exporter, "literalai", lambda: mock_lai_client)
+
+
+def test_get_project_id(literalai_client):
+    assert get_project_id() == "Test_Project_1234ABC"
+
+
+def test_query_threads(literalai_client):
+    start_date = datetime.fromisoformat("2025-03-06")
+    end_date = datetime.fromisoformat("2025-03-07")
+    threads = query_threads(start_date, end_date)
+    assert len(threads) == len(THREADS)
+
+
+def create_threads(num: int) -> list[Thread]:
+    threads = []
+    for i in range(num):
+        th = Thread(f"th_{i}")
+        q_step = Step(type="user_message")
+        q_step.output = {"content": "Q1"}
+        q_step.metadata = {
+            "request": {"user_id": "U1", "agency_id": "Agency1", "session_id": "sesh1"}
+        }
+        a_step = Step(type="assistant_message", parent_id=q_step.id)
+        a_step.output = {"content": "A1"}
+        a_step.metadata = {
+            "attributes": {
+                "benefit_program": "prog1",
+                "chat_history": [],
+                "citations": [
+                    {"uri": "uri1", "source_dataset": "dataset1", "source_name": "title1"}
+                ],
+            }
+        }
+        th.steps = [
+            q_step,
+            a_step,
+        ]
+        threads.append(th)
+    return threads
+
+
+def append_dangling_step(thread: Thread):
+    step = Step(type="user_message")
+    step.output = {"content": "Q1"}
+    step.metadata = {"request": {"user_id": "U1", "agency_id": "Agency1", "session_id": "sesh1"}}
+    assert thread.steps
+    thread.steps.append(step)
+    return step
+
+
+def test_convert_to_qa_rows_and_save_csv(caplog):
+    threads = create_threads(3)
+    dangling_step = append_dangling_step(threads[1])
+    project_id = "Test_Project_1234ABC"
+    with caplog.at_level(logging.INFO):
+        qa_rows = convert_to_qa_rows(project_id, threads)
+    assert len(qa_rows) == 3
+    assert f"Ignoring dangling step {dangling_step.id!r}"
+
+    mock_csv_file = StringIO()
+    save_csv(qa_rows, mock_csv_file)
+    mock_csv_file.seek(0)
+    csv_lines = mock_csv_file.readlines()
+    print("".join(csv_lines))
+    assert len(csv_lines) == 4
+
+    # Roughly check the contents of the CSV file
+    assert (
+        "thread_id,question_id,timestamp,user_id,agency_id,session_id,question,answer,program,citation_links,citation_sources,has_chat_history"
+        in csv_lines[0]
+    )
+    for line in csv_lines[1:]:
+        assert line.startswith("Test_Project_1234ABC,th_")
+        assert ",U1,Agency1,sesh1,Q1,A1,prog1," in line

--- a/app/tests/src/evaluation/test_literalai_exporter.py
+++ b/app/tests/src/evaluation/test_literalai_exporter.py
@@ -88,6 +88,7 @@ def create_threads(num: int) -> list[Thread]:
 
 
 def append_dangling_step(thread: Thread):
+    "A dangling step is not referenced in a question-answer pair"
     step = Step(type="user_message")
     step.output = {"content": "Q1"}
     step.metadata = {"request": {"user_id": "U1", "agency_id": "Agency1", "session_id": "sesh1"}}
@@ -118,5 +119,6 @@ def test_convert_to_qa_rows_and_save_csv(caplog):
         in csv_lines[0]
     )
     for line in csv_lines[1:]:
-        assert line.startswith("Test_Project_1234ABC,th_")
+        assert line.startswith(f"{project_id},th_")
+        # Check for metadata
         assert ",U1,Agency1,sesh1,Q1,A1,prog1," in line


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-804


## Changes

* Add `literalai_exporter.py` to export QA pairs from LiteralAI logs
* Only logs associated with API calls are exported

## Testing

Unit tests

Set `LITERAL_API_KEY` environment variable from [LiteralAI](https://cloud.getliteral.ai/projects/household-guru-ipuYd1J0Pnoz/settings?apiKeys-sorting=%5B%7B%22id%22%3A%22createdAt%22%2C%22desc%22%3Atrue%7D%5D&apiKeys-filter=%5B%5D)

```
LITERAL_API_KEY=... make literalai-exporter args="2025-03-05 2025-03-07"
```

Verify `lai_pairs.csv` output file.