### PR TITLE
fix: Improve referral link decision criteria in ImagineLaEngine

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -403,7 +403,9 @@ If the user's question is about these questions related to the benefit navigator
 then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
 
 For referral links below, only set canned_response to a referral link if:
-The user is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?") and the question is narrowly about the process of obtaining that resource and the question does not appear to be about eligibility, benefits programs, or resources for specific populations
+- Sser is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
+- Question is narrowly about the process of obtaining that resource
+- Question does not appear to be about eligibility, benefits programs, or resources for specific populations
 
 If these criteria are met, then set canned_response to:
 "Here's a trusted link to learn more: [referral link title](referral link). \

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -402,13 +402,8 @@ If the user's question is about these questions related to the benefit navigator
 - Or other kinds of support questions for the Benefit Navigator tool
 then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
 
-If canned_response is not set by the above instructions, then consider referral links. 
-Only use a referral link if the user is explicitly asking how to obtain/access/find the exact resource described by one of the referral links below.
-
 For referral links below, only set canned_response to a referral link if:
-1. The user is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
-2. and the question is narrowly about the process of obtaining that resource
-3. and the question does not appear to be about eligibility, benefits programs, or resources for specific populations
+The user is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?") and the question is narrowly about the process of obtaining that resource and the question does not appear to be about eligibility, benefits programs, or resources for specific populations
 
 If these criteria are met, then set canned_response to:
 "Here's a trusted link to learn more: [referral link title](referral link). \

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -402,11 +402,7 @@ If the user's question is about these questions related to the benefit navigator
 - Or other kinds of support questions for the Benefit Navigator tool
 then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
 
-# Precedence of canned_response:
-# 1. Coverage list of supported benefit programs
-# 2. Password reset instructions for the Benefit Navigator
-# 3. Benefit Navigator support issue instructions
-# Only if none of the above apply should you consider referral links
+If canned_response is not set by the above instructions, then consider referral links
 
 # Referral links section
 # Important: Be strict about when to use referral links

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -403,7 +403,7 @@ If the user's question is about these questions related to the benefit navigator
 then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
 
 For referral links below, only set canned_response to a referral link if:
-- Sser is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
+- User is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
 - Question is narrowly about the process of obtaining that resource
 - Question does not appear to be about eligibility, benefits programs, or resources for specific populations
 

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -402,13 +402,8 @@ If the user's question is about these questions related to the benefit navigator
 - Or other kinds of support questions for the Benefit Navigator tool
 then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
 
-If canned_response is not set by the above instructions, then consider referral links
-
-# Referral links section
-# Important: Be strict about when to use referral links
-# Only use a referral link if the user is explicitly asking how to obtain/access/find the exact resource described by one of the referral links below.
-# By default, prefer setting needs_context=True to search the knowledge base.
-# When uncertain, do not use referral links - set needs_context=True instead.
+If canned_response is not set by the above instructions, then consider referral links. 
+Only use a referral link if the user is explicitly asking how to obtain/access/find the exact resource described by one of the referral links below.
 
 For referral links below, only set canned_response to a referral link if:
 1. The user is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
@@ -443,11 +438,11 @@ Referral links: Format: [referral link title](referral link):
 - [See Federal Poverty Levels](https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines)
 - [Find Diapers](https://www.phfewic.org/en/diaper-resources-in-la-county)
 
-# Examples to illustrate correct referral link decisions:
-# Question: "How do I get an ID card?" → Use referral link for "Get an ID card"
-# Question: "Where can I apply for a passport?" → Use referral link for "Get a Passport"
-# Question: "Where can foster youth find legal help?" → DO NOT use referral link, set needs_context=True
-# Question: "What benefits can immigrants get?" → DO NOT use referral link, set needs_context=True
+Examples to illustrate correct referral link decisions:
+- Question: "How do I get an ID card?" → Use referral link for "Get an ID card"
+- Question: "Where can I apply for a passport?" → Use referral link for "Get a Passport"
+- Question: "Where can foster youth find legal help?" → DO NOT use referral link, set needs_context=True
+- Question: "What benefits can immigrants get?" → DO NOT use referral link, set needs_context=True
 
 If the user's question is related to any of the following policy updates listed below, \
 set canned_response to empty string and set alert_message to one or more of the following text based on the user's question:

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -402,13 +402,24 @@ If the user's question is about these questions related to the benefit navigator
 - Or other kinds of support questions for the Benefit Navigator tool
 then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
 
-If the user's question is about a referral link below, set canned_response to: \
+# Referral links section
+# Important: Be strict about when to use referral links
+# Only use a referral link if the user is explicitly asking how to obtain/access/find the exact resource described by one of the referral links below.
+# By default, prefer setting needs_context=True to search the knowledge base.
+# When uncertain, do not use referral links - set needs_context=True instead.
+
+For referral links below, only set canned_response to a referral link if:
+1. The user is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
+2. and the question is narrowly about the process of obtaining that resource
+3. and the question does not appear to be about eligibility, benefits programs, or resources for specific populations
+
+If these criteria are met, then set canned_response to:
 "Here's a trusted link to learn more: [referral link title](referral link). \
 I can give more detail about the benefit programs and tax credits in the [Benefits Information Hub](https://benefitnavigator.web.app/contenthub)."
 
 Referral links: Format: [referral link title](referral link):
 - [Get an ID card](https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/identification-id-cards/)
-- [Get a Passport]: [https://travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html](https://travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html)
+- [Get a Passport](https://travel.state.gov/content/travel/en/passports/need-passport/apply-in-person.html)
 - [Request Birth Certificates](https://www.cdph.ca.gov/Programs/CHSI/Pages/Vital-Records-Obtaining-Certified-Copies-of-Birth-Records.aspx)
 - [Request a Social Security Number](https://www.ssa.gov/number-card/request-number-first-time)
 - [Request an ITIN](https://www.irs.gov/tin/itin/how-to-apply-for-an-itin)
@@ -428,6 +439,12 @@ Referral links: Format: [referral link title](referral link):
 - [Find LADWP contact info](https://www.ladwp.com/account/customer-service/customer-service-centers)
 - [Find Legal Aid](https://lafla.org/get-help/)
 - [See Federal Poverty Levels](https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines)
+
+# Examples to illustrate correct referral link decisions:
+# Question: "How do I get an ID card?" → Use referral link for "Get an ID card"
+# Question: "Where can I apply for a passport?" → Use referral link for "Get a Passport"
+# Question: "Where can foster youth find legal help?" → DO NOT use referral link, set needs_context=True
+# Question: "What benefits can immigrants get?" → DO NOT use referral link, set needs_context=True
 
 If the user's question is related to any of the following policy updates listed below, \
 set canned_response to empty string and set alert_message to one or more of the following text based on the user's question:

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -402,6 +402,12 @@ If the user's question is about these questions related to the benefit navigator
 - Or other kinds of support questions for the Benefit Navigator tool
 then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
 
+# Precedence of canned_response:
+# 1. Coverage list of supported benefit programs
+# 2. Password reset instructions for the Benefit Navigator
+# 3. Benefit Navigator support issue instructions
+# Only if none of the above apply should you consider referral links
+
 # Referral links section
 # Important: Be strict about when to use referral links
 # Only use a referral link if the user is explicitly asking how to obtain/access/find the exact resource described by one of the referral links below.
@@ -439,6 +445,7 @@ Referral links: Format: [referral link title](referral link):
 - [Find LADWP contact info](https://www.ladwp.com/account/customer-service/customer-service-centers)
 - [Find Legal Aid](https://lafla.org/get-help/)
 - [See Federal Poverty Levels](https://aspe.hhs.gov/topics/poverty-economic-mobility/poverty-guidelines)
+- [Find Diapers](https://www.phfewic.org/en/diaper-resources-in-la-county)
 
 # Examples to illustrate correct referral link decisions:
 # Question: "How do I get an ID card?" → Use referral link for "Get an ID card"


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-951

## Changes

- Updated `system_prompt_1` in ImagineLaEngine to improve referral link decision criteria
- Added specific decision criteria for when to use referral links
- Examples to illustrate correct usage

## Context for reviewers

Message analysis prompt was incorrectly using referral links for questions about foster youth resources, where it should have instead searched the knowledge base. The previous prompt instruction was previously: "If the user's question is about a referral link below...". This appeared to lead to false positives where LLM serves an irrelevant link for foster youth resource questions.

Proposed edits makes criteria explicit and defaults to `need_context=True` when uncertain. [Slack link](https://nava.slack.com/archives/C06DP498D1D/p1746041077878979)

## Testing

Tested with problematic queries that previously triggered incorrect referral links:

Query: "Where can I find foster youth resources?"
- Before: LGBTQ Resources link
- After: Searches and returns foster youth benefits info

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-301-app-dev-1808349357.us-east-1.elb.amazonaws.com
- Deployed commit: e271d60963b36b530d30a6bb1e594790eb70c7aa
<!-- app - end PR environment info -->