### PR TITLE
feat: Add streaming to chainlit chat UI

### DIFF
--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -254,21 +254,13 @@ async def on_message(message: cl.Message) -> None:
         # Update the message with formatted content and metadata
         # See: https://docs.chainlit.io/api-reference/message#update-a-message
         msg.content = msg_content
-        msg.metadata = {
-            "system_prompt": engine.system_prompt_2,
-            "subsections": [
-                {
-                    "id": citations.id,
-                    "chunk.id": str(citations.chunk.id),
-                    "document.name": citations.chunk.document.name,
-                    "headings": citations.text_headings,
-                    "text": citations.text,
-                }
-                for citations in final_result.subsections
-            ],
-            "raw_response": final_result.response,
-            "attributes": attributes.model_dump(),
-        }
+        result = OnMessageResult(
+            response=final_result.response,
+            system_prompt=engine.system_prompt_2,
+            attributes=attributes,
+            subsections=final_result.subsections,
+        )
+        msg.metadata = _get_retrieval_metadata(result)
         await msg.update()
 
         if engine.show_msg_attributes:

--- a/app/src/chainlit.py
+++ b/app/src/chainlit.py
@@ -5,8 +5,6 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
-from asyncer import asyncify
-
 import chainlit as cl
 from chainlit.input_widget import InputWidget, Select, Slider, Switch, TextInput
 from chainlit.types import AskFileResponse
@@ -227,29 +225,54 @@ async def on_message(message: cl.Message) -> None:
         return
 
     try:
-        result = await asyncify(lambda: engine.on_message(message.content, chat_history))()
+        # Initial message
+        msg = cl.Message(content="")
 
-        # Simplify citation numbers in the response
-        final_result = simplify_citation_numbers(result.response, result.subsections)
-        result.response = final_result.response
-        result.subsections = final_result.subsections
-
-        logger.info("Raw response: %s", result.response)
-        msg_content = format_response(
-            subsections=result.subsections,
-            response=result.response,
-            config=engine.formatting_config,
-            attributes=result.attributes,
+        # Get response generator and metadata
+        response_generator, attributes, subsections = await engine.on_message_streaming(
+            message.content, chat_history
         )
 
-        await cl.Message(
-            type="assistant_message",
-            content=msg_content,
-            metadata=_get_retrieval_metadata(result),
-        ).send()
+        # Collect full response _while_ streaming
+        # See: https://docs.chainlit.io/api-reference/message#stream-a-message
+        full_response = ""
+        async for chunk in response_generator:
+            full_response += chunk
+            await msg.stream_token(chunk)
+
+        # When streaming complete, remap citations
+        final_result = simplify_citation_numbers(full_response, subsections)
+
+        # Format final response
+        msg_content = format_response(
+            subsections=final_result.subsections,
+            response=final_result.response,
+            config=engine.formatting_config,
+            attributes=attributes,
+        )
+
+        # Update the message with formatted content and metadata
+        # See: https://docs.chainlit.io/api-reference/message#update-a-message
+        msg.content = msg_content
+        msg.metadata = {
+            "system_prompt": engine.system_prompt_2,
+            "subsections": [
+                {
+                    "id": citations.id,
+                    "chunk.id": str(citations.chunk.id),
+                    "document.name": citations.chunk.document.name,
+                    "headings": citations.text_headings,
+                    "text": citations.text,
+                }
+                for citations in final_result.subsections
+            ],
+            "raw_response": final_result.response,
+            "attributes": attributes.model_dump(),
+        }
+        await msg.update()
 
         if engine.show_msg_attributes:
-            await _msg_attributes(result.attributes)
+            await _msg_attributes(attributes)
     except Exception as err:  # pylint: disable=broad-exception-caught
         await cl.Message(
             type="system_message",


### PR DESCRIPTION
## Ticket
https://navalabs.atlassian.net/browse/DST-946

## Changes
- Changed `on_message` in chainlit.py to use our new streaming functionality:
  - `on_message_streaming()` to get async response generator
  - Streams tokens in with `msg.stream_token()`
  - `msg.update()` to get final message with remapped citations and formatting

## Context for reviewers
Adds streaming support to our Chainlit UI interface
Works by:
1. Creating empty message first then streams tokens
2. After streaming is done, updates message with remapped and formatted citations
3. Reuses all existing functionality for the citations remapping, metadata, and tthe attributes

Chainlit docs:
- [Streaming Messages](https://docs.chainlit.io/api-reference/message#stream-a-message)
- [Updating Messages](https://docs.chainlit.io/api-reference/message#update-a-message)

## Testing
Tested functionality through `/chat` UI, verified threads in LiteralAI logs:
- Tested with question: "What benefits are available for low-income families in Los Angeles?"
- Tested with "batch processing"
- Tested canned response with out-of-scope question

Did not change unit tests needed as this modifies only the UI layer using streaming functionality from previous PR.

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-298-app-dev-1217013430.us-east-1.elb.amazonaws.com
- Deployed commit: 3a26eb60d117109d09f25c2bd83fe077bb9117ea
<!-- app - end PR environment info -->