### PR TITLE
fix: Preserve new lines in batch CSV processing

### DIFF
--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -68,7 +68,6 @@ def _process_question(
 ) -> dict[str, str | None]:
     try:
         logger.info("Processing question %i: %s...", index, question[:50])
-        logger.info("Question contains newlines: " + str("\n" in question))
         result = engine.on_message(question=question, chat_history=[])
         final_result = simplify_citation_numbers(result.response, result.subsections)
 

--- a/app/src/batch_process.py
+++ b/app/src/batch_process.py
@@ -1,5 +1,6 @@
 import asyncio
 import csv
+import io
 import logging
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
@@ -16,7 +17,8 @@ async def batch_process(file_path: str, engine: ChatEngineInterface) -> str:
     # Convert file contents to clean UTF-8
     content = convert_to_utf8(file_path)
 
-    reader = csv.DictReader(content.splitlines())
+    csv_file = io.StringIO(content)
+    reader = csv.DictReader(csv_file)
 
     if not reader.fieldnames or "question" not in reader.fieldnames:
         raise ValueError("CSV file must contain a 'question' column.")
@@ -66,6 +68,7 @@ def _process_question(
 ) -> dict[str, str | None]:
     try:
         logger.info("Processing question %i: %s...", index, question[:50])
+        logger.info("Question contains newlines: " + str("\n" in question))
         result = engine.on_message(question=question, chat_history=[])
         final_result = simplify_citation_numbers(result.response, result.subsections)
 

--- a/app/tests/src/test_batch_process.py
+++ b/app/tests/src/test_batch_process.py
@@ -14,9 +14,7 @@ def engine():
 
 @pytest.fixture
 def sample_csv(tmp_path):
-    csv_content = (
-        "question,metadata\n" "What is AI?,some metadata\n" "Second question,other metadata"
-    )
+    csv_content = 'question,metadata\nWhat is AI?,some metadata\n"Second question\nacross lines",other metadata'
     csv_path = tmp_path / "questions.csv"
     csv_path.write_text(csv_content)
     return str(csv_path)
@@ -51,7 +49,7 @@ async def test_batch_process(monkeypatch, sample_csv, engine):
         assert f.read() == (
             "question,metadata,answer,field_2,field_3\n"
             "What is AI?,some metadata,Answer to What is AI?,value_2,\n"
-            "Second question,other metadata,Answer to Second question,,value_3\n"
+            '"Second question\nacross lines",other metadata,Answer to Second question,,value_3\n'
         )
 
 


### PR DESCRIPTION
## Ticket

n/a

## Changes
Instead of splitting on newlines, feed the file contents directly as an IOStream into CSVDictReader. This prevents newlines from being stripped from multi-line rows, e.g.,:

```
question,next_col
"This question
goes across multiple lines",1
```


## Context for reviewers
Req from our eval partners at Georgetown


## Testing

Updated unit tests to reflect, they should fail without the patch here

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-294-app-dev-236366550.us-east-1.elb.amazonaws.com
- Deployed commit: a68d5d2ce7fe6607e063d1c5649062aaa117fdc5
<!-- app - end PR environment info -->