### PR TITLE
refactor: API: use ContextVar for db_session

### DIFF
--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -11,7 +11,7 @@ import uuid
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, Optional, Sequence
+from typing import Any, AsyncGenerator, Generator, Optional, Sequence
 
 from asyncer import asyncify
 from fastapi import APIRouter, HTTPException, Request, Response
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
-async def lifespan(_app: APIRouter):
+async def lifespan(_app: APIRouter) -> AsyncGenerator[Any, None]:
     logger.info("Initializing API")
     yield
     logger.info("Cleaning up API")
@@ -165,7 +165,7 @@ dbsession: ContextVar[db.Session] = ContextVar("db_session", default=app_config.
 
 
 @contextmanager
-def db_session_context_var():
+def db_session_context_var() -> Generator[db.Session, None, None]:
     with app_config.db_session() as db_session:
         token = dbsession.set(db_session)
         try:
@@ -373,7 +373,7 @@ async def query(request: QueryRequest) -> QueryResponse:
     return response
 
 
-def store_thread_id(session, thread_id):
+def store_thread_id(session: ChatSession, thread_id: str | None) -> None:
     # Update the DB with the LiteralAI thread ID, regardless of other DB updates,
     # so do this is its own DB transaction.
     # lai_thread_id is None when request.new_session=True

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Generator, Optional, Sequence
 
 from asyncer import asyncify
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from literalai import AsyncLiteralClient, Message
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
-async def lifespan(_app: APIRouter) -> AsyncGenerator[Any, None]:
+async def lifespan(_app: FastAPI) -> AsyncGenerator[Any, None]:
     logger.info("Initializing API")
     yield
     logger.info("Cleaning up API")

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -128,7 +128,9 @@ async def _get_chat_session(
     # Ensure user exists in Literal AI
     literalai_user = await literalai().api.get_or_create_user(user_id, user_meta)
     # Set the LiteralAI user ID for this session so it can be used in literalai().thread()
-    chat_session = __get_or_create_chat_session(user_id, session_id, literalai_user_id=literalai_user.id)
+    chat_session = __get_or_create_chat_session(
+        user_id, session_id, literalai_user_id=literalai_user.id
+    )
     logger.info(
         "Session %r (user %r): LiteralAI thread_id=%s",
         session_id,

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -8,6 +8,8 @@ import functools
 import logging
 import time
 import uuid
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 
@@ -18,6 +20,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 
 from src import chat_engine
+from src.adapters import db
 from src.app_config import app_config
 from src.chat_engine import ChatEngineInterface
 from src.citations import simplify_citation_numbers
@@ -28,7 +31,17 @@ from src.healthcheck import HealthCheck, health
 from src.util.string_utils import format_highlighted_uri
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/api", tags=["Chat API"])
+
+
+@asynccontextmanager
+async def lifespan(_app: APIRouter):
+    logger.info("Initializing API")
+    yield
+    logger.info("Cleaning up API")
+    # Clean up
+
+
+router = APIRouter(prefix="/api", tags=["Chat API"], lifespan=lifespan)
 
 
 @router.get("/healthcheck")
@@ -85,17 +98,14 @@ def __get_or_create_chat_session(
             chat_engine_settings=ChatEngineSettings(user_session.chat_engine_id),
             allowed_engines=["imagine-la"],
         )
-    with (
-        app_config.db_session() as db_session,
-        db_session.begin(),  # session is auto-committed or rolled back upon exception
-    ):
+    with dbsession.get().begin():  # session is auto-committed or rolled back upon exception
         user_session = UserSession(
             session_id=session_id or str(uuid.uuid4()),
             user_id=user_id,
             chat_engine_id="imagine-la",
             lai_thread_id=None,
         )
-        db_session.add(user_session)
+        dbsession.get().add(user_session)
 
     session = ChatSession(
         user_session=user_session,
@@ -118,9 +128,8 @@ async def _get_chat_session(
     # Ensure user exists in Literal AI
     literalai_user = await literalai().api.get_or_create_user(user_id, user_meta)
     # Set the LiteralAI user ID for this session so it can be used in literalai().thread()
-    chat_session = __get_or_create_chat_session(
-        user_id, session_id, literalai_user_id=literalai_user.id
-    )
+    user_uuid = literalai_user.id  # str(uuid.uuid4())  # FIXME
+    chat_session = __get_or_create_chat_session(user_id, session_id, literalai_user_id=user_uuid)
     logger.info(
         "Session %r (user %r): LiteralAI thread_id=%s",
         session_id,
@@ -133,15 +142,18 @@ async def _get_chat_session(
 def _load_user_session(session_id: str | None) -> Optional[UserSession]:
     if not session_id:
         return None
-    with app_config.db_session() as db_session:
-        return db_session.scalars(
-            select(UserSession).where(UserSession.session_id == session_id)
-        ).first()
+    with dbsession.get().begin():
+        logger.info("Loading user session %r", session_id)
+        return (
+            dbsession.get()
+            .scalars(select(UserSession).where(UserSession.session_id == session_id))
+            .first()
+        )
 
 
 def _load_chat_history(user_session: UserSession) -> ChatHistory:
-    with app_config.db_session() as db_session:
-        db_user_session = db_session.merge(user_session)
+    with dbsession.get().begin():
+        db_user_session = dbsession.get().merge(user_session)
         session_msgs = db_user_session.chat_messages
         return [{"role": message.role, "content": message.content} for message in session_msgs]
 
@@ -149,27 +161,56 @@ def _load_chat_history(user_session: UserSession) -> ChatHistory:
 # endregion
 # region: ===================  Example API Endpoint and logging to LiteralAI  ===================
 
+dbsession: ContextVar[db.Session] = ContextVar("db_session", default=app_config.db_session())
+
+
+@contextmanager
+def db_session_context_var():
+    with app_config.db_session() as db_session:
+        token = dbsession.set(db_session)
+        try:
+            # Use dbsession.get() to get the session without having to pass it to nested functions.
+            # Use `with dbsession.get().begin():` to auto-committed or rolled back upon exception.
+            yield db_session
+            db_session.commit()
+        finally:
+            db_session.close()
+            dbsession.reset(token)
+
+
+def wait_for_event(_db_session):
+    pass
+
 
 # Make sure to use async functions for faster responses
 @router.get("/engines")
-async def engines(user_id: str) -> list[str]:
+async def engines(user_id: str, session_id: str | None = None) -> list[str]:
     # async def engines(user_id: Annotated[str, Query(min_length=1)]) -> list[str]:
-    session = await _get_chat_session(user_id, None)
-    # Example of using Literal AI to log the request and response
-    with literalai().thread(name="API:/engines", participant_id=session.literalai_user_id):
-        request_msg = literalai().message(
-            content="List chat engines", type="user_message", name=user_id
-        )
-        # This will show up as a separate step in LiteralAI, showing input and output
-        with literalai().step(type="tool"):
-            response = [
-                engine
-                for engine in chat_engine.available_engines()
-                if engine in session.allowed_engines
-            ]
-        # Example of using parent_id to have a hierarchy of messages in Literal AI
-        literalai().message(content=str(response), type="system_message", parent_id=request_msg.id)
-    return response
+    with db_session_context_var():
+        wait_for_event(dbsession.get())
+
+        session = await _get_chat_session(user_id, session_id)
+        thread_name = "API:/engines" if not session.user_session.lai_thread_id else None
+
+        # Example of using Literal AI to log the request and response
+        with literalai().thread(name=thread_name, participant_id=session.literalai_user_id):
+            request_msg = literalai().message(
+                content="List chat engines", type="user_message", name=user_id
+            )
+            assert request_msg.thread_id
+            store_thread_id(session, request_msg.thread_id)
+            # This will show up as a separate step in LiteralAI, showing input and output
+            with literalai().step(type="tool"):
+                response = [
+                    engine
+                    for engine in chat_engine.available_engines()
+                    if engine in session.allowed_engines
+                ]
+            # Example of using parent_id to have a hierarchy of messages in Literal AI
+            literalai().message(
+                content=str(response), type="system_message", parent_id=request_msg.id
+            )
+        return response
 
 
 class FeedbackRequest(BaseModel):
@@ -265,86 +306,91 @@ def get_chat_engine(session: ChatSession) -> ChatEngineInterface:
 
 @router.post("/query")
 async def query(request: QueryRequest) -> QueryResponse:
-    start_time = time.perf_counter()
+    with db_session_context_var() as db_session:
+        start_time = time.perf_counter()
 
-    user_meta = {"agency_id": request.agency_id, "beneficiary_id": request.beneficiary_id}
-    session = await _get_chat_session(request.user_id, request.session_id, user_meta)
-    _validate_session_against_literalai(request, session)
+        user_meta = {"agency_id": request.agency_id, "beneficiary_id": request.beneficiary_id}
+        session = await _get_chat_session(request.user_id, request.session_id, user_meta)
+        _validate_session_against_literalai(request, session)
 
-    # Load history BEFORE adding the new message to the DB
-    chat_history = _load_chat_history(session.user_session)
-    _validate_chat_history(request, chat_history)
+        # Load history BEFORE adding the new message to the DB
+        chat_history = _load_chat_history(session.user_session)
+        _validate_chat_history(request, chat_history)
 
-    thread_name = None
-    # Only if new session, set the LiteralAI thread name; don't want the thread name to change otherwise
-    if request.new_session:
-        thread_name = request.message.strip().splitlines()[0] or "API:/query"
+        thread_name = None
+        # Only if new session, set the LiteralAI thread name; don't want the thread name to change otherwise
+        if request.new_session:
+            thread_name = request.message.strip().splitlines()[0] or "API:/query"
 
-    with literalai().thread(
-        name=thread_name,
-        participant_id=session.literalai_user_id,
-        thread_id=session.user_session.lai_thread_id,
-    ):
-        # Log the message to LiteralAI
-        request_msg = literalai().message(
-            content=request.message,
-            type="user_message",
-            name=request.session_id,
-            metadata={
-                "request": request.__dict__,
-                "user_id": session.user_session.user_id,
-            },
-        )
-        _validate_literalai_message(session, request_msg)
-
-        with app_config.db_session() as db_session, db_session.begin():
-            # Update the DB with the LiteralAI thread ID, regardless of other DB updates,
-            # so do this is its own DB transaction.
-            # lai_thread_id is None when request.new_session=True
-            # A thread_id is not created until the first message logged in LiteralAi
-            if not session.user_session.lai_thread_id and request_msg.thread_id:
-                session.user_session.lai_thread_id = request_msg.thread_id
-                logger.info(
-                    "Started new session with thread_id: %s",
-                    session.user_session.lai_thread_id,
-                )
-                db_session.merge(session.user_session)
-
-        engine = get_chat_engine(session)
-        response, metadata = await run_query(engine, request.message, chat_history)
-
-        # Example of using parent_id to have a hierarchy of messages in Literal AI
-        response_msg = literalai().message(
-            content=response.response_text,
-            type="assistant_message",
-            parent_id=request_msg.id,
-            metadata={
-                "citations": [c.__dict__ for c in response.citations],
-                "chat_history": chat_history,
-            }
-            | metadata,
-        )
-        # id needed to later provide feedback on this message in LiteralAI
-        response.response_id = response_msg.id
-
-    duration = time.perf_counter() - start_time
-    logger.info(f"Total /query endpoint execution took {duration:.2f} seconds")
-
-    # If successful, update the DB; otherwise the DB will contain questions without responses
-    with app_config.db_session() as db_session, db_session.begin():
-        # Now, add request and response messages to DB
-        db_session.add(
-            ChatMessage(session_id=request.session_id, role="user", content=request.message)
-        )
-        db_session.add(
-            ChatMessage(
-                session_id=request.session_id,
-                role="assistant",
-                content=response.response_text,
+        with literalai().thread(
+            name=thread_name,
+            participant_id=session.literalai_user_id,
+            thread_id=session.user_session.lai_thread_id,
+        ):
+            # Log the message to LiteralAI
+            request_msg = literalai().message(
+                content=request.message,
+                type="user_message",
+                name=request.session_id,
+                metadata={
+                    "request": request.__dict__,
+                    "user_id": session.user_session.user_id,
+                },
             )
-        )
+            _validate_literalai_message(session, request_msg)
+
+            store_thread_id(session, request_msg.thread_id)
+
+            engine = get_chat_engine(session)
+            response, metadata = await run_query(engine, request.message, chat_history)
+
+            # Example of using parent_id to have a hierarchy of messages in Literal AI
+            response_msg = literalai().message(
+                content=response.response_text,
+                type="assistant_message",
+                parent_id=request_msg.id,
+                metadata={
+                    "citations": [c.__dict__ for c in response.citations],
+                    "chat_history": chat_history,
+                }
+                | metadata,
+            )
+            # id needed to later provide feedback on this message in LiteralAI
+            response.response_id = response_msg.id
+
+        duration = time.perf_counter() - start_time
+        logger.info(f"Total /query endpoint execution took {duration:.2f} seconds")
+
+        # If successful, update the DB; otherwise the DB will contain questions without responses
+        with db_session.begin():
+            # Now, add request and response messages to DB
+            db_session.add(
+                ChatMessage(session_id=request.session_id, role="user", content=request.message)
+            )
+            db_session.add(
+                ChatMessage(
+                    session_id=request.session_id,
+                    role="assistant",
+                    content=response.response_text,
+                )
+            )
 
     return response
+
+
+def store_thread_id(session, thread_id):
+    # Update the DB with the LiteralAI thread ID, regardless of other DB updates,
+    # so do this is its own DB transaction.
+    # lai_thread_id is None when request.new_session=True
+    # A thread_id is not created until the first message logged in LiteralAi
+    if not session.user_session.lai_thread_id and thread_id:
+        with dbsession.get().begin():
+            session.user_session.lai_thread_id = thread_id
+            logger.info(
+                "Started new session with thread_id: %s",
+                session.user_session.lai_thread_id,
+            )
+            dbsession.get().merge(session.user_session)
 
 
 def _validate_session_against_literalai(request: QueryRequest, session: ChatSession) -> None:

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -178,17 +178,15 @@ def db_session_context_var():
             dbsession.reset(token)
 
 
-def wait_for_event(_db_session):
+async def wait_for_event(_db_session):
     pass
 
-
+import asyncio
 # Make sure to use async functions for faster responses
 @router.get("/engines")
 async def engines(user_id: str, session_id: str | None = None) -> list[str]:
     # async def engines(user_id: Annotated[str, Query(min_length=1)]) -> list[str]:
     with db_session_context_var():
-        wait_for_event(dbsession.get())
-
         session = await _get_chat_session(user_id, session_id)
         thread_name = "API:/engines" if not session.user_session.lai_thread_id else None
 
@@ -210,6 +208,9 @@ async def engines(user_id: str, session_id: str | None = None) -> list[str]:
             literalai().message(
                 content=str(response), type="system_message", parent_id=request_msg.id
             )
+        logger.info("waiting: %r", dbsession.get())
+        await asyncio.create_task(wait_for_event(dbsession.get()))
+        # logger.info("waiting done")
         return response
 
 

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -1,12 +1,14 @@
 import logging
+import pytest
+
 from contextlib import contextmanager
 from typing import Optional
 from unittest.mock import MagicMock
 
-import pytest
 from fastapi import HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from literalai import Score
 from literalai.observability.step import ScoreType
 
@@ -71,19 +73,134 @@ class MockLiteralAIApi:
 
 
 @pytest.fixture
-def client(monkeypatch):
-    lai_mock = MockLiteralAI()
-    monkeypatch.setattr(chat_api, "literalai", lambda: lai_mock)
+def mock_lai(monkeypatch):
+    monkeypatch.setattr(chat_api, "literalai", lambda: MockLiteralAI())
+    logger.info("Mocked literalai")
+
+
+@pytest.fixture
+def client(mock_lai, db_session):  # mock LiteralAI when testing API
     return TestClient(router)
 
 
-def test_api_engines(client, db_session):
+@pytest.fixture
+def async_client(mock_lai, db_session):  # mock LiteralAI when testing API
+    return AsyncClient(transport=ASGITransport(app=router), base_url="http://test")
+
+
+def test_api_engines(client):
     response = client.get("/api/engines?user_id=TestUser")
     assert response.status_code == 200
     assert response.json() == ["imagine-la"]
 
 
-def test_api_query(monkeypatch, client, db_session):
+import asyncio
+import concurrent.futures
+import threading
+import time
+
+from asyncer import asyncify
+
+logger = logging.getLogger(__name__)
+
+# from unittest.mock import AsyncMock
+
+
+def print_tasks(sleep=0):
+    print("Sleeping")
+    time.sleep(sleep)
+    print("Awake")
+    all_tasks = asyncio.all_tasks()
+    # print("All tasks:", len(all_tasks))
+    pending_tasks = [task for task in all_tasks if not task.done()]
+    if True or len(pending_tasks) > 1:
+        print("== Pending tasks:", len(pending_tasks))
+        for i, task in enumerate(pending_tasks):
+            print("-- Pending task", i, task.get_loop())
+            print("  Coro: ", task.get_coro())
+            # task.print_stack()
+        # time.sleep(20)
+
+
+@pytest.mark.asyncio
+async def test_contextvar_dbsession(async_client, monkeypatch):
+    event = threading.Event()
+
+    async def wait_until_tested(db_session):
+        # print("--")
+        # logger.info("waiting: %r", db_session)
+        event.wait()
+        logger.info("waiting done")
+
+    monkeypatch.setattr(chat_api, "wait_for_event", wait_until_tested)
+    monkeypatch.setattr("src.chat_api.wait_for_event", wait_until_tested)
+
+    async def checker_coroutine():
+        logger.info("checker_coroutine waiting for 5 seconds")
+        # await asyncio.sleep(5)
+        time.sleep(3)
+        logger.info("event.set()")
+        event.set()
+
+    async with async_client:
+    # async with AsyncClient(transport=ASGITransport(app=router), base_url="http://test") as async_client1:
+        call1 = async_client.get("/api/engines?user_id=TestUser1")
+        call2 = async_client.get("/api/engines?user_id=TestUser2")
+        checker = checker_coroutine()
+
+        tasks = [asyncio.create_task(call) for call in [call1, call2, checker]]
+        # asyncio.create_task(asyncify(print_tasks)(8))
+
+        results = await asyncio.gather(*tasks)
+        logger.info(results)
+
+    assert "Forced" is False
+    # assert response.status_code == 200
+
+    # async with AsyncClient(transport=ASGITransport(app=router), base_url="http://test") as client:
+    #     results = await asyncio.gather(
+    #         client.get("/api/engines?user_id=TestUserA"),
+    #         client.get("/api/engines?user_id=TestUserB"),
+    #         # make_request(client, "/api/engines?user_id=TestUserA"),
+    #         # make_request(client, "/api/engines?user_id=TestUserB"),
+    #     )
+    #     print(f"Request results: {results}")
+
+
+@pytest.mark.asyncio
+async def Atest_contextvar_db_oldclient(client, monkeypatch):
+    event = threading.Event()
+
+    async def wait_until_tested(db_session):
+        logger.info("waiting: %r", db_session)
+        event.wait()
+        logger.info("waiting done")
+
+    monkeypatch.setattr(chat_api, "wait_for_event", wait_until_tested)
+
+    async def checker_coroutine():
+        logger.info("asyncio waiting for 5 seconds")
+        # await asyncio.sleep(5)
+        time.sleep(3)
+        logger.info("event.set()")
+        event.set()
+
+    # ensure that the TestClient and the application share the same event loop
+    # with client:
+    call1 = asyncify(lambda: client.get("/api/engines?user_id=TestUser1"))
+    call2 = asyncify(lambda: client.get("/api/engines?user_id=TestUser2"))
+    checker = checker_coroutine  # asyncify(check_vars)
+
+    tasks = [asyncio.create_task(call()) for call in [call1, call2, checker]]
+    results = await asyncio.gather(*tasks)
+    logger.info(results)
+
+    assert "Forced" is False
+    # assert response.status_code == 200
+    # assert response.json() == ["imagine-la"]
+
+
+def test_api_query(monkeypatch, client):
     async def mock_run_query(engine, question, chat_history):
         return (
             QueryResponse(
@@ -144,7 +261,7 @@ def test_api_query(monkeypatch, client, db_session):
 
 
 """
-def test_api_query__empty_user_id(monkeypatch, client, db_session):
+def test_api_query__empty_user_id(monkeypatch, client):
     try:
         client.post(
             "/api/query",
@@ -164,7 +281,7 @@ def test_api_query__empty_user_id(monkeypatch, client, db_session):
 """
 
 
-def test_api_query__nonexistent_session_id(monkeypatch, client, db_session):
+def test_api_query__nonexistent_session_id(monkeypatch, client):
     try:
         client.post(
             "/api/query",
@@ -181,7 +298,7 @@ def test_api_query__nonexistent_session_id(monkeypatch, client, db_session):
         assert e.detail == "LiteralAI thread ID for existing session 'NewSession999' not found"
 
 
-def test_api_query__bad_request(client, db_session):
+def test_api_query__bad_request(client):
     try:
         client.post(
             "/api/query", json={"user_id": "user7", "session_id": "Session0", "new_session": True}
@@ -309,7 +426,7 @@ def test_get_chat_engine_not_allowed():
         get_chat_engine(session)
 
 
-def test_post_feedback_success(client, db_session):
+def test_post_feedback_success(client):
     response = client.post(
         "/api/feedback",
         json={
@@ -324,7 +441,7 @@ def test_post_feedback_success(client, db_session):
     assert response.status_code == 200
 
 
-def test_post_feedback_fail(monkeypatch, client, db_session):
+def test_post_feedback_fail(monkeypatch, client):
     try:
         client.post(
             "/api/feedback",


### PR DESCRIPTION
## Ticket

Part 1 for https://navalabs.atlassian.net/browse/DST-867

## Changes

Instead of creating a new `db.PostgresDBClient()` instance for each new DB session, use the same `db_session` when responding to a request, without having to pass it as an argument through intermediate functions. So put a `db_session` instance in a `ContextVar` to be safe for threads and asyncio tasks.

Secondary purpose of PR is to understand how to use `ContextVar` since `chainlit.context` uses it. `chainlit.context` is needed for the next PR to use Chainlit's data layer in the `chat_api.py`.

## Testing

No change in behavior. Test with `curl` or http://localhost:8000/docs

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-272-app-dev-334197002.us-east-1.elb.amazonaws.com
- Deployed commit: 9728fb04e6126a6f4642d9008fb196e9b7e3e6d1
<!-- app - end PR environment info -->