### PR TITLE
fix: resolve Promptfoo exports to Google Sheet

### DIFF
--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -59,8 +59,6 @@ jobs:
         run: |
           echo '${{ secrets.GOOGLE_CREDENTIALS_JSON }}' > "/tmp/gcp-creds.json"
           jq -e . "/tmp/gcp-creds.json" > /dev/null || echo "Warning: Invalid JSON format in credentials"
-          echo "Credentials info:"
-          jq -r '{"type": .type, "project_id": .project_id, "client_email": .client_email}' /tmp/gcp-creds.json
           echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds.json" >> "${GITHUB_ENV}"
 
       - name: Install promptfoo and googleapis
@@ -104,9 +102,6 @@ jobs:
             exit 1
           fi
 
-          echo "Input Sheet URL: $GOOGLE_SHEET_INPUT_URL"
-          echo "Output Sheet URL: $GOOGLE_SHEET_OUTPUT_URL"
-
           OUTPUT_JSON_FILE="/tmp/promptfoo-output.json"
 
           if [ -n "$PROMPTFOO_API_KEY" ]; then
@@ -118,7 +113,6 @@ jobs:
           if [ -f "${OUTPUT_JSON_FILE}" ]; then
             echo "Output JSON file generated successfully"
 
-            # Get the evaluation ID from the output file
             EVAL_ID=$(jq -r '.evaluationId // "unknown"' "${OUTPUT_JSON_FILE}")
 
             if [ "${EVAL_ID}" != "unknown" ] && [ "${EVAL_ID}" != "null" ]; then

--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           echo '${{ secrets.GOOGLE_CREDENTIALS_JSON }}' > "/tmp/gcp-creds.json"
           jq -e . "/tmp/gcp-creds.json" > /dev/null || echo "Warning: Invalid JSON format in credentials"
+          echo "Credentials info:"
+          jq -r '{"type": .type, "project_id": .project_id, "client_email": .client_email}' /tmp/gcp-creds.json
           echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds.json" >> "${GITHUB_ENV}"
 
       - name: Install promptfoo and googleapis
@@ -76,14 +78,7 @@ jobs:
       - name: Process config file
         run: |
           cp app/promptfoo/generateUniqueId.js /tmp/generateUniqueId.js
-          
-          # Export environment variables without quotes for envsubst
-          export GOOGLE_SHEET_INPUT_URL=$(echo $GOOGLE_SHEET_INPUT_URL | tr -d "'")
-          export GOOGLE_SHEET_OUTPUT_URL=$(echo $GOOGLE_SHEET_OUTPUT_URL | tr -d "'")
-          export CHATBOT_INSTANCE_URL=$(echo $CHATBOT_INSTANCE_URL | tr -d "'")
-          
           envsubst < app/promptfoo/promptfooconfig.ci.yaml > /tmp/promptfooconfig.processed.yaml
-          
           echo "Config file processed, checking..."
           grep -v "GOOGLE_SHEET\|CHATBOT_INSTANCE" /tmp/promptfooconfig.processed.yaml | grep -i "url\|path"
 

--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -107,27 +107,6 @@ jobs:
           echo "Input Sheet URL: $GOOGLE_SHEET_INPUT_URL"
           echo "Output Sheet URL: $GOOGLE_SHEET_OUTPUT_URL"
 
-          node -e "
-            const {google} = require('googleapis');
-            const auth = new google.auth.GoogleAuth({
-              scopes: ['https://www.googleapis.com/auth/spreadsheets']
-            });
-            auth.getClient().then(client => {
-              console.log('Successfully authenticated with Google');
-              const sheets = google.sheets({version: 'v4', auth: client});
-              // Extract spreadsheet ID from URL
-              const url = new URL('$GOOGLE_SHEET_OUTPUT_URL');
-              const path = url.pathname.split('/');
-              const spreadsheetId = path[3];
-              return sheets.spreadsheets.get({spreadsheetId});
-            }).then(response => {
-              console.log('Successfully accessed Google Sheet:', response.data.properties.title);
-            }).catch(error => {
-              console.error('Error accessing Google Sheet:', error);
-              process.exit(1);
-            });
-          "
-
           OUTPUT_JSON_FILE="/tmp/promptfoo-output.json"
 
           if [ -n "$PROMPTFOO_API_KEY" ]; then

--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -76,6 +76,12 @@ jobs:
       - name: Process config file
         run: |
           cp app/promptfoo/generateUniqueId.js /tmp/generateUniqueId.js
+          
+          # Export environment variables without quotes for envsubst
+          export GOOGLE_SHEET_INPUT_URL=$(echo $GOOGLE_SHEET_INPUT_URL | tr -d "'")
+          export GOOGLE_SHEET_OUTPUT_URL=$(echo $GOOGLE_SHEET_OUTPUT_URL | tr -d "'")
+          export CHATBOT_INSTANCE_URL=$(echo $CHATBOT_INSTANCE_URL | tr -d "'")
+          
           envsubst < app/promptfoo/promptfooconfig.ci.yaml > /tmp/promptfooconfig.processed.yaml
           
           echo "Config file processed, checking..."
@@ -83,8 +89,27 @@ jobs:
 
       - name: Run promptfoo evaluation
         id: eval
-        continue-on-error: true
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcp-creds.json
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PROMPTFOO_FAILED_TEST_EXIT_CODE: 0
         run: |
+          # Validate required credentials
+          if [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+            echo "Error: Google credentials file not found at $GOOGLE_APPLICATION_CREDENTIALS"
+            exit 1
+          fi
+
+          if ! jq -e . "$GOOGLE_APPLICATION_CREDENTIALS" > /dev/null 2>&1; then
+            echo "Error: Invalid JSON format in Google credentials file"
+            exit 1
+          fi
+
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "Error: OPENAI_API_KEY environment variable is not set"
+            exit 1
+          fi
+
           OUTPUT_JSON_FILE="/tmp/promptfoo-output.json"
 
           if [ -n "$PROMPTFOO_API_KEY" ]; then
@@ -113,9 +138,6 @@ jobs:
           else
             echo "No output JSON file was generated"
           fi
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          PROMPTFOO_FAILED_TEST_EXIT_CODE: 0
 
       - name: Create PR comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -89,7 +89,6 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PROMPTFOO_FAILED_TEST_EXIT_CODE: 0
         run: |
-          # Validate required credentials
           if [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
             echo "Error: Google credentials file not found at $GOOGLE_APPLICATION_CREDENTIALS"
             exit 1
@@ -105,6 +104,30 @@ jobs:
             exit 1
           fi
 
+          echo "Input Sheet URL: $GOOGLE_SHEET_INPUT_URL"
+          echo "Output Sheet URL: $GOOGLE_SHEET_OUTPUT_URL"
+
+          node -e "
+            const {google} = require('googleapis');
+            const auth = new google.auth.GoogleAuth({
+              scopes: ['https://www.googleapis.com/auth/spreadsheets']
+            });
+            auth.getClient().then(client => {
+              console.log('Successfully authenticated with Google');
+              const sheets = google.sheets({version: 'v4', auth: client});
+              // Extract spreadsheet ID from URL
+              const url = new URL('$GOOGLE_SHEET_OUTPUT_URL');
+              const path = url.pathname.split('/');
+              const spreadsheetId = path[3];
+              return sheets.spreadsheets.get({spreadsheetId});
+            }).then(response => {
+              console.log('Successfully accessed Google Sheet:', response.data.properties.title);
+            }).catch(error => {
+              console.error('Error accessing Google Sheet:', error);
+              process.exit(1);
+            });
+          "
+
           OUTPUT_JSON_FILE="/tmp/promptfoo-output.json"
 
           if [ -n "$PROMPTFOO_API_KEY" ]; then
@@ -116,8 +139,15 @@ jobs:
           if [ -f "${OUTPUT_JSON_FILE}" ]; then
             echo "Output JSON file generated successfully"
 
+            # Get the evaluation ID from the output file
+            EVAL_ID=$(jq -r '.evaluationId // "unknown"' "${OUTPUT_JSON_FILE}")
+
+            if [ "${EVAL_ID}" != "unknown" ] && [ "${EVAL_ID}" != "null" ]; then
+              echo "Exporting results to Google Sheets..."
+              promptfoo export "${EVAL_ID}" --output "${GOOGLE_SHEET_OUTPUT_URL}"
+            fi
+
             if [ -n "$PROMPTFOO_API_KEY" ]; then
-              EVAL_ID=$(jq -r '.evaluationId // "unknown"' "${OUTPUT_JSON_FILE}")
               SHARE_URL=$(jq -r '.shareableUrl // ""' "${OUTPUT_JSON_FILE}")
 
               if [ -z "${SHARE_URL}" ] && [ "${EVAL_ID}" != "unknown" ] && [ "${EVAL_ID}" != "null" ]; then

--- a/app/promptfoo/promptfooconfig.ci.yaml
+++ b/app/promptfoo/promptfooconfig.ci.yaml
@@ -28,4 +28,4 @@ evaluateOptions:
   showProgressBar: true
 
 tests: ${GOOGLE_SHEET_INPUT_URL}
-outputPath: ${GOOGLE_SHEET_OUTPUT_URL} 
+outputPath: ${GOOGLE_SHEET_OUTPUT_URL}

--- a/app/promptfoo/promptfooconfig.ci.yaml
+++ b/app/promptfoo/promptfooconfig.ci.yaml
@@ -4,7 +4,7 @@ description: 'Decision Support Tool Evaluation (CI)'
 prompts:
   - response
 providers:
-  - id: ${CHATBOT_INSTANCE_URL}
+  - id: "${CHATBOT_INSTANCE_URL}"
     config:
       method: POST
       headers:
@@ -27,5 +27,5 @@ evaluateOptions:
   delay: 1000
   showProgressBar: true
 
-tests: ${GOOGLE_SHEET_INPUT_URL}
-outputPath: ${GOOGLE_SHEET_OUTPUT_URL}
+tests: "${GOOGLE_SHEET_INPUT_URL}"
+outputPath: "${GOOGLE_SHEET_OUTPUT_URL}"

--- a/app/promptfoo/promptfooconfig.ci.yaml
+++ b/app/promptfoo/promptfooconfig.ci.yaml
@@ -4,7 +4,7 @@ description: 'Decision Support Tool Evaluation (CI)'
 prompts:
   - response
 providers:
-  - id: "${CHATBOT_INSTANCE_URL}"
+  - id: $CHATBOT_INSTANCE_URL
     config:
       method: POST
       headers:
@@ -27,5 +27,5 @@ evaluateOptions:
   delay: 1000
   showProgressBar: true
 
-tests: "${GOOGLE_SHEET_INPUT_URL}"
-outputPath: "${GOOGLE_SHEET_OUTPUT_URL}"
+tests: $GOOGLE_SHEET_INPUT_URL
+outputPath: $GOOGLE_SHEET_OUTPUT_URL


### PR DESCRIPTION
## Changes

* Fixed promptfoo export functionality by properly handling evaluation IDs for the Google Sheets export
* Added nice-to-know checks validating the Google credentials and OpenAI API key

## Context for reviewers

The main fix addresses the promptfoo export functionality by adding explicit export command to Google Sheets

## Testing

Local testing using: 

`act pull_request -W .github/workflows/promptfoo-googlesheet-evaluation.yml --secret-file .secrets -e test-event.json --container-architecture linux/amd64 -v`

Testing for Github Actions on this branch 