### PR TITLE
hotfix: pin litellm version between 1.15.2 and 1.82.7

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-# Use the official python3 image based on Debian 11 "Bullseye".
+# Use the official python3 image based on Debian.
 # https://hub.docker.com/_/python
 
 # The build stage that will be used to deploy to the various environments
@@ -12,8 +12,9 @@ RUN pip install --no-cache-dir poetry==1.5
 
 RUN apt-get update && apt-get install -y lsb-release wget gnupg && \
     # Need to add the official PostgreSQL repo to install v16 -- https://askubuntu.com/a/1442247
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgres.list && \
+    # Use gpg --dearmor instead of deprecated apt-key (removed in Debian 13+)
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgres.list && \
     apt-get update \
     # Install security updates
     # https://pythonspeed.com/articles/security-updates-in-docker/

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -21,7 +21,7 @@ psycopg = {extras = ["binary"], version = "^3.1.10"}
 pydantic-settings = "^2.0.3"
 chainlit = "^2.4.0"
 sentence-transformers = "^3.0.1"
-litellm = "^1.51.2"
+litellm = ">=1.51.2,<1.82.7"
 pgvector = "^0.2.5"
 torch = "2.2.2"
 gunicorn = "^22.0.0"


### PR DESCRIPTION
- [x] Update PR Title to follow this pattern: `[INTENT]: [MESSAGE]`

## Changes
[Hotfix for LiteLLM security vuln](https://www.xda-developers.com/popular-python-library-backdoor-machine/).

## Context for reviewers
The locked version of LiteLLM is `1.63.8`, which is well below the compromised versions (`1.82.7` and `1.82.8`). This project is not affected by this supply chain attack.

However, the [pyproject.toml specifies ^1.51.2](https://github.com/navapbc/labs-decision-support-tool/blob/f2c05b6be9c55bc22c4dc0f899afcf1f2d5827f3/app/pyproject.toml#L24) (compatible with any 1.x >= 1.51.2), so if someone runs `poetry update` or installs without a lock file, they could pull in a compromised version.

I've pinned the version **between** `1.51.2` and `1.82.7`.
