### PR TITLE
fix: LiteralAI exporter: handle threads without citation.source_dataset

### DIFF
--- a/app/src/evaluation/literalai_exporter.py
+++ b/app/src/evaluation/literalai_exporter.py
@@ -121,7 +121,9 @@ class QARow(NamedTuple):
             program=attribs["benefit_program"] if attribs else None,
             citation_links=("\n".join(c["uri"] for c in citations) if citations else None),
             citation_sources=(
-                "\n".join(f"{c.get('source_dataset', '')}: {c.get('source_name', '')}" for c in citations)
+                "\n".join(
+                    f"{c.get('source_dataset', '')}: {c.get('source_name', '')}" for c in citations
+                )
                 if citations
                 else None
             ),

--- a/app/src/evaluation/literalai_exporter.py
+++ b/app/src/evaluation/literalai_exporter.py
@@ -121,7 +121,7 @@ class QARow(NamedTuple):
             program=attribs["benefit_program"] if attribs else None,
             citation_links=("\n".join(c["uri"] for c in citations) if citations else None),
             citation_sources=(
-                "\n".join(f"{c['source_dataset']}: {c['source_name']}" for c in citations)
+                "\n".join(f"{c.get('source_dataset', '')}: {c.get('source_name', '')}" for c in citations)
                 if citations
                 else None
             ),


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1741804943062599)

## Changes

For LiteralAI exporter, handle (old) threads without `citation.source_dataset`

## Testing

```
make literalai-exporter args="2024-07-01 2025-03-12"
```