### PR TITLE
ci: Add cron: literalai_tagger

### DIFF
--- a/app/src/util/literalai_util.py
+++ b/app/src/util/literalai_util.py
@@ -161,10 +161,7 @@ def tag_threads() -> None:  # pragma: no cover
     if env == "local" and not bucket_name:
         input_json = "literalai_user_tags.json"
         if not os.path.exists(input_json):
-            logger.error(
-                "Missing input file %r. Download from S3.",
-                input_json,
-            )
+            logger.error("Missing input file %r. Download from S3.", input_json)
             sys.exit(4)
     else:
         bucket = bucket_name or f"decision-support-tool-app-{env}"

--- a/app/src/util/literalai_util.py
+++ b/app/src/util/literalai_util.py
@@ -156,7 +156,7 @@ def tag_threads() -> None:  # pragma: no cover
     args = parser.parse_args(sys.argv[1:])
     logger.info("Running with args %r", args)
 
-    env = os.environ.get("ENVIRONMENT")
+    env = os.environ.get("ENVIRONMENT", "local")
     bucket_name = os.environ.get("BUCKET_NAME")
     if env == "local" and not bucket_name:
         input_json = "literalai_user_tags.json"

--- a/app/src/util/literalai_util.py
+++ b/app/src/util/literalai_util.py
@@ -7,6 +7,7 @@ import pickle
 import sys
 from datetime import datetime
 from typing import Any, Callable
+from smart_open import open as smart_open
 
 from literalai import LiteralClient, Thread, User
 from literalai.my_types import PaginatedResponse
@@ -157,13 +158,13 @@ def tag_threads() -> None:  # pragma: no cover
 
     input_json = "literalai_user_tags.json"
     if not os.path.exists(input_json):
-        logger.error(
-            "Missing input file %r. Download from the 'LiteralAI logs' Google Drive folder.",
+        logger.info(
+            "Missing input file %r. Attempting to use the file from S3.",
             input_json,
         )
-        sys.exit(4)
+        input_json = "s3://decision-support-tool-app-prod/literalai_user_tags.json"
 
-    with open(input_json, "r", encoding="utf-8") as f:
+    with smart_open(input_json, "r", encoding="utf-8") as f:
         user_objs = json.load(f)
     user2tag = {u["user_id"]: u["tag"] for u in user_objs}
     logger.info(user2tag)

--- a/app/src/util/literalai_util.py
+++ b/app/src/util/literalai_util.py
@@ -161,7 +161,10 @@ def tag_threads() -> None:  # pragma: no cover
     if env == "local" and not bucket_name:
         input_json = "literalai_user_tags.json"
         if not os.path.exists(input_json):
-            logger.error("Missing input file %r. Download from S3.", input_json)
+            logger.error(
+                "Missing input file %r. Download from S3 or specify BUCKET_NAME environment variable.",
+                input_json,
+            )
             sys.exit(4)
     else:
         bucket = bucket_name or f"decision-support-tool-app-{env}"

--- a/infra/app/app-config/env-config/scheduled_jobs.tf
+++ b/infra/app/app-config/env-config/scheduled_jobs.tf
@@ -13,7 +13,7 @@ locals {
     literalai_tagger = {
       # Tag LiteralAI threads to distinguish testing from pilot users
       # Only needs to run in prod
-      task_command        = ["poetry", "run", "literalai-tagger"]
+      task_command = ["poetry", "run", "literalai-tagger"]
       # Run every 3 hours during the day
       schedule_expression = "cron(0 12,15,18,21,24 * * ? *)"
     }

--- a/infra/app/app-config/env-config/scheduled_jobs.tf
+++ b/infra/app/app-config/env-config/scheduled_jobs.tf
@@ -10,5 +10,12 @@ locals {
     #   task_command        = ["python", "-m", "flask", "--app", "app.py", "cron"]
     #   schedule_expression = "cron(0 * ? * * *)"
     # }
+    literalai_tagger = {
+      # Tag LiteralAI threads to distinguish testing from pilot users
+      # Only needs to run in prod
+      task_command        = ["poetry", "run", "literalai-tagger"]
+      # Run every 3 hours during the day
+      schedule_expression = "cron(0 12,15,18,21,24 * * ? *)"
+    }
   }
 }

--- a/infra/app/app-config/env-config/scheduled_jobs.tf
+++ b/infra/app/app-config/env-config/scheduled_jobs.tf
@@ -15,7 +15,7 @@ locals {
       # Only needs to run in prod
       task_command = ["poetry", "run", "literalai-tagger"]
       # Run every 3 hours during the day
-      schedule_expression = "cron(0 12,15,18,21,24 * * ? *)"
+      schedule_expression = "cron(0 12,15,18,21,0 * * ? *)"
     }
   }
 }


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1743080416620329)

## Changes

Automate running `literalai-tagger`, which tags LiteralAI threads to distinguish testing from pilot users, every 3 hours during the day.

## Testing

Tested `make literalai-tagger` for dev and prod `LITERAL_API_KEY` env vars.

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-281-app-dev-666907410.us-east-1.elb.amazonaws.com
- Deployed commit: b6869eb7157228377e9ded9258d0c5576189fdfc
<!-- app - end PR environment info -->