### PR TITLE
feat: Utility to auto-tag LiteralAI threads based on user_id

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -308,3 +308,6 @@ literalai-exporter:
 
 literalai-archiver:
 	$(PY_RUN_CMD) literalai-archiver $(args)
+
+literalai-tagger:
+	$(PY_RUN_CMD) literalai-tagger $(args)

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -74,6 +74,7 @@ init-schema = "src.db.manage:main"
 pg-dump = "src.db.pg_dump_util:main"
 literalai-exporter = "src.evaluation.literalai_exporter:main"
 literalai-archiver = "src.util.literalai_util:archive_threads"
+literalai-tagger = "src.util.literalai_util:tag_threads"
 
 scrape-edd-web = "src.ingestion.scrape_edd_web:main"
 ingest-imagine-la = "src.ingestion.imagine_la.ingest:main"

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -25,6 +25,16 @@ logger = logging.getLogger(__name__)
 require_login()
 
 
+@cl.set_chat_profiles
+async def chat_profiles() -> list[cl.ChatProfile]:
+    return [
+        cl.ChatProfile(
+            name="chainlit",
+            markdown_description="Default profile. Threads will be auto-tagged with the profile name.",
+        ),
+    ]
+
+
 @cl.on_chat_start
 async def start() -> None:
     url = cl.user_session.get("http_referer")
@@ -55,10 +65,11 @@ async def start() -> None:
         ).send()
 
     user = cl.user_session.get("user")
+    chat_profile = cl.user_session.get("chat_profile")
     await cl.Message(
         author="backend",
         metadata={"engine": engine_id, "settings": settings},
-        content=f"{engine.name} started {f'for {user}' if user else ''}",
+        content=f"{engine.name} started {f'for {user}' if user else ''} (using {chat_profile!r} profile)",
     ).send()
 
 
@@ -167,6 +178,7 @@ _WIDGET_FACTORIES = {
 }
 
 
+# TODO: Try cl.chat_context.to_openai() to get the conversation in OpenAI format
 def extract_raw_chat_history(messages: list[cl.Message]) -> ChatHistory:
     raw_chat_history: ChatHistory = []
     for message in messages:

--- a/app/src/util/literalai_util.py
+++ b/app/src/util/literalai_util.py
@@ -54,12 +54,14 @@ def query_threads_between(start_date: datetime, end_date: datetime) -> list[Thre
     ]
     return get_threads(filters)
 
+
 def query_untagged_threads(user_ids: list[str]) -> list[Thread]:
     filters: list[Filter] = [
         Filter(field="participantIdentifiers", operator="in", value=user_ids),
         Filter(field="tags", operator="is", value=None),
     ]
     return get_threads(filters)
+
 
 def tag_threads_by_user(threads: list[Thread], user2tag: dict[str, str]) -> None:
     lai_client = client()
@@ -70,6 +72,7 @@ def tag_threads_by_user(threads: list[Thread], user2tag: dict[str, str]) -> None
         new_tag = user2tag[th.participant_identifier]
         lai_client.api.update_thread(th.id, tags=[new_tag])
         logger.info("Tagged thread %r with %r", th.id, new_tag)
+
 
 def save_threads(threads: list[Thread], basefilename: str) -> None:  # pragma: no cover
     with open(f"{basefilename}.pickle", "wb") as file:
@@ -119,7 +122,6 @@ def archive_threads() -> None:  # pragma: no cover
     logger.info("REMINDER: Upload the JSON file to the 'LiteralAI logs' Google Drive folder")
 
 
-
 def tag_threads() -> None:  # pragma: no cover
     # Configure logging since this function is run directly
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -131,7 +133,10 @@ def tag_threads() -> None:  # pragma: no cover
 
     input_json = "literalai_user_tags.json"
     if not os.path.exists(input_json):
-        logger.error("Missing input file %r. Download from the 'LiteralAI logs' Google Drive folder.", input_json)
+        logger.error(
+            "Missing input file %r. Download from the 'LiteralAI logs' Google Drive folder.",
+            input_json,
+        )
         sys.exit(4)
 
     with open(input_json, "r", encoding="utf-8") as f:
@@ -146,4 +151,3 @@ def tag_threads() -> None:  # pragma: no cover
             logger.info("%s (%s) %s %r", th.id, th.created_at, th.participant_identifier, th.tags)
         if not args.dry_run:
             tag_threads_by_user(threads, user2tag)
-


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-857
[Slack](https://nava.slack.com/archives/C06ETE82UHM/p1741801462799589?thread_ts=1741799299.480569&cid=C06ETE82UHM)

## Changes

Add utility to auto-tag LiteralAI threads based on user_id

## Testing

Download `literalai_user_tags.json` from the ['LiteralAI logs' Google Drive folder](https://drive.google.com/drive/folders/1Me71t3HnBWpNGdLF7IXsv-qPTL5ZaSz6).

Set `LITERAL_API_KEY` env var for the prod or dev env
```
make literalai-tagger args="--dry-run"
make literalai-tagger
```

LiteralAI UI shows tags:
<img width="109" alt="image" src="https://github.com/user-attachments/assets/0f8bd187-1831-46e2-b078-0951adda4deb" />
