### PR TITLE
fix: Ignore table formatting for CoveredCA data source

### DIFF
--- a/app/src/ingestion/scrapy_dst/spiders/covered_ca_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/covered_ca_spider.py
@@ -197,7 +197,7 @@ def to_markdown(html: Optional[str], base_url: Optional[str] = None) -> str:
 
     # Page https://www.coveredca.com/support/before-you-buy/copays-deductibles-coinsurance/
     # (unintentionally?) wrapped the main text in a single-cell table,
-    # which result in markdown with text followed by `---`, which causes the text to be interpreted as heading
+    # which results in markdown with text followed by `---`, which causes the text to be interpreted as heading
     h2t.ignore_tables = True
 
     if base_url:

--- a/app/src/ingestion/scrapy_dst/spiders/covered_ca_spider.py
+++ b/app/src/ingestion/scrapy_dst/spiders/covered_ca_spider.py
@@ -137,6 +137,8 @@ class CoveredCaliforniaSpider(scrapy.Spider):
         for body in body_sel:
             md = to_markdown(body.get(), response.url)
             assert md
+            if body.css("table"):
+                self.logger.warning("Ignored table formatting for: %r", md)
             markdowns.append(md)
         markdown = "\n\n".join(markdowns)
         return {
@@ -192,6 +194,11 @@ def to_markdown(html: Optional[str], base_url: Optional[str] = None) -> str:
     # 0 for no wrapping
     h2t.body_width = 0
     h2t.wrap_links = False
+
+    # Page https://www.coveredca.com/support/before-you-buy/copays-deductibles-coinsurance/
+    # (unintentionally?) wrapped the main text in a single-cell table,
+    # which result in markdown with text followed by `---`, which causes the text to be interpreted as heading
+    h2t.ignore_tables = True
 
     if base_url:
         h2t.baseurl = base_url


### PR DESCRIPTION
## Ticket

[Slack](https://nava.slack.com/archives/C06DP498D1D/p1747763179422329)

The scraped markdown looks like:
```md
# Health Insurance Basics: Copays, Deductibles and Coinsurance

Copays are a fixed out-of-pocket amount paid for covered services. Insurance providers often charge copays for services such as doctor visits or prescription drugs. Your deductible is the amount you pay out of pocket for health care services covered under your insurance plan before your plan begins to pay for eligible expenses. The amount you pay for a health insurance deductible is determined by the type of plan you choose. Coinsurance is your share of costs for a covered health care service after the deductible is reached. It's calculated as a percentage.   
---
```
Note the `---` at the end, which denotes that the text above it is a heading! 

The cause is [this particular webpage](https://www.coveredca.com/support/before-you-buy/copays-deductibles-coinsurance/) wraps the text in a single-cell `<table>`; other pages don't do this.

## Changes

Configure HTML2Text to `ignore_tables`. (LLMs don't interpret tables well anyway.)

(I tried other solutions, but this was the simplest and least amount of code.)

## Testing

Before the PR, search for `---` that is not part of a table:
```sh
grep '[^n]\\n---[^|]' *pretty.json 
```
This results in the `covered_ca_scrapings.json-pretty.json` having this problem.

After the PR, the problem goes away.

The resulting markdown in `covered_ca_scrapings.json-pretty.json` is:
```md
# Health Insurance Basics: Copays, Deductibles and Coinsurance

Copays are a fixed out-of-pocket amount paid for covered services. Insurance providers often charge copays for services such as doctor visits or prescription drugs.

Your deductible is the amount you pay out of pocket for health care services covered under your insurance plan before your plan begins to pay for eligible expenses. The amount you pay for a health insurance deductible is determined by the type of plan you choose.

Coinsurance is your share of costs for a covered health care service after the deductible is reached. It’s calculated as a percentage.
```

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-312-app-dev-520927042.us-east-1.elb.amazonaws.com
- Deployed commit: 0700697196790ee76f73463a50f8ddb59e242214
<!-- app - end PR environment info -->