### PR TITLE
fix: include LiteralAI link column in export

### DIFF
--- a/app/src/evaluation/literalai_exporter.py
+++ b/app/src/evaluation/literalai_exporter.py
@@ -126,7 +126,7 @@ def convert_to_qa_rows(project_id: str, threads: list[Thread]) -> list[QARow]:
 
 
 def save_csv(qa_pairs: list[QARow], csv_file: IO) -> None:
-    fields = [field for field in QARow._fields if field != "project_id"]
+    fields = [field for field in QARow._fields if field != "project_id"] + ["lai_link"]
     writer = csv.DictWriter(csv_file, fieldnames=fields)
     writer.writeheader()
     for pair in qa_pairs:


### PR DESCRIPTION
## Ticket

Discovered from today's standup

## Changes

Include LiteralAI link column in export


## Testing

Set LITERAL_API_KEY to `prod` version
```
make literalai-exporter args="2025-03-16 2025-03-19"
```

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-277-app-dev-736275883.us-east-1.elb.amazonaws.com
- Deployed commit: 409b59548b000084836a872067f0236e1326d28d
<!-- app - end PR environment info -->