### PR TITLE
feat: Run refresh-ingestion in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ app/Makefile.local
 
 # Local refresh-ingestion-created scripts
 /refresh-*.sh
+/dev-task-*.log
+/prod-task-*.log
 

--- a/app/refresh-ingestion.sh
+++ b/app/refresh-ingestion.sh
@@ -387,7 +387,7 @@ case "$1" in
 
         echo ""
         echo "REMINDERS:"
-        echo "- Upload the zip files to the 'Chatbot Knowledge Markdown' Google Drive folder."
+        echo "- Upload the zip files to the ['Chatbot Knowledge Markdown' Google Drive folder](https://drive.google.com/drive/folders/1ZLWC2HdWKqprvIcd_6Y_M_ekJmABeONk)."
         echo "- Review and run the refresh scripts (in the top-level folder): refresh-dev-${TODAY} and refresh-prod-${TODAY}."
         echo "- Check ingestion status and wait for completion: DEPLOY_ENV=prod ./refresh-ingestion.sh wait_until_done"
         echo "- Restore local TF to dev environment: ./bin/terraform-init infra/app/service dev"

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -13,7 +13,7 @@ The `./refresh-ingestion.sh` script automates most of the scraping and ingestion
 
 ### Refreshing all data sources
 
-Before refreshing, create a backup of the database -- see the "Backing up DB contents" section below.
+Before refreshing, create a backup of the database -- see the [Backing up DB contents](#backing-up-db-contents) section below.
 
 To refresh all data sources at once, use the refresh-ingestion.sh script from within `/app`:
 
@@ -27,7 +27,7 @@ Note that for the imagine_la dataset, you'll need to set the `CONTENT_HUB_ACCESS
 
 The `./refresh-ingestion.sh` script will scrape and ingest data from all supported sources except for 'ssa' (which requires manual scraping). The script only modifies the local database. To update the database in the respective deployment environments, the script generates 2 other scripts in the top-level directory: `refresh-dev-*.sh` and `refresh-prod-*.sh`, which should be reviewed before running. These scripts will start ingestion of each dataset in parallel.
 
-About 10 minutes after running `refresh-dev-*.sh`, you can check the ingestion status and wait them to complete:
+About 10 minutes after running `refresh-dev-*.sh`, you can check the ingestion status and wait for them to complete:
 ```bash
 cd app
 DEPLOY_ENV=dev ./refresh-ingestion.sh wait_until_done

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -16,17 +16,18 @@ The `./refresh-ingestion.sh` script automates most of the scraping and ingestion
 To refresh all data sources at once, use the refresh-ingestion.sh script from within `/app`:
 
 ```bash
-./refresh-ingestion.sh all
-```
-
-This will scrape and ingest data from all supported sources except for 'ssa' (which requires manual scraping). The script only modifies the local database. To update the database in the respective deployment environments, the script generates 2 other scripts in the top-level directory: `refresh-dev-*.sh` and `refresh-prod-*.sh`, which should be reviewed before running.
-
-Note that for the imagine_la dataset, you'll need to set the CONTENT_HUB_ACCESS_TOKEN and CONTENT_HUB_SPACE_ID environment variables:
-
-```bash
 export CONTENT_HUB_SPACE_ID="space_id_here"
 export CONTENT_HUB_ACCESS_TOKEN="access_token_here"
 ./refresh-ingestion.sh all
+```
+
+Note that for the imagine_la dataset, you'll need to set the `CONTENT_HUB_ACCESS_TOKEN` and `CONTENT_HUB_SPACE_ID` environment variables.
+
+The `./refresh-ingestion.sh` script will scrape and ingest data from all supported sources except for 'ssa' (which requires manual scraping). The script only modifies the local database. To update the database in the respective deployment environments, the script generates 2 other scripts in the top-level directory: `refresh-dev-*.sh` and `refresh-prod-*.sh`, which should be reviewed before running.
+
+After running `refresh-dev-*.sh`, to see the status and wait for ingestion to complete:
+```bash
+DEPLOY_ENV=dev ./refresh-ingestion.sh wait_until_done
 ```
 
 ### Refreshing specific data sources

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -13,6 +13,8 @@ The `./refresh-ingestion.sh` script automates most of the scraping and ingestion
 
 ### Refreshing all data sources
 
+Before refreshing, create a backup of the database -- see the "Backing up DB contents" section below.
+
 To refresh all data sources at once, use the refresh-ingestion.sh script from within `/app`:
 
 ```bash
@@ -23,10 +25,11 @@ export CONTENT_HUB_ACCESS_TOKEN="access_token_here"
 
 Note that for the imagine_la dataset, you'll need to set the `CONTENT_HUB_ACCESS_TOKEN` and `CONTENT_HUB_SPACE_ID` environment variables.
 
-The `./refresh-ingestion.sh` script will scrape and ingest data from all supported sources except for 'ssa' (which requires manual scraping). The script only modifies the local database. To update the database in the respective deployment environments, the script generates 2 other scripts in the top-level directory: `refresh-dev-*.sh` and `refresh-prod-*.sh`, which should be reviewed before running.
+The `./refresh-ingestion.sh` script will scrape and ingest data from all supported sources except for 'ssa' (which requires manual scraping). The script only modifies the local database. To update the database in the respective deployment environments, the script generates 2 other scripts in the top-level directory: `refresh-dev-*.sh` and `refresh-prod-*.sh`, which should be reviewed before running. These scripts will start ingestion of each dataset in parallel.
 
-After running `refresh-dev-*.sh`, to see the status and wait for ingestion to complete:
+About 10 minutes after running `refresh-dev-*.sh`, you can check the ingestion status and wait them to complete:
 ```bash
+cd app
 DEPLOY_ENV=dev ./refresh-ingestion.sh wait_until_done
 ```
 


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-906

## Changes

* Run ingestion AWS tasks in the background
* Add `sleep 5` between invocations to avoid Terraform `Error locking state: [{%!s(tfdiags.Severity=69) Error acquiring the state lock Error message: resource temporarily unavailable`
* Add `poll_until_finished` function to check task status and wait for completion
* Updated md instructions

## Testing

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1747093738438519?thread_ts=1747083614.517959&cid=C06DP498D1D)

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-309-app-dev-1487272209.us-east-1.elb.amazonaws.com
- Deployed commit: d301a585aa1b5fa9779b04c9002af5e66bcc91b5
<!-- app - end PR environment info -->