### PR TITLE
fix: Translate canned response and alert message to the same language as the user's question

### DIFF
--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -356,10 +356,12 @@ Analyze the user's message to respond with a JSON dictionary populated with the 
 - canned_response: empty string
 - alert_message: empty string
 - needs_context: True
+- users_language: empty string
 - translated_message: empty string
 - benefit_program: empty string
-The canned_response string must be in the same language as the user's question. \
-If canned_response is set to a non-empty string, leave the other JSON fields as their default values.
+Set the users_language to the language of the user's question.
+The canned_response and alert_message string must be in the same language as the user's question. \
+If canned_response is set to a non-empty string, set needs_context to True.
 
 Benefit programs include:
 - CalWORKS (including CalWORKS childcare)
@@ -445,7 +447,7 @@ Examples to illustrate correct referral link decisions:
 - Question: "What benefits can immigrants get?" → DO NOT use referral link, set needs_context=True
 
 If the user's question is related to any of the following policy updates listed below, \
-set canned_response to empty string and set alert_message to one or more of the following text, translated to the same language as the user's question:
+set canned_response to empty string and set alert_message to a translation of one or more of the following text in the same language as the user's question:
 
 - Medi-Cal for immigrants: "Since January 1, 2024, everyone who lives in California can qualify for full-scope Medi-Cal, regardless of immigration status. All other Medi-Cal eligibility rules, including income limits, still apply. [Read more](https://www.coveredca.com/learning-center/information-for-immigrants/)."
 - Medi-Cal asset limits: "As of January 1, 2024, assets will no longer be counted to determine Medi-Cal eligibility. [Read more](https://www.dhcs.ca.gov/Get-Medi-Cal/Pages/asset-limits.aspx)"
@@ -457,6 +459,7 @@ with household income over 200% of the Federal Poverty Level (FPL); or the house
 because of an intentional program violation, or some other specific compliance requirement; or there is a disputed claim for benefits paid in the past. \
 [Read more](https://calfresh.guide/how-many-resources-a-household-can-have/#:~:text=In%20California%2C%20if%20the%20household,recipients%20have%20a%20resource%20limit)"
 
+Translate canned_response and alert_message strings to be in the same language as the user's question.
 If the user's question is to translate text, set needs_context to False.
 If the user's question is not in English, set translated_message to be an English translation of the user's message."""
 

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -449,15 +449,19 @@ Examples to illustrate correct referral link decisions:
 If the user's question is related to any of the following policy updates listed below, \
 set canned_response to empty string and set alert_message to a translation of one or more of the following text in the same language as the user's question:
 
-- Medi-Cal for immigrants: "Since January 1, 2024, everyone who lives in California can qualify for full-scope Medi-Cal, regardless of immigration status. All other Medi-Cal eligibility rules, including income limits, still apply. [Read more](https://www.coveredca.com/learning-center/information-for-immigrants/)."
-- Medi-Cal asset limits: "As of January 1, 2024, assets will no longer be counted to determine Medi-Cal eligibility. [Read more](https://www.dhcs.ca.gov/Get-Medi-Cal/Pages/asset-limits.aspx)"
-- CalFresh work requirements (ABAWDs, time limits): "California has a statewide waiver through October 31, 2025. \
-This means no ABAWDs living in California will have to meet the work requirement to keep receiving CalFresh benefits. ABAWDs who have lost their CalFresh benefits may reapply and continue to receive CalFresh if otherwise eligible. [Read more](https://www.cdss.ca.gov/inforesources/calfresh/abawd)"
-- Calfresh asset limits/resource limits: "California has dramatically modified its rules for 'categorical eligibility' in the CalFresh program, \
+- Medi-Cal for immigrants: "**Policy update**: Since January 1, 2024, everyone who lives in California can qualify for full-scope Medi-Cal, regardless of immigration status. All other Medi-Cal eligibility rules, including income limits, still apply. [Read more](https://www.coveredca.com/learning-center/information-for-immigrants/).
+The rest of this answer may be outdated."
+- Medi-Cal asset limits: "**Policy update**: As of January 1, 2024, assets will no longer be counted to determine Medi-Cal eligibility. [Read more](https://www.dhcs.ca.gov/Get-Medi-Cal/Pages/asset-limits.aspx)
+The rest of this answer may be outdated."
+- CalFresh work requirements (ABAWDs, time limits): "**Policy update**: California has a statewide waiver through October 31, 2025. \
+This means no ABAWDs living in California will have to meet the work requirement to keep receiving CalFresh benefits. ABAWDs who have lost their CalFresh benefits may reapply and continue to receive CalFresh if otherwise eligible. [Read more](https://www.cdss.ca.gov/inforesources/calfresh/abawd)
+The rest of this answer may be outdated."
+- Calfresh asset limits/resource limits: "**Policy update**: California has dramatically modified its rules for 'categorical eligibility' in the CalFresh program, \
 such that asset limits have all but been removed. The only exceptions would be if either the household includes one or more members who are aged or disabled, \
 with household income over 200% of the Federal Poverty Level (FPL); or the household fits within a narrow group of cases where it has been disqualified \
 because of an intentional program violation, or some other specific compliance requirement; or there is a disputed claim for benefits paid in the past. \
-[Read more](https://calfresh.guide/how-many-resources-a-household-can-have/#:~:text=In%20California%2C%20if%20the%20household,recipients%20have%20a%20resource%20limit)"
+[Read more](https://calfresh.guide/how-many-resources-a-household-can-have/#:~:text=In%20California%2C%20if%20the%20household,recipients%20have%20a%20resource%20limit)
+The rest of this answer may be outdated."
 
 Translate canned_response and alert_message strings to be in the same language as the user's question.
 If the user's question is to translate text, set needs_context to False.
@@ -530,8 +534,8 @@ they can apply for both, and the state will check if they qualify for either one
             f"System Prompt 1 (analyze_message) took {system_prompt_1_duration:.2f} seconds"
         )
 
-        if attributes.alert_message:
-            attributes.alert_message = f"**Policy update**: {attributes.alert_message}\n\nThe rest of this answer may be outdated."
+        # if attributes.alert_message:
+        #     attributes.alert_message = attributes.alert_message
 
         if attributes.canned_response:
             return OnMessageResult(attributes.canned_response, self.system_prompt_1, attributes)
@@ -555,8 +559,8 @@ they can apply for both, and the state will check if they qualify for either one
         )
 
         # Format alert message the same way as non-streaming version
-        if attributes.alert_message:
-            attributes.alert_message = f"**Policy update**: {attributes.alert_message}\n\nThe rest of this answer may be outdated."
+        # if attributes.alert_message:
+        #     attributes.alert_message = f"**Policy update**: {attributes.alert_message}\n\nThe rest of this answer may be outdated."
 
         # Handle canned responses - return the entire response at once with empty subsections
         if attributes.canned_response:

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -534,9 +534,6 @@ they can apply for both, and the state will check if they qualify for either one
             f"System Prompt 1 (analyze_message) took {system_prompt_1_duration:.2f} seconds"
         )
 
-        # if attributes.alert_message:
-        #     attributes.alert_message = attributes.alert_message
-
         if attributes.canned_response:
             return OnMessageResult(attributes.canned_response, self.system_prompt_1, attributes)
 
@@ -557,10 +554,6 @@ they can apply for both, and the state will check if they qualify for either one
         logger.info(
             f"System Prompt 1 (analyze_message) took {system_prompt_1_duration:.2f} seconds"
         )
-
-        # Format alert message the same way as non-streaming version
-        # if attributes.alert_message:
-        #     attributes.alert_message = f"**Policy update**: {attributes.alert_message}\n\nThe rest of this answer may be outdated."
 
         # Handle canned responses - return the entire response at once with empty subsections
         if attributes.canned_response:

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -358,7 +358,7 @@ Analyze the user's message to respond with a JSON dictionary populated with the 
 - needs_context: True
 - translated_message: empty string
 - benefit_program: empty string
-The canned_response string should be in the same language as the user's question. \
+The canned_response string must be in the same language as the user's question. \
 If canned_response is set to a non-empty string, leave the other JSON fields as their default values.
 
 Benefit programs include:
@@ -402,7 +402,7 @@ If the user's question is about these questions related to the benefit navigator
 - Cannot find clients in user portal
 - Or other kinds of support questions for the Benefit Navigator tool
 then set canned_response to: "To get support with that issue, select 'Need help? Contact the support team' at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)", \
-translated to the same language as the user's question.
+but translated to the same language as the user's question.
 
 For referral links below, only set canned_response to a referral link if:
 - User is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
@@ -412,7 +412,7 @@ For referral links below, only set canned_response to a referral link if:
 If these criteria are met, then set canned_response to:
 "Here's a trusted link to learn more: [referral link title](referral link). \
 I can give more detail about the benefit programs and tax credits in the [Benefits Information Hub](https://benefitnavigator.web.app/contenthub).", \
-translated to the same language as the user's question.
+but translated to the same language as the user's question.
 
 Referral links: Format: [referral link title](referral link):
 - [Get an ID card](https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/identification-id-cards/)
@@ -445,8 +445,7 @@ Examples to illustrate correct referral link decisions:
 - Question: "What benefits can immigrants get?" → DO NOT use referral link, set needs_context=True
 
 If the user's question is related to any of the following policy updates listed below, \
-set canned_response to empty string and set alert_message to one or more of the following text based on the user's question, \
-translated to the same language as the user's question:
+set canned_response to empty string and set alert_message to one or more of the following text, translated to the same language as the user's question:
 
 - Medi-Cal for immigrants: "Since January 1, 2024, everyone who lives in California can qualify for full-scope Medi-Cal, regardless of immigration status. All other Medi-Cal eligibility rules, including income limits, still apply. [Read more](https://www.coveredca.com/learning-center/information-for-immigrants/)."
 - Medi-Cal asset limits: "As of January 1, 2024, assets will no longer be counted to determine Medi-Cal eligibility. [Read more](https://www.dhcs.ca.gov/Get-Medi-Cal/Pages/asset-limits.aspx)"

--- a/app/src/chat_engine.py
+++ b/app/src/chat_engine.py
@@ -386,7 +386,8 @@ Child and Dependent Care Tax Credit (CDCTC), California Renter's Credit, Califor
 Set benefit_program to the name of the in-scope benefit program that the user's question is about.
 
 If the user is trying to understand what benefit programs the chatbot supports, \
-set canned_response to a list that gives examples and describes categories for the in-scope benefit programs. \
+set canned_response to a list that gives examples and describes categories for the in-scope benefit programs,
+translated to the same language as the user's question. \
 Example prompts: "What do you know about?" "What info do you have?" "What can I ask you?" "What programs do you cover?" "What benefits do you cover?" "What topics do you know?"
 
 If the user's question is about how to reset their password for the Benefit Navigator, set canned_response to \
@@ -400,7 +401,8 @@ If the user's question is about these questions related to the benefit navigator
 - Cannot create or save reports
 - Cannot find clients in user portal
 - Or other kinds of support questions for the Benefit Navigator tool
-then set canned_response to: "To get support with that issue, select "Need help? Contact the support team" at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)"
+then set canned_response to: "To get support with that issue, select 'Need help? Contact the support team' at the top of this chatbot to open a ticket with the operations team. You can also email us at [socialbenefithelp@imaginela.org](mailto:socialbenefithelp@imaginela.org)", \
+translated to the same language as the user's question.
 
 For referral links below, only set canned_response to a referral link if:
 - User is explicitly asking how to obtain/access/find that specific resource (e.g., "How do I get an ID card?")
@@ -409,7 +411,8 @@ For referral links below, only set canned_response to a referral link if:
 
 If these criteria are met, then set canned_response to:
 "Here's a trusted link to learn more: [referral link title](referral link). \
-I can give more detail about the benefit programs and tax credits in the [Benefits Information Hub](https://benefitnavigator.web.app/contenthub)."
+I can give more detail about the benefit programs and tax credits in the [Benefits Information Hub](https://benefitnavigator.web.app/contenthub).", \
+translated to the same language as the user's question.
 
 Referral links: Format: [referral link title](referral link):
 - [Get an ID card](https://www.dmv.ca.gov/portal/driver-licenses-identification-cards/identification-id-cards/)
@@ -442,7 +445,8 @@ Examples to illustrate correct referral link decisions:
 - Question: "What benefits can immigrants get?" → DO NOT use referral link, set needs_context=True
 
 If the user's question is related to any of the following policy updates listed below, \
-set canned_response to empty string and set alert_message to one or more of the following text based on the user's question:
+set canned_response to empty string and set alert_message to one or more of the following text based on the user's question, \
+translated to the same language as the user's question:
 
 - Medi-Cal for immigrants: "Since January 1, 2024, everyone who lives in California can qualify for full-scope Medi-Cal, regardless of immigration status. All other Medi-Cal eligibility rules, including income limits, still apply. [Read more](https://www.coveredca.com/learning-center/information-for-immigrants/)."
 - Medi-Cal asset limits: "As of January 1, 2024, assets will no longer be counted to determine Medi-Cal eligibility. [Read more](https://www.dhcs.ca.gov/Get-Medi-Cal/Pages/asset-limits.aspx)"

--- a/app/src/generate.py
+++ b/app/src/generate.py
@@ -155,6 +155,8 @@ def completion_args(llm: str) -> dict[str, Any]:
 class MessageAttributes(BaseModel):
     "'Message' refers to the user's message/question"
     needs_context: bool
+    # The language of the user's question
+    users_language: str
     # The user's message/question translated by the LLM so that RAG retrieval is in English
     translated_message: str
 

--- a/app/tests/src/test_batch_process.py
+++ b/app/tests/src/test_batch_process.py
@@ -61,6 +61,7 @@ def test_process_question(monkeypatch, engine):
         subsections=[Subsection("citation-1", chunk, 0, subsection_text)],
         attributes=ImagineLA_MessageAttributes(
             needs_context=True,
+            users_language="en",
             translated_message="",
             benefit_program="CalFresh",
             canned_response="",
@@ -78,6 +79,7 @@ def test_process_question(monkeypatch, engine):
         "citation_1_source": mock_result.subsections[0].chunk.document.source,
         "citation_1_text": subsection_text,
         "attrib__needs_context": True,
+        "attrib__users_language": "en",
         "attrib__translated_message": "",
         "attrib__benefit_program": "CalFresh",
         "attrib__alert_message": "Some alert message.",

--- a/app/tests/src/test_chainlit.py
+++ b/app/tests/src/test_chainlit.py
@@ -31,7 +31,7 @@ def test__get_retrieval_metadata(chunks_with_scores):
     result = OnMessageResult(
         "Some response",
         system_prompt,
-        MessageAttributes(needs_context=True, translated_message=""),
+        MessageAttributes(needs_context=True, users_language="en", translated_message=""),
         chunks_with_scores=chunks_with_scores,
         subsections=subsections,
     )

--- a/app/tests/src/test_chat_api.py
+++ b/app/tests/src/test_chat_api.py
@@ -357,7 +357,7 @@ async def test_run_query__1_citation(subsections):
             return OnMessageResult(
                 "Response from LLM (citation-2)",
                 "Some system prompt",
-                MessageAttributes(needs_context=True, translated_message=""),
+                MessageAttributes(needs_context=True, users_language="en", translated_message=""),
                 chunks_with_scores=[],
                 subsections=subsections,
             )
@@ -379,20 +379,18 @@ async def test_run_query__2_citations(subsections):
                 "Some system prompt",
                 ImagineLA_MessageAttributes(
                     needs_context=True,
+                    users_language="en",
                     translated_message="",
                     benefit_program="CalFresh",
                     canned_response="",
-                    alert_message="**Policy update**: Some alert message.\n\nThe rest of this answer may be outdated.",
+                    alert_message="Some alert message.",
                 ),
                 chunks_with_scores=[],
                 subsections=subsections,
             )
 
     query_response, _metadata = await run_query(MockChatEngine(), "My question")
-    assert (
-        query_response.alert_message
-        == "**Policy update**: Some alert message.\n\nThe rest of this answer may be outdated."
-    )
+    assert query_response.alert_message == "Some alert message."
     assert (
         query_response.response_text
         == f"{query_response.alert_message}\n\nResponse from LLM (citation-1) (citation-2)"
@@ -409,7 +407,7 @@ async def test_run_query__unknown_citation(subsections, caplog):
             return OnMessageResult(
                 "Response from LLM (citation-2)(citation-44)",
                 "Some system prompt",
-                MessageAttributes(needs_context=True, translated_message=""),
+                MessageAttributes(needs_context=True, users_language="en", translated_message=""),
                 chunks_with_scores=[],
                 subsections=subsections,
             )
@@ -543,7 +541,9 @@ async def test_query_stream_basic(async_client, monkeypatch, db_session):
                 yield "hello "
                 yield "world"
 
-            attributes = MessageAttributes(needs_context=False, translated_message="")
+            attributes = MessageAttributes(
+                needs_context=False, users_language="en", translated_message=""
+            )
             return gen(), attributes, []
 
     monkeypatch.setattr(chat_api, "get_chat_engine", lambda session: MockEngine())
@@ -589,6 +589,7 @@ async def test_query_stream_with_alert(async_client, monkeypatch, db_session):
             # Provide an attributes object with alert_message
             attributes = ImagineLA_MessageAttributes(
                 needs_context=False,
+                users_language="en",
                 translated_message="",
                 benefit_program="",
                 canned_response="",

--- a/app/tests/src/test_chat_engine.py
+++ b/app/tests/src/test_chat_engine.py
@@ -44,6 +44,7 @@ def test_on_message_Imagine_LA_canned_response(monkeypatch):
         "analyze_message",
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=True,
+            users_language="en",
             translated_message="",
             benefit_program="",
             canned_response="This is a canned response",
@@ -64,6 +65,7 @@ def test_on_message_Imagine_LA_alert_message(monkeypatch):
         "analyze_message",
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=True,
+            users_language="en",
             translated_message="",
             benefit_program="CalFresh",
             canned_response="",
@@ -77,8 +79,7 @@ def test_on_message_Imagine_LA_alert_message(monkeypatch):
     result = engine.on_message("What is AI?")
     assert result.response == "This is a generated response"
     assert result.attributes.benefit_program == "CalFresh"
-    assert result.attributes.alert_message.startswith("**Policy update**: ")
-    assert result.attributes.alert_message.endswith("\n\nThe rest of this answer may be outdated.")
+    assert result.attributes.alert_message == "Some alert message"
 
 
 def test_on_message_Imagine_LA_needs_context_False(monkeypatch):
@@ -87,6 +88,7 @@ def test_on_message_Imagine_LA_needs_context_False(monkeypatch):
         "analyze_message",
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=False,
+            users_language="en",
             translated_message="",
             benefit_program="CalFresh",
             canned_response="",
@@ -101,8 +103,7 @@ def test_on_message_Imagine_LA_needs_context_False(monkeypatch):
     assert not result.chunks_with_scores
     assert not result.subsections
     assert result.attributes.benefit_program == "CalFresh"
-    assert result.attributes.alert_message.startswith("**Policy update**: ")
-    assert result.attributes.alert_message.endswith("\n\nThe rest of this answer may be outdated.")
+    assert result.attributes.alert_message == "Some alert message"
 
 
 @pytest.mark.asyncio
@@ -112,6 +113,7 @@ async def test_on_message_streaming_Imagine_LA_canned_response(monkeypatch):
         "analyze_message",
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=True,
+            users_language="en",
             translated_message="",
             benefit_program="",
             canned_response="This is a canned response",
@@ -140,6 +142,7 @@ async def test_on_message_streaming_Imagine_LA_with_context(monkeypatch):
         "analyze_message",
         lambda *_, **_kw: ImagineLA_MessageAttributes(
             needs_context=True,
+            users_language="en",
             translated_message="",
             benefit_program="CalFresh",
             canned_response="",
@@ -167,6 +170,5 @@ async def test_on_message_streaming_Imagine_LA_with_context(monkeypatch):
 
     assert chunks == ["First chunk", " second chunk", " final chunk"]
     assert attributes.benefit_program == "CalFresh"
-    assert attributes.alert_message.startswith("**Policy update**: ")
-    assert attributes.alert_message.endswith("\n\nThe rest of this answer may be outdated.")
+    assert attributes.alert_message == "Some alert message"
     assert subsections == []  # Empty because we mocked retrieve_with_scores to return []

--- a/app/tests/src/test_format.py
+++ b/app/tests/src/test_format.py
@@ -32,7 +32,7 @@ def test__get_breadcrumb_html():
 
 def test_format_response(chunks_with_scores):
     config = FormattingConfig()
-    msg_attribs = MessageAttributes(needs_context=True, translated_message="")
+    msg_attribs = MessageAttributes(needs_context=True, users_language="en", translated_message="")
     # Test empty response
     assert format_response([], "", config, msg_attribs) == "<div></div>"
 


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-956

## Changes

Add 'translated to the same language as the user's question' to prompt

## Testing

Ask questions that would trigger a canned response or alert message in a non-English language; expect response to be in the non-English language.

<img width="781" alt="image" src="https://github.com/user-attachments/assets/2eee25fb-e3b9-489a-985c-b9d569de03c4" />

<img width="781" alt="image" src="https://github.com/user-attachments/assets/7467ba75-072e-4db8-83bd-791204ae317d" />

<img width="781" alt="image" src="https://github.com/user-attachments/assets/869a80de-ee22-4955-bc1b-65e8d98d3c9e" />

<img width="781" alt="image" src="https://github.com/user-attachments/assets/0b79d9fe-45c8-4622-bf16-c1404d9ac281" />




<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-302-app-dev-1677135999.us-east-1.elb.amazonaws.com
- Deployed commit: f7ca917ec4c5604a773f1eeafba16838d8012404
<!-- app - end PR environment info -->