### PR TITLE
fix: Don't create LiteralAI data layer in test_chat_api

### DIFF
--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -42,6 +42,8 @@ logger = logging.getLogger(__name__)
 
 @cl.data_layer
 def chainlit_data_layer() -> ChainlitPolyDataLayer:
+    print("chainlit_data_layer() called")
+    # import pdb; pdb.set_trace()
     data_layers = None
     if app_config.literal_api_key_for_api:
         data_layers = [

--- a/app/src/chat_api.py
+++ b/app/src/chat_api.py
@@ -42,8 +42,6 @@ logger = logging.getLogger(__name__)
 
 @cl.data_layer
 def chainlit_data_layer() -> ChainlitPolyDataLayer:
-    print("chainlit_data_layer() called")
-    # import pdb; pdb.set_trace()
     data_layers = None
     if app_config.literal_api_key_for_api:
         data_layers = [

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -28,6 +28,11 @@ from tests.src.test_chainlit_data import clear_data_layer_data
 
 @pytest.fixture
 def no_literalai_data_layer(monkeypatch):
+    """
+    Disables the LiteralAI data layer by clearing the API key environment variable
+    and resetting the `literal_api_key_for_api` attribute in the app configuration.
+    This prevents unintentional creation of the data layer during tests.
+    """
     monkeypatch.setenv("LITERAL_API_KEY", "")
     monkeypatch.setattr(app_config, "literal_api_key_for_api", "")
 

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -38,7 +38,7 @@ def no_literalai_data_layer(monkeypatch):
 
 
 @pytest.fixture
-def async_client(no_literalai_data_layer, db_session):  # mock LiteralAI when testing API
+def async_client(no_literalai_data_layer, db_session):
     """
     The typical FastAPI TestClient creates its own event loop to handle requests,
     which led to issues when testing code that relies on asynchronous operations

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -13,6 +13,7 @@ import chainlit as cl
 from chainlit import data as cl_data
 from chainlit.data.literalai import LiteralDataLayer
 from src import chainlit_data, chat_api
+from src.app_config import app_config
 from src.chat_api import (
     ChatEngineSettings,
     ChatSession,
@@ -33,29 +34,32 @@ from tests.src.test_chainlit_data import clear_data_layer_data
 def mock_lai(monkeypatch):
     # Set LITERAL_API_KEY to create a secondary data layer
     monkeypatch.setenv("LITERAL_API_KEY", "")
+    monkeypatch.setattr(app_config, "literal_api_key_for_api", "")
 
     # Create mock for the secondary data layer
-    class MockLiteralAiDataLayer(LiteralDataLayer):
-        def __init__(self):
-            self.stored_user = None
+    # class MockLiteralAiDataLayer(LiteralDataLayer):
+    #     def __init__(self):
+    #         self.stored_user = None
 
-        async def create_user(self, user: cl.User):
-            self.stored_user = cl.PersistedUser(
-                id=str(uuid.uuid4()),
-                identifier=user.identifier,
-                metadata=user.metadata,
-                createdAt=str(datetime.datetime.now()),
-            )
-            return self.stored_user
+    #     async def create_user(self, user: cl.User):
+    #         self.stored_user = cl.PersistedUser(
+    #             id=str(uuid.uuid4()),
+    #             identifier=user.identifier,
+    #             metadata=user.metadata,
+    #             createdAt=str(datetime.datetime.now()),
+    #         )
+    #         return self.stored_user
 
-        async def get_user(self, identifier: str):
-            assert identifier == self.stored_user.identifier
-            return self.stored_user
+    #     async def get_user(self, identifier: str):
+    #         assert identifier == self.stored_user.identifier
+    #         return self.stored_user
 
-    # Create a no-op mock for the secondary data layer
-    monkeypatch.setattr(
-        chainlit_data, "get_literal_data_layer", lambda _key: MockLiteralAiDataLayer()
-    )
+    # # Create a no-op mock for the secondary data layer
+    # monkeypatch.setattr(
+    #     chainlit_data, "get_literal_data_layer", lambda _key: (_ for _ in ()).throw(NotImplementedError("Mock LiteralAI Data Layer not implemented"))
+    # )
+    print("mock_lai() called")
+    # import pdb; pdb.set_trace()
 
 
 @pytest.fixture
@@ -130,6 +134,9 @@ async def test_api_engines(async_client, db_session):
 
 @pytest.mark.asyncio
 async def test_api_engines__dbsession_contextvar(async_client, monkeypatch, db_session):
+    # dl = chat_api.cl_get_data_layer()
+    # dl.data_layers
+    # import pdb; pdb.set_trace()
     event = asyncio.Event()
     db_sessions = []
     orig_init_chat_session = chat_api._init_chat_session


### PR DESCRIPTION
If `LITERAL_API_KEY_FOR_API` is set locally, a LiteralAI data layer is created unintentionally.
[Slack](https://nava.slack.com/archives/C06DP498D1D/p1746027863743589?thread_ts=1746017995.398199&cid=C06DP498D1D)

Adding `monkeypatch.setattr(app_config, "literal_api_key_for_api", "")` in `mock_lai()` prevents the LiteralAI data layer from being created.
Reasoning:
- `mock_lai()` is called before `chainlit_data_layer()`, which is called by `@cl.data_layer`
- so monkeypatch in `mock_lai()`  before `app_config.literal_api_key_for_api` is accessed in `chainlit_data_layer()`

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-300-app-dev-277212110.us-east-1.elb.amazonaws.com
- Deployed commit: b626616bb0ed515f2082747ff5f74d948d2f3e81
<!-- app - end PR environment info -->