### PR TITLE
feat: Merge contiguous cited subsections

### DIFF
--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -67,7 +67,7 @@ def _process_question(
     try:
         logger.info("Processing question %i: %s...", index, question[:50])
         result = engine.on_message(question=question, chat_history=[])
-        final_result = simplify_citation_numbers(result)
+        final_result = simplify_citation_numbers(result.response, result.subsections)
 
         result_table: dict[str, str | None] = {"answer": final_result.response}
 

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -504,7 +504,7 @@ async def run_query(
     result = await asyncify(lambda: engine.on_message(question, chat_history))()
     logger.info("Response: %s", result.response)
 
-    final_result = simplify_citation_numbers(result)
+    final_result = simplify_citation_numbers(result.response, result.subsections)
     citations = [Citation.from_subsection(subsection) for subsection in final_result.subsections]
 
     alert_msg = getattr(result.attributes, "alert_message", None)

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -367,8 +367,6 @@ class Citation(BaseModel):
     uri: Optional[str] | None
     headings: Sequence[str]
     citation_text: str
-    chunk_id: str
-    subsection_index: int
 
     @staticmethod
     def from_subsection(subsection: Subsection) -> "Citation":
@@ -383,8 +381,6 @@ class Citation(BaseModel):
             uri=highlighted_text_src,
             headings=subsection.text_headings,
             citation_text=subsection.text,
-            chunk_id=str(chunk.id),
-            subsection_index=subsection.subsection_index,
         )
 
 

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -367,6 +367,8 @@ class Citation(BaseModel):
     uri: Optional[str] | None
     headings: Sequence[str]
     citation_text: str
+    chunk_id: str
+    subsection_index: int
 
     @staticmethod
     def from_subsection(subsection: Subsection) -> "Citation":
@@ -381,6 +383,8 @@ class Citation(BaseModel):
             uri=highlighted_text_src,
             headings=subsection.text_headings,
             citation_text=subsection.text,
+            chunk_id=str(chunk.id),
+            subsection_index=subsection.subsection_index,
         )
 
 

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -3,12 +3,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Optional, Sequence
 
-from src.citations import (
-    CitationFactory,
-    ResponseWithSubsections,
-    create_prompt_context,
-    split_into_subsections,
-)
+from src.citations import CitationFactory, create_prompt_context, split_into_subsections
 from src.db.models.document import ChunkWithScore, Subsection
 from src.format import FormattingConfig
 from src.generate import (
@@ -49,7 +44,7 @@ If the client lost their job at no fault, they may be eligible for unemployment 
 """
 
 
-class OnMessageResult(ResponseWithSubsections):
+class OnMessageResult:
     def __init__(
         self,
         response: str,
@@ -59,7 +54,8 @@ class OnMessageResult(ResponseWithSubsections):
         chunks_with_scores: Sequence[ChunkWithScore] | None = None,
         subsections: Sequence[Subsection] | None = None,
     ):
-        super().__init__(response, subsections if subsections is not None else [])
+        self.response = response
+        self.subsections = subsections if subsections is not None else []
         self.system_prompt = system_prompt
         self.attributes = attributes
         self.chunks_with_scores = chunks_with_scores if chunks_with_scores is not None else []

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -281,9 +281,6 @@ def merge_contiguous_cited_subsections(
                         text="\n\n".join([ss.text for ss in contig_group]),
                         text_headings=contig_group[0].text_headings,
                     )
-                    for ss in contig_group:
-                        if ss.id in updated_subsections:
-                            del updated_subsections[ss.id]
 
             updated_subsections[new_ss.id] = new_ss
             new_citation_strs.append(f" ({citation_id})")

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -2,7 +2,7 @@ import logging
 import re
 from dataclasses import dataclass
 from itertools import count
-from typing import Callable, Match, Sequence
+from typing import Callable, Match, Optional, Sequence
 
 from nutree import Node
 
@@ -21,12 +21,18 @@ class CitationFactory:
         if next_id:
             self.next_id = next_id
         else:
-            self.next_id = lambda: f"{prefix}{self.counter.__next__()}"
+            self.next_id = lambda: f"{prefix}{next(self.counter)}"
 
-    def create_citation(self, chunk: Chunk, text: str, text_headings: Sequence[str]) -> Subsection:
+    def create_citation(
+        self,
+        chunk: Chunk,
+        subsection_index: int,
+        text: str,
+        text_headings: Optional[Sequence[str]] = None,
+    ) -> Subsection:
         if not self._text_in_chunk(text, chunk):
             logger.warning("Text not found in chunk: %r\n%r", text, chunk.content)
-        return Subsection(self.next_id(), chunk, text, text_headings)
+        return Subsection(self.next_id(), chunk, subsection_index, text, text_headings)
 
     def _text_in_chunk(self, text: str, chunk: Chunk) -> bool:
         # Check that text is in chunk.content, ignoring whitespace and dashes
@@ -58,6 +64,7 @@ def basic_chunk_splitter(
     better_splits = []
     base_headings = chunk.headings or []
     curr_headings = ["" for _ in range(6)]
+    split_index = count()
     for split in splits:
         if split.startswith("#"):
             heading_level, heading_text = parse_heading_markdown(split)
@@ -68,7 +75,7 @@ def basic_chunk_splitter(
             continue
 
         headings = [text for text in base_headings + curr_headings if text]
-        better_splits.append(factory.create_citation(chunk, split, headings))
+        better_splits.append(factory.create_citation(chunk, next(split_index), split, headings))
     return better_splits
 
 
@@ -76,21 +83,23 @@ def tree_based_chunk_splitter(
     chunk: Chunk, factory: CitationFactory = citation_factory
 ) -> list[Subsection]:
     tree = create_markdown_tree(chunk.content)
-    return _split_section(tree.first_child(), chunk, factory)
+    subsections: list[Subsection] = []
+    _split_section(subsections, tree.first_child(), chunk, factory)
+    return subsections
 
 
 def _split_section(
+    subsections: list[Subsection],
     hs_node: Node,
     chunk: Chunk,
     factory: CitationFactory = citation_factory,
-) -> list[Subsection]:
+) -> None:
     base_headings = chunk.headings or []
     headings = None
-    subsections: list[Subsection] = []
     node = hs_node.first_child()
     while node:
         if node.data_type == "HeadingSection":
-            subsections += _split_section(node, chunk, factory)
+            _split_section(subsections, node, chunk, factory)
         elif node.data_type == "Heading":
             pass
         elif node.has_token() and node.is_block_token():
@@ -105,15 +114,18 @@ def _split_section(
                 intro_sentence = markdown
                 markdown = next_node.render().strip()
                 subsections.append(
-                    factory.create_citation(chunk, intro_sentence + "\n" + markdown, headings)
+                    factory.create_citation(
+                        chunk, len(subsections), intro_sentence + "\n" + markdown, headings
+                    )
                 )
                 node.next_sibling().remove()
             else:
-                subsections.append(factory.create_citation(chunk, markdown, headings))
+                subsections.append(
+                    factory.create_citation(chunk, len(subsections), markdown, headings)
+                )
         else:
             raise NotImplementedError(f"Unexpected: {node.id_string()}")
         node = node.next_sibling()
-    return subsections
 
 
 def split_into_subsections(
@@ -148,10 +160,10 @@ def create_prompt_context(subsections: Sequence[Subsection]) -> str:
 
 def remap_citation_ids(subsections: Sequence[Subsection], response: str) -> dict[str, Subsection]:
     """
-    Map '(citation-<id>)' in `response`, where '(citation-<id>)' is the `id` in one of the `subsections`,
-    to a dict from '(citation-<id>)' to corresponding Subsection,
+    Map '(citation-<id>)' in `response`, where '(citation-<id>)' refers to the `id` in one of the `subsections`,
+    to a dict from string '(citation-<id>)' to the corresponding Subsection,
     where the order of the list reflects the order of the citations in `response`.
-    Only cited subsections are included in the returned dict.
+    Only cited subsections in the response are included in the returned dict.
     Remap the Subsection.id value to be the user-friendly citation number for that citation.
     E.g., if `subsections` is a list with five entries, and `response` is a string like
     "Example (citation-3)(citation-1), another example (citation-1).", then this function will return
@@ -180,7 +192,7 @@ def remap_citation_ids(subsections: Sequence[Subsection], response: str) -> dict
             # Add a copy of the subsection with the id replaced by a new consecutive citation number
             citation = citation_map[citation_id]
             citations[citation_id] = factory.create_citation(
-                citation.chunk, citation.text, citation.text_headings
+                citation.chunk, citation.subsection_index, citation.text, citation.text_headings
             )
     if citations:
         logger.info(

--- a/app/src/citations.py
+++ b/app/src/citations.py
@@ -224,6 +224,10 @@ def merge_contiguous_cited_subsections(
 ) -> Tuple[str, Sequence[Subsection]]:
     subsection_dict: dict[str, Subsection] = {ss.id: ss for ss in subsections}
     updated_subsections = {ss.id: ss for ss in subsections}
+    # logger.info(
+    #     "Merging any contiguous citations:\n  %s",
+    #     "\n  ".join([f"{ss.id} -> {ss.chunk.id}, {ss.subsection_index}" for ss in subsections]),
+    # )
 
     def group_contiguous_cited_subsections(
         multiple_citations_group: str,
@@ -274,6 +278,7 @@ def merge_contiguous_cited_subsections(
                 if citation_id in updated_subsections:
                     new_ss = updated_subsections[citation_id]
                 else:
+                    logger.info("Merging %d citations into %s", len(contig_group), citation_id)
                     new_ss = Subsection(
                         id=citation_id,
                         chunk=contig_group[0].chunk,

--- a/app/src/db/models/document.py
+++ b/app/src/db/models/document.py
@@ -83,12 +83,19 @@ class DocumentWithMaxScore(NamedTuple):
 class Subsection:
 
     def __init__(
-        self, id: str, chunk: Chunk, text: str, text_headings: Optional[Sequence[str]] = None
+        self,
+        id: str,
+        chunk: Chunk,
+        subsection_index: int,
+        text: str,
+        text_headings: Optional[Sequence[str]] = None,
     ) -> None:
         # user-friendly, consecutive identifier for the subsection starting from 1
         self.id = id
         # chunk containing the subsection
         self.chunk = chunk
+        # index of the subsection within the chunk (0-based)
+        self.subsection_index = subsection_index
         # specific substring within chunk.text
         self.text = text
         # parent headings for the text

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -94,9 +94,7 @@ def _create_accordion_html(
 
         citation_body = _build_citation_body(config, document, cited_subsections)
         formatted_citation_body = config.format_accordion_body(citation_body)
-
         citation_numbers = [citation.id for citation in cited_subsections]
-        subsection_indices = [str(citation.subsection_index) for citation in cited_subsections]
 
         for citation_number in citation_numbers:
             map_of_accordion_ids[citation_number] = _accordion_id
@@ -108,7 +106,7 @@ def _create_accordion_html(
                     class="usa-accordion__button"
                     aria-expanded="false"
                     aria-controls="a-{_accordion_id}">
-                    {",".join(citation_numbers)}. ({",".join(subsection_indices)}) {document.dataset}: {document.name}
+                    {",".join(citation_numbers)}. {document.dataset}: {document.name}
                 </button>
             </h4>
             <div id="a-{_accordion_id}" class="usa-accordion__content usa-prose" hidden>

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -27,7 +27,7 @@ class FormattingConfig:
 
     def get_document_link(self, document: Document) -> str:
         if document.source:
-            return f"<p>Source: <a href={document.source!r}>{document.source}</a></p>"
+            return f"Source: <a href={document.source!r}>{document.source}</a>"
         return ""
 
     def get_citation_link(self, subsection: Union[Subsection, "ContiguousGroup"]) -> str:

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -136,31 +136,30 @@ ChunkWithCitation = tuple[Chunk, Sequence[Subsection]]
 def _build_citation_body(
     config: FormattingConfig, document: Document, subsections: Sequence[Subsection]
 ) -> str:
-    citation_body = ""
+    citation_body = []
     for grouping in _group_by_contiguous_subsections(subsections):
         # for subsection in subsections:
-        citation_headings = (
+        citation_headings_html = (
             _get_breadcrumb_html(grouping.text_headings, document.name)
             if grouping.text_headings
             else ""
-        )
+        ).strip()
 
         citation_ids = ", ".join([f"#{id}" for id in grouping.ids])
         citation_text = "\n\n".join(grouping.texts)
-        citation_body += (
-            f"<b>{citation_headings}</b>"
-            f"<div>Citation {citation_ids}: </div>"
-            f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{to_html(citation_text)}</div>'
+        citation_body.append(
+            f"{citation_headings_html}\n"
+            f"<div>Citation {citation_ids}:</div>\n"
+            f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{to_html(citation_text)}</div>\n'
         )
-        logger.info("citation_body: %s", citation_body)
         if config.add_citation_link_per_subsection:
             citation_link = config.get_citation_link(grouping)
-            citation_body += f"<div>{citation_link}</div>"
+            citation_body.append(f"<div>{citation_link}</div>")
 
     if not config.add_citation_link_per_subsection:
         citation_link = config.get_document_link(document)
-        citation_body += f"<div>{citation_link}</div>"
-    return citation_body
+        citation_body.append(f"<div>{citation_link}</div>")
+    return "\n".join(citation_body)
 
 
 class ContiguousGroup:

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -137,7 +137,6 @@ def _build_citation_body(
     config: FormattingConfig, document: Document, subsections: Sequence[Subsection]
 ) -> str:
     citation_body = ""
-    rendered_heading = ""
     for grouping in _group_by_contiguous_subsections(subsections):
         # for subsection in subsections:
         citation_headings = (
@@ -145,17 +144,15 @@ def _build_citation_body(
             if grouping.text_headings
             else ""
         )
-        # only show headings if they are different
-        if rendered_heading != citation_headings:
-            citation_body += f"<b>{citation_headings}</b>"
-            rendered_heading = citation_headings
 
         citation_ids = ", ".join([f"#{id}" for id in grouping.ids])
         citation_text = "\n\n".join(grouping.texts)
         citation_body += (
+            f"<b>{citation_headings}</b>"
             f"<div>Citation {citation_ids}: </div>"
             f'<div class="margin-left-2 border-left-1 border-base-lighter padding-left-2">{to_html(citation_text)}</div>'
         )
+        logger.info("citation_body: %s", citation_body)
         if config.add_citation_link_per_subsection:
             citation_link = config.get_citation_link(grouping)
             citation_body += f"<div>{citation_link}</div>"
@@ -177,7 +174,7 @@ class ContiguousGroup:
         for ss in subsections[1:]:
             assert ss.chunk == self.chunk
             assert ss.text_headings == self.text_headings
-            # assert ss.subsection_index == curr_index + 1
+            assert ss.subsection_index == curr_index + 1
             curr_index = ss.subsection_index
 
         self.ids = [ss.id for ss in subsections]

--- a/app/src/format.py
+++ b/app/src/format.py
@@ -172,7 +172,6 @@ class ContiguousGroup:
         curr_index = subsections[0].subsection_index
         for ss in subsections[1:]:
             assert ss.chunk == self.chunk
-            assert ss.text_headings == self.text_headings
             assert ss.subsection_index == curr_index + 1
             curr_index = ss.subsection_index
 

--- a/app/tests/src/test_batch_process.py
+++ b/app/tests/src/test_batch_process.py
@@ -60,7 +60,7 @@ def test_process_question(monkeypatch, engine):
     subsection_text = chunk.content[: int(len(chunk.content) / 2)]
     mock_result = OnMessageResult(
         response="Answer to question.(citation-1)",
-        subsections=[Subsection("citation-1", chunk, subsection_text)],
+        subsections=[Subsection("citation-1", chunk, 0, subsection_text)],
         attributes=ImagineLA_MessageAttributes(
             needs_context=True,
             translated_message="",

--- a/app/tests/src/test_chainlit.py
+++ b/app/tests/src/test_chainlit.py
@@ -27,7 +27,7 @@ def test_url_query_values(monkeypatch):
 def test__get_retrieval_metadata(chunks_with_scores):
     system_prompt = "Some system prompt"
     chunks = [chunk_with_score.chunk for chunk_with_score in chunks_with_scores]
-    subsections = [Subsection(chunk.id, chunk, chunk.content) for chunk in chunks]
+    subsections = [Subsection(chunk.id, chunk, 0, chunk.content) for chunk in chunks]
     result = OnMessageResult(
         "Some response",
         system_prompt,

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -416,7 +416,7 @@ async def test_run_query__2_citations(subsections):
     )
     assert (
         query_response.response_text
-        == f"{query_response.alert_message}\n\nResponse from LLM (citation-1)(citation-2)"
+        == f"{query_response.alert_message}\n\nResponse from LLM (citation-1) (citation-2)"
     )
     assert len(query_response.citations) == 2
     assert query_response.citations[0].citation_id == "citation-1"
@@ -438,7 +438,8 @@ async def test_run_query__unknown_citation(subsections, caplog):
     with caplog.at_level(logging.ERROR):
         query_response, _metadata = await run_query(MockChatEngine(), "My question")
         assert any(
-            text == "LLM generated a citation for a reference (citation-44) that doesn't exist."
+            text
+            == "LLM generated a citation for a reference (citation-44) that doesn't exist; ignoring."
             for text in caplog.messages
         )
 

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -240,7 +240,8 @@ def test_merge_contiguous_cited_subsections(subsections):
         f"Some topic related to B. ({noncontig_subsection.id}) "
         f"Something about topic A. ({subsections[0].id}) ({subsections[1].id}) ({noncontig_subsection.id}) "
         f"Repeated citation to topic A. ({subsections[0].id}) ({subsections[1].id}) "
-        f"Single citation to topic B. ({contig_subsection.id}) "
+        f"Single citation from contiguous group to topic B. ({contig_subsection.id}) "
+        f"Reverse order citations to topic B. ({contig_subsection.id}) ({subsection.id}) "
     )
     m_response, m_subsections = merge_contiguous_cited_subsections(llm_response, subsections)
 
@@ -249,7 +250,8 @@ def test_merge_contiguous_cited_subsections(subsections):
         "Some topic related to B. (citation-3) "
         "Something about topic A. (citation-00010002) (citation-3) "
         "Repeated citation to topic A. (citation-00010002) "
-        "Single citation to topic B. (citation-5) "
+        "Single citation from contiguous group to topic B. (citation-5) "
+        "Reverse order citations to topic B. (citation-5) (citation-4) "
     )
 
     # Check new citations
@@ -274,10 +276,13 @@ def test_merge_contiguous_cited_subsections(subsections):
         "Some topic related to B. (citation-2) "
         "Something about topic A. (citation-3) (citation-2) "
         "Repeated citation to topic A. (citation-3) "
-        "Single citation to topic B. (citation-4) "
+        "Single citation from contiguous group to topic B. (citation-4) "
+        "Reverse order citations to topic B. (citation-4) (citation-5) "
     )
 
     remapped_subsections = {ss.id: ss for ss in remapped_citations.values()}
     assert remapped_subsections["1"].text == citation_aboutB.text
     assert remapped_subsections["2"].text == noncontig_subsection.text
     assert remapped_subsections["3"].text == citation_aboutA.text
+    assert remapped_subsections["4"].text == contig_subsection.text
+    assert remapped_subsections["5"].text == subsection.text

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -39,9 +39,9 @@ def subsections(chunks):
 def context(chunks):
     factory = CitationFactory()
     return [
-        factory.create_citation(chunks[0], "This is the first chunk."),
-        factory.create_citation(chunks[0], "With two subsections"),
-        factory.create_citation(chunks[1], chunks[1].content),
+        factory.create_citation(chunks[0], 0, "This is the first chunk."),
+        factory.create_citation(chunks[0], 1, "With two subsections"),
+        factory.create_citation(chunks[1], 0, chunks[1].content),
     ]
 
 
@@ -156,8 +156,8 @@ def test_replace_citation_ids():
     assert replace_citation_ids("Hallucinated.(citation-1)", {}) == "Hallucinated."
 
     remapped_citations = {
-        "citation-4": Subsection("1", ChunkFactory.build(), ""),
-        "citation-3": Subsection("2", ChunkFactory.build(), ""),
+        "citation-4": Subsection("1", ChunkFactory.build(), 0, ""),
+        "citation-3": Subsection("2", ChunkFactory.build(), 1, ""),
     }
     assert (
         replace_citation_ids("Remapped. (citation-4)(citation-3)", remapped_citations)

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -1,3 +1,4 @@
+import copy
 from textwrap import dedent
 
 import pytest
@@ -6,6 +7,7 @@ from src.citations import (
     CitationFactory,
     basic_chunk_splitter,
     create_prompt_context,
+    merge_contiguous_cited_subsections,
     move_citations_after_punctuation,
     remap_citation_ids,
     replace_citation_ids,
@@ -45,7 +47,7 @@ def context(chunks):
     ]
 
 
-def test_get_context_for_prompt(chunks, subsections):
+def test_create_prompt_context(chunks, subsections):
     assert create_prompt_context([]) == ""
 
     assert create_prompt_context(subsections) == (
@@ -78,7 +80,7 @@ Content: | Header 1 | Header 2 |
     )
 
 
-def test_get_context(chunks, subsections):
+def test_split_into_subsections(chunks, subsections):
     assert subsections[0].id == "citation-1"
     assert subsections[0].chunk == chunks[0]
     assert subsections[0].text == "This is the first chunk."
@@ -191,22 +193,97 @@ The officer weighs all these factors. They consider positive factors, like a job
 def test_move_citations_after_punctuation():
     text = dedent(
         """
-                     Some text (citation-1). Another sentence on same line with no space(citation-2)? Sentence 3 has the correct citation formatting. (citation-3)
-                     - Bullet 1 is on a new line (citation-4) (citation-5)!
-                     - Bullet 2 is on next line (citation-14) (citation-15) (citation-16).
-                     Last sentence(citation-6)!
+        Some text (citation-1). Another sentence on same line with no space(citation-2)? Sentence 3 has the correct citation formatting. (citation-3)
+        - Bullet 1 is on a new line (citation-4) (citation-5)!
+        - Bullet 2 is on next line (citation-14) (citation-15) (citation-16).
+        Last sentence(citation-6)!
 
-                     New paragraph (citation-100).
-                  """
+        New paragraph (citation-100).
+        """
     )
     expected_text = dedent(
         """
-                            Some text. (citation-1) Another sentence on same line with no space? (citation-2) Sentence 3 has the correct citation formatting. (citation-3)
-                            - Bullet 1 is on a new line! (citation-4) (citation-5)
-                            - Bullet 2 is on next line. (citation-14) (citation-15) (citation-16)
-                            Last sentence! (citation-6)
+        Some text. (citation-1) Another sentence on same line with no space? (citation-2) Sentence 3 has the correct citation formatting. (citation-3)
+        - Bullet 1 is on a new line! (citation-4) (citation-5)
+        - Bullet 2 is on next line. (citation-14) (citation-15) (citation-16)
+        Last sentence! (citation-6)
 
-                            New paragraph. (citation-100)
-                           """
+        New paragraph. (citation-100)
+        """
     ).strip()
     assert move_citations_after_punctuation(text) == expected_text
+
+
+def test_merge_contiguous_cited_subsections(subsections):
+
+    # # Append a subsection that is NOT contiguous with the last one
+    # noncontig_subsection = copy.copy(subsection)
+    # noncontig_subsection.id = f"citation-{len(subsections) + 1}"
+    # noncontig_subsection.subsection_index = 3
+    # noncontig_subsection.text = "Noncontiguous citation text about topic A."
+    # subsections.append(noncontig_subsection)
+
+    # Ensure we have some contiguous subsections
+    assert subsections[0].chunk == subsections[1].chunk
+    assert subsections[1].subsection_index == 1
+    assert subsections[3].chunk == subsections[4].chunk
+    assert subsections[4].subsection_index == 1
+
+    subsection = subsections[3]
+    contig_subsection = subsections[4]
+    noncontig_subsection = subsections[2]
+
+    # Append a third contiguous subsection
+    contig_subsection2 = copy.copy(contig_subsection)
+    contig_subsection2.subsection_index = 2
+    contig_subsection2.id = f"citation-{len(subsections) + 1}"
+    contig_subsection2.text = "Third contiguous subsection text about topic B."
+    subsections.append(contig_subsection2)
+
+    # [(ss.id, ss.subsection_index) for ss in subsections]
+    # [(ss.id, ss.text_headings) for ss in subsections]
+    # [(ss.id, ss.text) for ss in subsections]
+
+    llm_response = dedent(
+        f"Something about B. ({subsection.id}) ({contig_subsection.id}) ({contig_subsection2.id}) "
+        f"Some topic related to B. ({noncontig_subsection.id}) "
+        f"Something about topic A. ({subsections[0].id}) ({subsections[1].id}) ({noncontig_subsection.id})"
+    )
+    result = merge_contiguous_cited_subsections(subsections, llm_response)
+
+    print("Result:", result.response)
+    print("Subsections:", result.subsections)
+    assert result.response == (
+        "Something about B. (citation-000400050006) "
+        "Some topic related to B. (citation-3) "
+        "Something about topic A. (citation-00010002) (citation-3)"
+    )
+
+    # Check new citations
+    subsection_dict = {ss.id: ss for ss in result.subsections}
+    citation_aboutB = subsection_dict["citation-000400050006"]
+    assert citation_aboutB.text == "\n\n".join(
+        [subsection.text, contig_subsection.text, contig_subsection2.text]
+    )
+
+    citation_aboutA = subsection_dict["citation-00010002"]
+    assert citation_aboutA.text == "\n\n".join([subsections[0].text, subsections[1].text])
+
+    citation_3 = subsection_dict["citation-3"]
+    assert citation_3 == noncontig_subsection
+
+    remapped_citations = remap_citation_ids(result.subsections, result.response)
+    remapped_response = replace_citation_ids(result.response, remapped_citations)
+    print("Remapped response:", remapped_response)
+    assert remapped_response == (
+        "Something about B. (citation-1) "
+        "Some topic related to B. (citation-2) "
+        "Something about topic A. (citation-3) (citation-2)"
+    )
+    # import pdb; pdb.set_trace()
+    remapped_subsections = {ss.id: ss for ss in remapped_citations.values()}
+    assert remapped_subsections["1"].text == citation_aboutB.text
+    assert remapped_subsections["2"].text == noncontig_subsection.text
+    assert remapped_subsections["3"].text == citation_aboutA.text
+
+    assert False

--- a/app/tests/src/test_citations.py
+++ b/app/tests/src/test_citations.py
@@ -239,7 +239,8 @@ def test_merge_contiguous_cited_subsections(subsections):
         f"Something about B. ({subsection.id}) ({contig_subsection.id}) ({contig_subsection2.id}) "
         f"Some topic related to B. ({noncontig_subsection.id}) "
         f"Something about topic A. ({subsections[0].id}) ({subsections[1].id}) ({noncontig_subsection.id}) "
-        f"Repeated citation to topic A. ({subsections[0].id}) ({subsections[1].id})"
+        f"Repeated citation to topic A. ({subsections[0].id}) ({subsections[1].id}) "
+        f"Single citation to topic B. ({contig_subsection.id}) "
     )
     m_response, m_subsections = merge_contiguous_cited_subsections(llm_response, subsections)
 
@@ -247,7 +248,8 @@ def test_merge_contiguous_cited_subsections(subsections):
         "Something about B. (citation-000400050006) "
         "Some topic related to B. (citation-3) "
         "Something about topic A. (citation-00010002) (citation-3) "
-        "Repeated citation to topic A. (citation-00010002)"
+        "Repeated citation to topic A. (citation-00010002) "
+        "Single citation to topic B. (citation-5) "
     )
 
     # Check new citations
@@ -271,7 +273,8 @@ def test_merge_contiguous_cited_subsections(subsections):
         "Something about B. (citation-1) "
         "Some topic related to B. (citation-2) "
         "Something about topic A. (citation-3) (citation-2) "
-        "Repeated citation to topic A. (citation-3)"
+        "Repeated citation to topic A. (citation-3) "
+        "Single citation to topic B. (citation-4) "
     )
 
     remapped_subsections = {ss.id: ss for ss in remapped_citations.values()}

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -100,9 +100,9 @@ def test_format_response__merge_contiguous_citations(chunks_with_scores):
     )
 
     assert re.search(
-        f"<div>Citation #1, #2: </div><div .*><p>{subsection.text}</p></p>\n<p>{contig_subsection.text}</p>\n<p></div>",
+        f"<div>Citation #1, #2:</div>\n<div .*><p>{subsection.text}</p>\n<p>{contig_subsection.text}</p></div>",
         html,
     )
     assert re.search(
-        f"<div>Citation #3: </div></p>\n<div .*><p>{noncontig_subsection.text}</p></div>", html
+        f"<div>Citation #3:</div>\n<div .*><p>{noncontig_subsection.text}</p></div>", html
     )

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -1,4 +1,3 @@
-import copy
 import re
 
 from src.citations import CitationFactory, split_into_subsections
@@ -68,41 +67,3 @@ def test_format_response(chunks_with_scores):
     assert "Source(s)" in html
     assert "usa-accordion__button" in html
     assert "usa-accordion__content" in html
-
-
-def test_format_response__merge_contiguous_citations(chunks_with_scores):
-    subsections = to_subsections(chunks_with_scores)
-
-    # Append a subsection that is contiguous with the last one
-    subsection = subsections[-1]
-    contig_subsection = copy.copy(subsection)
-    contig_subsection.id = f"citation-{len(subsections) + 1}"
-    contig_subsection.subsection_index = 1
-    contig_subsection.text = "Continued citation text about topic A."
-    subsections.append(contig_subsection)
-
-    # Append a subsection that is NOT contiguous with the last one
-    noncontig_subsection = copy.copy(subsection)
-    noncontig_subsection.id = f"citation-{len(subsections) + 1}"
-    noncontig_subsection.subsection_index = 3
-    noncontig_subsection.text = "Noncontiguous citation text about topic A."
-    subsections.append(noncontig_subsection)
-
-    config = FormattingConfig()
-    msg_attribs = MessageAttributes(needs_context=True, translated_message="")
-
-    llm_response = f"Something about A. ({subsection.id}) More about A. ({contig_subsection.id}) Some topic related to A. ({noncontig_subsection.id})"
-    html = format_response(
-        subsections,
-        llm_response,
-        config,
-        msg_attribs,
-    )
-
-    assert re.search(
-        f"<div>Citation #1, #2:</div>\n<div .*><p>{subsection.text}</p>\n<p>{contig_subsection.text}</p></div>",
-        html,
-    )
-    assert re.search(
-        f"<div>Citation #3:</div>\n<div .*><p>{noncontig_subsection.text}</p></div>", html
-    )

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -1,3 +1,4 @@
+import copy
 import re
 
 from src.citations import CitationFactory, split_into_subsections
@@ -69,25 +70,20 @@ def test_format_response(chunks_with_scores):
     assert "usa-accordion__content" in html
 
 
-import copy
-
-
 def test_format_response__merge_contiguous_citations(chunks_with_scores):
     subsections = to_subsections(chunks_with_scores)
 
     # Append a subsection that is contiguous with the last one
     subsection = subsections[-1]
     contig_subsection = copy.copy(subsection)
-    contig_subsection.id = f"citation-{len(subsections)+1}"
+    contig_subsection.id = f"citation-{len(subsections) + 1}"
     contig_subsection.subsection_index = 1
-    contig_subsection.text = (
-        "Continued citation text about topic A."  # \n- list item 1\n- list item 2"
-    )
+    contig_subsection.text = "Continued citation text about topic A."
     subsections.append(contig_subsection)
 
     # Append a subsection that is NOT contiguous with the last one
     noncontig_subsection = copy.copy(subsection)
-    noncontig_subsection.id = f"citation-{len(subsections)+1}"
+    noncontig_subsection.id = f"citation-{len(subsections) + 1}"
     noncontig_subsection.subsection_index = 3
     noncontig_subsection.text = "Noncontiguous citation text about topic A."
     subsections.append(noncontig_subsection)


### PR DESCRIPTION
## Ticket

Part of https://navalabs.atlassian.net/browse/DST-646

## Changes

Sequential contiguous subsections that are cited together are merged into a single citation.

Also:
- fix bullet rendering by ensuring a new line occurs before any bullet character.
- fix extra spaces after citation heading

## Testing

![image](https://github.com/user-attachments/assets/dc056c52-5c29-47ab-94d2-8633acdd9eef)
Citation #3 merges 3 citations/paragraphs:
![image](https://github.com/user-attachments/assets/2ef99b93-7a51-4736-b088-1abf29be77e1)


<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-282-app-dev-1134576066.us-east-1.elb.amazonaws.com
- Deployed commit: 8dda71b2fade3f0a5f220154301b22586c976d75
<!-- app - end PR environment info -->