### PR TITLE
feat: Add document-level recall to retrieval evaluation pipeline

### DIFF
--- a/app/src/evaluation/data_models.py
+++ b/app/src/evaluation/data_models.py
@@ -44,6 +44,7 @@ class ExpectedChunk:
     chunk_id: str
     content_hash: str
     content: str  # The actual text content of the chunk
+    document_id: str
 
 
 @dataclass
@@ -54,6 +55,7 @@ class RetrievedChunk:
     score: float
     content: str
     content_hash: str  # Hash of chunk content for verification
+    document_id: str
 
 
 @dataclass
@@ -70,6 +72,10 @@ class EvaluationResult:
     retrieved_chunks: List[RetrievedChunk]
     dataset: str  # Dataset name for this QA pair
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    correct_document_retrieved: bool = (
+        False  # Whether the correct document was found in top k results
+    )
+    document_rank_if_found: Optional[int] = None
 
 
 @dataclass
@@ -79,6 +85,7 @@ class DatasetMetrics:
     recall_at_k: float  # Whether the correct chunk was found in top k results
     sample_size: int
     avg_score_incorrect: float  # Average similarity score for incorrect retrievals in this dataset
+    document_recall_at_k: float
 
 
 @dataclass

--- a/app/tests/src/evaluation/metrics/test_logging.py
+++ b/app/tests/src/evaluation/metrics/test_logging.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from datetime import datetime
 
 import pytest
 
@@ -55,22 +54,31 @@ def test_evaluation_result():
         chunk_id="chunk123",
         content_hash="hash456",
         content="test content",
+        document_id="doc456",
     )
-    retrieved_chunk = RetrievedChunk(
-        chunk_id="chunk123",
-        score=0.85,
-        content="test content",
-        content_hash="hash456",
-    )
+
+    retrieved_chunks = [
+        RetrievedChunk(
+            chunk_id="chunk123",
+            score=0.85,
+            content="test content",
+            content_hash="hash456",
+            document_id="doc456",
+        )
+    ]
+
     return EvaluationResult(
         qa_pair_id="qa123",
         question="test question?",
         expected_answer="test answer",
         expected_chunk=expected,
+        retrieved_chunks=retrieved_chunks,
         correct_chunk_retrieved=True,
         rank_if_found=1,
         retrieval_time_ms=100.5,
-        retrieved_chunks=[retrieved_chunk],
+        timestamp="2024-01-01T00:00:00Z",
+        correct_document_retrieved=True,
+        document_rank_if_found=1,
         dataset="test_dataset",
     )
 
@@ -83,21 +91,26 @@ def test_metrics_summary():
             recall_at_k=0.75,
             sample_size=10,
             avg_score_incorrect=0.45,
+            document_recall_at_k=0.85,
         )
     }
+
     incorrect_analysis = IncorrectRetrievalsAnalysis(
         incorrect_retrievals_count=2,
         avg_score_incorrect=0.45,
         datasets_with_incorrect_retrievals=["test_dataset"],
     )
+
     return MetricsSummary(
-        batch_id="batch123",
-        timestamp=datetime.now().isoformat(),
+        batch_id="test_batch",
+        timestamp="2024-01-01T00:00:00Z",
         overall_metrics={
             "recall_at_k": 0.75,
+            "document_recall_at_k": 0.85,
             "mean_retrieval_time_ms": 100.5,
             "total_questions": 10,
             "successful_retrievals": 8,
+            "successful_document_retrievals": 9,
         },
         dataset_metrics=dataset_metrics,
         incorrect_analysis=incorrect_analysis,

--- a/app/tests/src/evaluation/metrics/test_metric_computation.py
+++ b/app/tests/src/evaluation/metrics/test_metric_computation.py
@@ -13,10 +13,23 @@ def create_test_result(
     rank: int = 1,
     scores: list = None,
     source: str = "test_dataset",
+    document_correct: bool = None,
+    document_rank: int = None,
+    expected_doc_id: str = "doc123",
+    retrieved_doc_ids: list = None,
 ) -> EvaluationResult:
     """Helper function to create test evaluation results."""
     if scores is None:
         scores = [0.85, 0.75]
+
+    if document_correct is None:
+        document_correct = correct
+
+    # Default retrieved_doc_ids
+    if retrieved_doc_ids is None:
+        retrieved_doc_ids = (
+            [expected_doc_id, "doc456"] if document_correct else ["doc456", "doc789"]
+        )
 
     expected = ExpectedChunk(
         name="test_doc",
@@ -24,16 +37,19 @@ def create_test_result(
         chunk_id="chunk123",
         content_hash="hash456",
         content="test content",
+        document_id=expected_doc_id,
     )
 
     retrieved_chunks = []
     for i, score in enumerate(scores):
+        doc_id = retrieved_doc_ids[i] if i < len(retrieved_doc_ids) else f"doc{i + 100}"
         retrieved_chunks.append(
             RetrievedChunk(
                 chunk_id=f"chunk{i + 1}",
                 score=score,
                 content="test content",
                 content_hash="hash456" if i == 0 and correct else f"hash{i + 1}",
+                document_id=doc_id,
             )
         )
 
@@ -47,6 +63,8 @@ def create_test_result(
         retrieval_time_ms=100.5,
         retrieved_chunks=retrieved_chunks,
         dataset=source,
+        correct_document_retrieved=document_correct,
+        document_rank_if_found=document_rank if document_correct else None,
     )
 
 
@@ -57,24 +75,30 @@ def test_compute_dataset_metrics():
     assert empty_metrics.recall_at_k == 0.0
     assert empty_metrics.sample_size == 0
     assert empty_metrics.avg_score_incorrect == 0.0
+    assert empty_metrics.document_recall_at_k == 0.0
 
-    # Test with all correct results
-    correct_results = [create_test_result(correct=True) for _ in range(3)]
+    correct_results = [create_test_result(correct=True, document_correct=True) for _ in range(3)]
     correct_metrics = compute_dataset_metrics(correct_results)
     assert correct_metrics.recall_at_k == 1.0
     assert correct_metrics.sample_size == 3
     assert correct_metrics.avg_score_incorrect == 0.0
+    assert correct_metrics.document_recall_at_k == 1.0
 
     # Test with mixed results
     mixed_results = [
-        create_test_result(correct=True, scores=[0.9, 0.8]),
-        create_test_result(correct=False, scores=[0.7, 0.6]),
-        create_test_result(correct=False, scores=[0.5, 0.4]),
+        create_test_result(correct=True, document_correct=True, scores=[0.9, 0.8]),
+        create_test_result(
+            correct=False, document_correct=True, scores=[0.7, 0.6]
+        ),  # Document found but not exact chunk
+        create_test_result(
+            correct=False, document_correct=False, scores=[0.5, 0.4]
+        ),  # Neither found
     ]
     mixed_metrics = compute_dataset_metrics(mixed_results)
-    assert mixed_metrics.recall_at_k == 1 / 3
+    assert mixed_metrics.recall_at_k == 1 / 3  # Only 1 chunk correct out of 3
     assert mixed_metrics.sample_size == 3
     assert mixed_metrics.avg_score_incorrect == 0.6  # Average of [0.7, 0.5]
+    assert mixed_metrics.document_recall_at_k == 2 / 3  # 2 documents correct out of 3
 
 
 def test_compute_incorrect_analysis():
@@ -112,11 +136,19 @@ def test_compute_metrics_summary():
     """Test metrics summary computation."""
     results = [
         # Dataset 1 results
-        create_test_result(correct=True, scores=[0.9, 0.8], source="dataset1"),
-        create_test_result(correct=False, scores=[0.7, 0.6], source="dataset1"),
+        create_test_result(
+            correct=True, document_correct=True, scores=[0.9, 0.8], source="dataset1"
+        ),
+        create_test_result(
+            correct=False, document_correct=True, scores=[0.7, 0.6], source="dataset1"
+        ),
         # Dataset 2 results
-        create_test_result(correct=True, scores=[0.85, 0.75], source="dataset2"),
-        create_test_result(correct=False, scores=[0.65, 0.55], source="dataset2"),
+        create_test_result(
+            correct=True, document_correct=True, scores=[0.85, 0.75], source="dataset2"
+        ),
+        create_test_result(
+            correct=False, document_correct=False, scores=[0.65, 0.55], source="dataset2"
+        ),
     ]
 
     summary = compute_metrics_summary(results, "batch123")
@@ -127,16 +159,73 @@ def test_compute_metrics_summary():
 
     # Check overall metrics
     assert summary.overall_metrics["recall_at_k"] == 0.5  # 2 correct out of 4
+    assert summary.overall_metrics["document_recall_at_k"] == 0.75  # 3 documents correct out of 4
     assert summary.overall_metrics["total_questions"] == 4
     assert summary.overall_metrics["successful_retrievals"] == 2
+    assert summary.overall_metrics["successful_document_retrievals"] == 3
     assert isinstance(summary.overall_metrics["mean_retrieval_time_ms"], float)
 
     # Check dataset metrics
     assert len(summary.dataset_metrics) == 2
     assert summary.dataset_metrics["dataset1"].recall_at_k == 0.5  # 1 correct out of 2
+    assert (
+        summary.dataset_metrics["dataset1"].document_recall_at_k == 1.0
+    )  # 2 documents correct out of 2
     assert summary.dataset_metrics["dataset2"].recall_at_k == 0.5  # 1 correct out of 2
+    assert (
+        summary.dataset_metrics["dataset2"].document_recall_at_k == 0.5
+    )  # 1 document correct out of 2
 
     # Check incorrect analysis
     assert summary.incorrect_analysis.incorrect_retrievals_count == 2
     assert len(summary.incorrect_analysis.datasets_with_incorrect_retrievals) == 2
     assert isinstance(summary.incorrect_analysis.avg_score_incorrect, float)
+
+
+def test_document_level_recall():
+    """Test document-level recall computation specifically."""
+    # Test case where chunk is wrong but document is correct
+    results = [
+        create_test_result(
+            correct=False,
+            document_correct=True,
+            expected_doc_id="doc123",
+            retrieved_doc_ids=["doc123", "doc456"],
+            scores=[0.8, 0.7],
+        ),
+        create_test_result(
+            correct=False,
+            document_correct=True,
+            expected_doc_id="doc789",
+            retrieved_doc_ids=["doc456", "doc789"],
+            scores=[0.9, 0.6],
+        ),
+        create_test_result(
+            correct=False,
+            document_correct=False,
+            expected_doc_id="doc999",
+            retrieved_doc_ids=["doc123", "doc456"],
+            scores=[0.5, 0.4],
+        ),
+    ]
+
+    metrics = compute_dataset_metrics(results)
+
+    assert metrics.recall_at_k == 0.0
+
+    assert metrics.document_recall_at_k == 2 / 3
+
+    # Test case where chunk is correct and document is correct
+    perfect_results = [
+        create_test_result(
+            correct=True,
+            document_correct=True,
+            expected_doc_id="doc123",
+            retrieved_doc_ids=["doc123", "doc456"],
+            scores=[0.9, 0.8],
+        )
+    ]
+
+    perfect_metrics = compute_dataset_metrics(perfect_results)
+    assert perfect_metrics.recall_at_k == 1.0
+    assert perfect_metrics.document_recall_at_k == 1.0

--- a/app/tests/src/evaluation/metrics/test_metric_models.py
+++ b/app/tests/src/evaluation/metrics/test_metric_models.py
@@ -1,7 +1,5 @@
 """Tests for metrics models."""
 
-from datetime import datetime
-
 from src.evaluation.data_models import (
     BatchConfig,
     DatasetMetrics,
@@ -51,12 +49,15 @@ def test_expected_chunk():
         chunk_id="chunk123",
         content_hash="hash456",
         content="test content",
+        document_id="doc456",
     )
+
     assert expected.name == "test_doc"
     assert expected.source == "test_dataset"
     assert expected.chunk_id == "chunk123"
     assert expected.content_hash == "hash456"
     assert expected.content == "test content"
+    assert expected.document_id == "doc456"
 
 
 def test_retrieved_chunk():
@@ -66,11 +67,14 @@ def test_retrieved_chunk():
         score=0.85,
         content="test content",
         content_hash="hash456",
+        document_id="doc456",
     )
+
     assert chunk.chunk_id == "chunk123"
     assert chunk.score == 0.85
     assert chunk.content == "test content"
     assert chunk.content_hash == "hash456"
+    assert chunk.document_id == "doc456"
 
 
 def test_evaluation_result():
@@ -81,36 +85,45 @@ def test_evaluation_result():
         chunk_id="chunk123",
         content_hash="hash456",
         content="test content",
+        document_id="doc456",
     )
-    retrieved_chunk = RetrievedChunk(
-        chunk_id="chunk123",
-        score=0.85,
-        content="test content",
-        content_hash="hash456",
-    )
+
+    retrieved_chunks = [
+        RetrievedChunk(
+            chunk_id="chunk123",
+            score=0.85,
+            content="test content",
+            content_hash="hash456",
+            document_id="doc456",
+        )
+    ]
+
     result = EvaluationResult(
         qa_pair_id="qa123",
         question="test question?",
         expected_answer="test answer",
         expected_chunk=expected,
+        retrieved_chunks=retrieved_chunks,
         correct_chunk_retrieved=True,
         rank_if_found=1,
-        retrieval_time_ms=100.5,
-        retrieved_chunks=[retrieved_chunk],
+        retrieval_time_ms=150.5,
+        timestamp="2024-01-01T00:00:00Z",
+        correct_document_retrieved=True,
+        document_rank_if_found=1,
         dataset="test_dataset",
     )
 
-    # Test that fields are set correctly
     assert result.qa_pair_id == "qa123"
     assert result.question == "test question?"
     assert result.expected_answer == "test answer"
     assert result.expected_chunk == expected
+    assert result.retrieved_chunks == retrieved_chunks
     assert result.correct_chunk_retrieved is True
     assert result.rank_if_found == 1
-    assert result.retrieval_time_ms == 100.5
-    assert result.retrieved_chunks == [retrieved_chunk]
-    assert result.timestamp is not None
-    assert result.dataset == "test_dataset"
+    assert result.retrieval_time_ms == 150.5
+    assert result.timestamp == "2024-01-01T00:00:00Z"
+    assert result.correct_document_retrieved is True
+    assert result.document_rank_if_found == 1
 
 
 def test_dataset_metrics():
@@ -119,10 +132,13 @@ def test_dataset_metrics():
         recall_at_k=0.75,
         sample_size=100,
         avg_score_incorrect=0.45,
+        document_recall_at_k=0.85,
     )
+
     assert metrics.recall_at_k == 0.75
     assert metrics.sample_size == 100
     assert metrics.avg_score_incorrect == 0.45
+    assert metrics.document_recall_at_k == 0.85
 
 
 def test_incorrect_retrievals_analysis():
@@ -140,35 +156,38 @@ def test_incorrect_retrievals_analysis():
 def test_metrics_summary():
     """Test MetricsSummary creation with all components."""
     dataset_metrics = {
-        "dataset1": DatasetMetrics(recall_at_k=0.75, sample_size=50, avg_score_incorrect=0.45),
-        "dataset2": DatasetMetrics(recall_at_k=0.80, sample_size=50, avg_score_incorrect=0.40),
+        "dataset1": DatasetMetrics(
+            recall_at_k=0.75, sample_size=50, avg_score_incorrect=0.45, document_recall_at_k=0.85
+        ),
+        "dataset2": DatasetMetrics(
+            recall_at_k=0.80, sample_size=50, avg_score_incorrect=0.40, document_recall_at_k=0.90
+        ),
     }
+
     incorrect_analysis = IncorrectRetrievalsAnalysis(
-        incorrect_retrievals_count=25,
-        avg_score_incorrect=0.45,
+        incorrect_retrievals_count=10,
+        avg_score_incorrect=0.42,
         datasets_with_incorrect_retrievals=["dataset1", "dataset2"],
     )
+
     summary = MetricsSummary(
         batch_id="batch123",
-        timestamp=datetime.now().isoformat(),
+        timestamp="2024-01-01T00:00:00Z",
         overall_metrics={
-            "recall_at_k": 0.775,
-            "mean_retrieval_time_ms": 100.5,
+            "recall_at_k": 0.77,
+            "document_recall_at_k": 0.87,
+            "mean_retrieval_time_ms": 125.0,
             "total_questions": 100,
-            "successful_retrievals": 75,
+            "successful_retrievals": 77,
+            "successful_document_retrievals": 87,
         },
         dataset_metrics=dataset_metrics,
         incorrect_analysis=incorrect_analysis,
     )
 
-    # Test that all components are set correctly
     assert summary.batch_id == "batch123"
-    assert summary.timestamp is not None
-    assert summary.overall_metrics["recall_at_k"] == 0.775
-    assert summary.overall_metrics["mean_retrieval_time_ms"] == 100.5
-    assert summary.overall_metrics["total_questions"] == 100
-    assert summary.overall_metrics["successful_retrievals"] == 75
+    assert summary.timestamp == "2024-01-01T00:00:00Z"
+    assert summary.overall_metrics["recall_at_k"] == 0.77
+    assert summary.overall_metrics["document_recall_at_k"] == 0.87
     assert len(summary.dataset_metrics) == 2
-    assert isinstance(summary.dataset_metrics["dataset1"], DatasetMetrics)
-    assert isinstance(summary.dataset_metrics["dataset2"], DatasetMetrics)
-    assert isinstance(summary.incorrect_analysis, IncorrectRetrievalsAnalysis)
+    assert summary.dataset_metrics["dataset1"].recall_at_k == 0.75


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-970

## Changes

- Added `document_id` field to `ExpectedChunk` and `RetrievedChunk` data models
- `correct_document_retrieved` and `document_rank_if_found` fields in `EvaluationResult`
- `document_recall_at_k` field in `DatasetMetrics`
- Updatd `process_retrieved_chunks()` to calculate document-level recall
- `compute_dataset_metrics()` and `compute_metrics_summary()` now include document recall metrics
- Updated tests to include th new required fields

## Context for reviewers

Document-level recall measures if the correct document (not only the correct chunk) appears in the retrieved results. The idea is this provides us a better baseline for comparing embedding models that produce different chunk sizes.

To do this we compare `document_id` of expected chunk against `document_id` of all retrieved chunks to determine if the correct document is found

## Testing

Generated new QA pairs and ran evaluation with `k=5`:

```
{
  "recall_at_k": 0.7777777777777778,
  "document_recall_at_k": 0.8571428571428571,
  "mean_retrieval_time_ms": 131.1714196157705,
  "total_questions": 63,
  "successful_retrievals": 49,
  "successful_document_retrievals": 54
}
```

Shows document-level recall (85.7%) is higher than chunk-level recall (77.8%), showing the feature is working

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-314-app-dev-963610977.us-east-1.elb.amazonaws.com
- Deployed commit: a77bebbab2641dce3f5fc11c330f579eb0b664ef
<!-- app - end PR environment info -->