### PR TITLE
fix: LiteralAI exporter: ignore chainlit message

### DIFF
--- a/app/src/evaluation/literalai_exporter.py
+++ b/app/src/evaluation/literalai_exporter.py
@@ -56,7 +56,7 @@ class QARow(NamedTuple):
         # start_time can also be used to distinguish question-answer pairs
         assert question_step.start_time, "Question step start_time must not be None"
 
-        assert question_step.type == "user_message", "Question step must be a user_message"
+        assert question_step.type == "user_message", f"Question step must be a user_message, not {question_step.type!r}"
         assert answer_step.type == "assistant_message", "Answer step must be an assistant_message"
 
         # output["content"] is the text shown in the chatbot UI
@@ -99,6 +99,9 @@ def convert_to_qa_rows(project_id: str, threads: list[Thread]) -> list[QARow]:
     for th in threads:
         if not th.steps:
             logger.warning("Thread %r has no steps", th.id)
+            continue
+        if th.tags and "chainlit" in th.tags:
+            logger.info("Skipping thread %r with chainlit tag", th.id)
             continue
         logger.info("Thread %r has %r steps", th.id, len(th.steps))
         steps = {step.id: step for step in th.steps}

--- a/app/src/evaluation/literalai_exporter.py
+++ b/app/src/evaluation/literalai_exporter.py
@@ -56,7 +56,9 @@ class QARow(NamedTuple):
         # start_time can also be used to distinguish question-answer pairs
         assert question_step.start_time, "Question step start_time must not be None"
 
-        assert question_step.type == "user_message", f"Question step must be a user_message, not {question_step.type!r}"
+        assert (
+            question_step.type == "user_message"
+        ), f"Question step must be a user_message, not {question_step.type!r}"
         assert answer_step.type == "assistant_message", "Answer step must be an assistant_message"
 
         # output["content"] is the text shown in the chatbot UI


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1742320270627999)

LiteralAI exporter is erroring due to our upgrade of chainlit, which now creates a different thread tree than it did before, i.e., it's now creating more parent steps than it didn't before.

## Changes

Skip LiteralAI threads tagged with `chainlit`.

## Testing
Set the prod `LITERAL_API_KEY` and run:
```
make literalai-exporter args="2025-01-16 2025-03-19"
```

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-271-app-dev-721484110.us-east-1.elb.amazonaws.com
- Deployed commit: bb9e71cbad09e9a0d0f06bbc03d3d30d228d738d
<!-- app - end PR environment info -->