### PR TITLE
fix: Update connection URL for deployed environments

### DIFF
--- a/app/src/adapters/db/clients/postgres_client.py
+++ b/app/src/adapters/db/clients/postgres_client.py
@@ -123,6 +123,12 @@ def generate_iam_auth_token(aws_region: str, host: str, port: int, user: str) ->
     return token
 
 
+def get_database_url() -> str:
+    conf = get_db_config()
+    conn = get_connection_parameters(conf)
+    return f"postgresql://{conn['user']}:{conn['password']}@{conn['host']}:{conn['port']}/{conn['dbname']}?search_path={conf.db_schema}"
+
+
 def verify_ssl(connection_info: Any) -> None:
     """Verify that the database connection is encrypted and log the SSL status."""
     ssl_status = "using SSL" if connection_info.pgconn.ssl_in_use else "not using SSL"

--- a/app/src/chainlit_data.py
+++ b/app/src/chainlit_data.py
@@ -11,18 +11,13 @@ from chainlit.logger import logger
 from chainlit.step import StepDict
 from chainlit.types import Feedback, PaginatedResponse, Pagination, ThreadDict, ThreadFilter
 from chainlit.user import PersistedUser, User
-from src.adapters.db.clients.postgres_config import PostgresDBConfig
+from src.adapters.db.clients.postgres_client import get_database_url
 
 
 def get_postgres_data_layer(database_url: str) -> ChainlitDataLayer:
     # See chainlit/data/__init__.py for storage_client options like S3
     storage_client = None
     return ChainlitDataLayer(database_url=database_url, storage_client=storage_client)
-
-
-def get_database_url() -> str:
-    conf = PostgresDBConfig()
-    return f"postgresql://{conf.username}:{conf.password}@{conf.host}:{conf.port}/{conf.name}?search_path={conf.db_schema}"
 
 
 def get_literal_data_layer(api_key: str) -> LiteralDataLayer:

--- a/app/tests/src/test_chainlit_data.py
+++ b/app/tests/src/test_chainlit_data.py
@@ -10,7 +10,8 @@ import chainlit as cl
 from chainlit.context import init_http_context
 from chainlit.data.chainlit_data_layer import ChainlitDataLayer
 from src import chainlit_data
-from src.chainlit_data import ChainlitPolyDataLayer, get_database_url, get_postgres_data_layer
+from src.adapters.db.clients.postgres_client import get_database_url
+from src.chainlit_data import ChainlitPolyDataLayer, get_postgres_data_layer
 from src.db.models.conversation import Element, Feedback, Step, Thread, User
 
 


### PR DESCRIPTION
## Ticket

n/a


## Changes
 - Use generated IAM token as password when in deployed environments


## Context for reviewers
 - Connection URLs were previously using an empty password in deployed envs


## Testing
 - Will confirm preview environment works when it's deployed
