### PR TITLE
fix: Correctly URL-encode special characters in the database password

### DIFF
--- a/app/src/adapters/db/clients/postgres_client.py
+++ b/app/src/adapters/db/clients/postgres_client.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any
+from urllib.parse import quote_plus
 
 import boto3
 import psycopg
@@ -126,7 +127,7 @@ def generate_iam_auth_token(aws_region: str, host: str, port: int, user: str) ->
 def get_database_url() -> str:
     conf = get_db_config()
     conn = get_connection_parameters(conf)
-    return f"postgresql://{conn['user']}:{conn['password']}@{conn['host']}:{conn['port']}/{conn['dbname']}?search_path={conf.db_schema}"
+    return f"postgresql://{conn['user']}:{quote_plus(conn['password'])}@{conn['host']}:{conn['port']}/{conn['dbname']}?search_path={conf.db_schema}"
 
 
 def verify_ssl(connection_info: Any) -> None:

--- a/app/tests/src/adapters/db/clients/test_postgres_client.py
+++ b/app/tests/src/adapters/db/clients/test_postgres_client.py
@@ -1,9 +1,14 @@
 import logging
 from dataclasses import dataclass
+from urllib.parse import quote_plus
 
 import pytest
 
-from src.adapters.db.clients.postgres_client import get_connection_parameters, verify_ssl
+from src.adapters.db.clients.postgres_client import (
+    get_connection_parameters,
+    get_database_url,
+    verify_ssl,
+)
 from src.adapters.db.clients.postgres_config import get_db_config
 
 
@@ -51,4 +56,17 @@ def test_get_connection_parameters(monkeypatch: pytest.MonkeyPatch):
         options=f"-c search_path={db_config.db_schema}",
         connect_timeout=10,
         sslmode="require",
+    )
+
+
+def test_get_database_url(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("DB_SSL_MODE")
+    monkeypatch.setenv("DB_PASSWORD", "some:pass:with:colons")
+    db_config = get_db_config()
+    conn_params = get_connection_parameters(db_config)
+    db_url = get_database_url()
+
+    assert (
+        db_url
+        == f"postgresql://{conn_params['user']}:{quote_plus("some:pass:with:colons")}@{conn_params['host']}:{conn_params['port']}/{conn_params['dbname']}?search_path={db_config.db_schema}"
     )


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1742914226216779)


## Changes
 - URL encode the database password


## Context for reviewers
 - The DB password token used for RDS includes `:` which if not URL-encoded causes parsing issues for asyncpg


## Testing
 - Added test coverage, also confirmed by running the code to connect to the RDS database locally

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-276-app-dev-1061947334.us-east-1.elb.amazonaws.com
- Deployed commit: 5b32f10f85979a85891a80539b5a8fbd9640a2dd
<!-- app - end PR environment info -->