### PR TITLE
fix: LA policy ingestion formatting change

### DIFF
--- a/app/src/ingestion/scrapy_dst/spiders/la_policy_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/la_policy_spider.py
@@ -118,11 +118,11 @@ class LA_PolicyManualSpider(scrapy.Spider):
             self.logger.debug("URL for %r => %s", name, page_url)
             yield response.follow(page_url, callback=self.parse_page)
 
-    def parse_page(self, response: Response) -> dict[str, str]:
+    def parse_page(self, response: Response) -> dict[str, str] | None:
         "Parses content pages; return value is add to file set by scrape_la_policy.OUTPUT_JSON"
         if response.url in URLS_TO_SKIP:
             self.logger.info("Skipping URL %s", response.url)
-            return {}
+            return None
 
         assert isinstance(response, HtmlResponse)
         url = response.url
@@ -1088,7 +1088,7 @@ def to_markdown(html: str, base_url: Optional[str] = None) -> str:
 
     # Ill-formatted lists causes markdown chunking error (44-220_Emergency_Aid.htm)
     # Remove bullet before "Note:" text
-    markdown = re.sub(r"^ *\* \*\*_Note_\*\*", "**_Note_**", markdown, flags=re.MULTILINE)
+    markdown = re.sub(r"^ *\* \*\* *_Note_\*\*", "**_Note_**", markdown, flags=re.MULTILINE)
 
     # Consolidate newlines
     markdown = re.sub(r"\n\n+", "\n\n", markdown)


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-916


## Changes
 - Don't populate skipped URLs in the JSON as `{}`, omit them entirely
 - Remove leading asterisks for both `* **_NOTE_**` and `* ** _NOTE_ **` (extra space in second one)

## Context for reviewers
Looks like a minor formatting change on the LA policy website side

## Testing
`./refresh-ingestion.sh la_policy` should run scraping, parsing, and ingestion successfully

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-290-app-dev-603792696.us-east-1.elb.amazonaws.com
- Deployed commit: 103ca48a79af50a26037515028471945ad362761
<!-- app - end PR environment info -->