### PR TITLE
doc: Promptfoo evaluations instructions: don't use SSL

### DIFF
--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -85,8 +85,8 @@ jobs:
           cp app/promptfoo/generateUniqueId.js /tmp/generateUniqueId.js
           cp app/promptfoo/readability_assessment.py /tmp/readability_assessment.py
 
-          echo "Using Google Sheet input URL: $GOOGLE_SHEET_INPUT_URL"
-          echo "Using Google Sheet output URL: $GOOGLE_SHEET_OUTPUT_URL"
+          echo "Using Google Sheet input URL: $(echo "$GOOGLE_SHEET_INPUT_URL" | grep -o 'spreadsheets.*')"
+          echo "Using Google Sheet output URL: $(echo "$GOOGLE_SHEET_OUTPUT_URL" | grep -o 'spreadsheets.*')"
           echo "Using Chatbot instance URL: $CHATBOT_INSTANCE_URL"
           envsubst < app/promptfoo/promptfooconfig.ci.yaml > /tmp/promptfooconfig.processed.yaml
           echo "Config file processed, checking..."

--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -84,6 +84,10 @@ jobs:
         run: |
           cp app/promptfoo/generateUniqueId.js /tmp/generateUniqueId.js
           cp app/promptfoo/readability_assessment.py /tmp/readability_assessment.py
+
+          echo "Using Google Sheet input URL: $GOOGLE_SHEET_INPUT_URL"
+          echo "Using Google Sheet output URL: $GOOGLE_SHEET_OUTPUT_URL"
+          echo "Using Chatbot instance URL: $CHATBOT_INSTANCE_URL"
           envsubst < app/promptfoo/promptfooconfig.ci.yaml > /tmp/promptfooconfig.processed.yaml
           echo "Config file processed, checking..."
           grep -v "GOOGLE_SHEET\|CHATBOT_INSTANCE" /tmp/promptfooconfig.processed.yaml | grep -i "url\|path"

--- a/docs/promptfoo-evaluations.md
+++ b/docs/promptfoo-evaluations.md
@@ -30,4 +30,4 @@ You can change the `Run workflow from` dropdown to select a branch that GitHub w
 
 ### Chatbot API endpoint URL
 
-By default, the version of the chatbot that is evaluated is our DEV instance. You can manually change this to, for example, evaluate a different version of the chatbot's prompt in a preview environment, e.g., `https://p-310-app-dev-652842717.us-east-1.elb.amazonaws.com/api/query`.
+By default, the version of the chatbot that is evaluated is our DEV instance. You can manually change this to, for example, evaluate a different version of the chatbot's prompt in a preview environment, e.g., `http://p-310-app-dev-652842717.us-east-1.elb.amazonaws.com/api/query` (without SSL since the certificate will fail due to having a different domain name).


### PR DESCRIPTION
## Ticket

Related to https://navalabs.atlassian.net/browse/DST-985

## Changes

Correct instructions: remove SSL from the `Chatbot API endpoint URL` for preview environments.
Also add more logging to GH Action.

## Testing

URLs are [shown](https://github.com/navapbc/labs-decision-support-tool/actions/runs/15427823055/job/43419024962?pr=316#step:9:19) for traceability

<!-- app - begin PR environment info -->
## Preview environment for app
- Service endpoint: https://p-316-app-dev-2032634175.us-east-1.elb.amazonaws.com
- Deployed commit: 0790e5874e3c341ab0bcd5937b9aca844159e499
<!-- app - end PR environment info -->