### PR TITLE
fix: Chainlit: replace 3 space list indents to 4 spaces

### DIFF
--- a/app/src/format.py
+++ b/app/src/format.py
@@ -43,6 +43,8 @@ class FormattingConfig:
 def to_html(text: str) -> str:
     # markdown expects '\n' before the start of a list
     corrected_text = re.sub(r"^([\-\+\*]) ", "\n- ", text, flags=re.MULTILINE, count=1)
+    # markdown expect 4 spaces before a nested list item; LLMs often use 3 spaces
+    corrected_text = re.sub(r"^   ([\-\+\*]) ", "    - ", corrected_text, flags=re.MULTILINE)
     return markdown.markdown(corrected_text)
 
 

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -59,6 +59,12 @@ def test_format_response(chunks_with_scores):
         == "<div><p>List intro sentence: </p>\n<ul>\n<li>item 1</li>\n<li>item 2</li>\n</ul></div>"
     )
 
+    # Test nested list formatting
+    assert (
+        format_response([], "List intro sentence: \n\n1. number 1\n   - subitem 1\n   - subitem 2", config, msg_attribs)
+        == "<div><p>List intro sentence: </p>\n<ol>\n<li>number 1<ul>\n<li>subitem 1</li>\n<li>subitem 2</li>\n</ul>\n</li>\n</ol></div>"
+    )
+
     # Test real citations
     html = format_response(
         subsections, "Some real citations: (citation-1) (citation-2)", config, msg_attribs


### PR DESCRIPTION
## Ticket

Part of https://navalabs.atlassian.net/browse/DST-301

Claude outputs 3 spaces to indent sublists.
The `markdown` library expect 4 spaces before a nested list item; LLMs often use 3 spaces

## Changes

Convert 3-space indented sublists with 4 spaces.

## Testing

Added to unit test
