### PR TITLE
chore: Exclude out-of-date DPSS webpage Coverage_for_Immigrants

### DIFF
--- a/app/src/ingestion/scrapy_dst/spiders/la_policy_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/la_policy_spider.py
@@ -45,6 +45,11 @@ class TargetElementType(Enum):
 # 42-431_2_Noncitizen_Status.htm, 42-200_Property.htm use all these as bullets
 BULLETS = ["·", "•", "Ø", "o", "§"]
 
+URLS_TO_SKIP = [
+    # From 2016, mostly out-of-date. We see this page getting cited more often than Benefits Info Hub, which is up-to-date
+    "https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/mergedProjects/Medi-Cal/Medi-Cal/Coverage_for_Immigrants/Coverage_for_Immigrants.htm",
+]
+
 
 class LA_PolicyManualSpider(scrapy.Spider):
     name = "la_policy_spider"
@@ -115,6 +120,10 @@ class LA_PolicyManualSpider(scrapy.Spider):
 
     def parse_page(self, response: Response) -> dict[str, str]:
         "Parses content pages; return value is add to file set by scrape_la_policy.OUTPUT_JSON"
+        if response.url in URLS_TO_SKIP:
+            self.logger.info("Skipping URL %s", response.url)
+            return {}
+
         assert isinstance(response, HtmlResponse)
         url = response.url
         title = response.xpath("head/title/text()").get("").strip()


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-898

## Changes

Add `URLS_TO_SKIP` to `la_policy_spider.py`

## Testing

```
make scrapy-runner args="la_policy --debug" &> scrapy.log
grep "Skipping URL" scrapy.log
```
Also check that no content from https://epolicy.dpss.lacounty.gov/epolicy/epolicy/server/general/projects_responsive/ePolicyMaster/mergedProjects/Medi-Cal/Medi-Cal/Coverage_for_Immigrants/Coverage_for_Immigrants.htm is present in `src/ingestion/la_policy_scrapings.json-pretty.json`

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-286-app-dev-2103794513.us-east-1.elb.amazonaws.com
- Deployed commit: e133955f0ae8e30fb0913a7f52ecd1c43e7a1610
<!-- app - end PR environment info -->