### PR TITLE
perf: Minimize Promptfoo concurrency to 1 thread

### DIFF
--- a/.github/workflows/promptfoo-googlesheet-evaluation.yml
+++ b/.github/workflows/promptfoo-googlesheet-evaluation.yml
@@ -114,9 +114,9 @@ jobs:
           EVAL_OUTPUT_FILE="/tmp/promptfoo-output.txt"
 
           if [ -n "$PROMPTFOO_API_KEY" ]; then
-            promptfoo eval --config "/tmp/promptfooconfig.processed.yaml" --share --output "${OUTPUT_JSON_FILE}" --no-cache | tee "${EVAL_OUTPUT_FILE}"
+            promptfoo eval -j 1 --config "/tmp/promptfooconfig.processed.yaml" --share --output "${OUTPUT_JSON_FILE}" --no-cache | tee "${EVAL_OUTPUT_FILE}"
           else
-            promptfoo eval --config "/tmp/promptfooconfig.processed.yaml" --output "${OUTPUT_JSON_FILE}" --no-cache | tee "${EVAL_OUTPUT_FILE}"
+            promptfoo eval -j 1 --config "/tmp/promptfooconfig.processed.yaml" --output "${OUTPUT_JSON_FILE}" --no-cache | tee "${EVAL_OUTPUT_FILE}"
           fi
 
           if [ -f "${OUTPUT_JSON_FILE}" ]; then


### PR DESCRIPTION
## Ticket

https://navalabs.atlassian.net/browse/DST-1024

## Changes

Use the `-j 1` command line argument to force 1 thread for concurrency.

## Context for reviewers

Other methods (which modify the config file) didn't have an affect:
* `evaluateOptions.maxConcurrency` in `promptfooconfig.ci.yaml` https://github.com/navapbc/labs-decision-support-tool/pull/315#discussion_r2124640023
* `commandLineOptions.maxConcurrency` in `promptfooconfig.ci.yaml` https://github.com/navapbc/labs-decision-support-tool/pull/315#discussion_r2124871829

## Testing

